### PR TITLE
Fix ‘cannot read property “internal” of undefined’ bug

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -53,7 +53,7 @@ import io.sentry.event.interfaces.UserInterface;
 public class RNSentryModule extends ReactContextBaseJavaModule {
 
     private static final Pattern mJsModuleIdPattern = Pattern.compile("(?:^|[/\\\\])(\\d+\\.js)$");
-    private static final String versionString = "0.42.0";
+    private static final String versionString = "0.42.1";
     private static final String sdkName = "sentry-react-native";
 
     private final ReactApplicationContext reactContext;

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -8,7 +8,7 @@
 
 #import <Sentry/Sentry.h>
 
-NSString *const RNSentryVersionString = @"0.42.0";
+NSString *const RNSentryVersionString = @"0.42.1";
 NSString *const RNSentrySdkName = @"sentry.javascript.react-native";
 
 @interface RNSentry()

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -191,7 +191,7 @@ export const Sentry = {
       Sentry._nativeClient.addExtraContext('__sentry_' + key, value);
     }
     if (!Sentry.options || [undefined, null].includes(Sentry.options.internal)) {
-      Sentry.options.internal = {};
+      Sentry.options = {internal: {}};
     }
     Sentry.options.internal[key] = value;
   },

--- a/lib/Sentry.js
+++ b/lib/Sentry.js
@@ -190,13 +190,16 @@ export const Sentry = {
     if (Sentry.isNativeClientAvailable()) {
       Sentry._nativeClient.addExtraContext('__sentry_' + key, value);
     }
-    if (undefined === Sentry.options.internal) {
+    if (!Sentry.options || [undefined, null].includes(Sentry.options.internal)) {
       Sentry.options.internal = {};
     }
     Sentry.options.internal[key] = value;
   },
 
   _getInternalOption(key) {
+    if (!Sentry.options || !Sentry.options.internal) {
+      return undefined;
+    }
     return Sentry.options.internal[key];
   },
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-sentry",
   "homepage": "https://github.com/getsentry/react-native-sentry",
   "repository": "https://github.com/getsentry/react-native-sentry",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Official Sentry SDK for react-native",
   "typings": "lib/Sentry.d.ts",
   "typescript": {


### PR DESCRIPTION
Hi guys, we use your service in every app and now we have a problem with ```setRelease``` method.

```Sentry.setRelease(`<project_name>@${DeviceInfo.getVersion()}.${DeviceInfo.getBuildNumber()}`);```

If you will try to set release version you catch the error

```ExceptionsManager.js:82 Unhandled JS Exception: Cannot read property 'internal' of undefined```

I fixed that in current PR. 