### PR TITLE
Export types

### DIFF
--- a/lib/Sentry.d.ts
+++ b/lib/Sentry.d.ts
@@ -4,9 +4,9 @@
 // Definitions: https://github.com/getsentry/react-native-sentry
 // TypeScript Version: 2.3
 
-type SentryBreadcrumbType = "navigation" | "http";
+export type SentryBreadcrumbType = "navigation" | "http";
 
-interface SentryBreadcrumb {
+export interface SentryBreadcrumb {
   message?: string;
   category?: string;
   level?: SentrySeverity;
@@ -30,7 +30,7 @@ export enum SentryLog {
   Verbose = 3
 }
 
-interface SentryOptions {
+export interface SentryOptions {
   /** Deactivates the stacktrace merging feature. Default: true */
   deactivateStacktraceMerging?: boolean;
   /** Deactivates the native integration and only uses raven-js */


### PR DESCRIPTION
Exports all the types from the TypeScript declaration file.
It is sometimes useful to be able to type variables.

_Example :_
```ts
const options: SentryOptions = { ... }
```