### PR TITLE
Move snyk dependency and fix lockfile entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "@sentry/integrations": "^5.5.0",
     "@sentry/types": "^5.5.0",
     "@sentry/utils": "^5.5.0",
-    "@sentry/wizard": "^1.0.0",
-    "snyk": "^1.193.1"
+    "@sentry/wizard": "^1.0.0"
   },
   "devDependencies": {
     "@sentry/typescript": "5.*",
@@ -46,6 +45,7 @@
     "prettier": "^1.17.0",
     "replace-in-file": "^4.0.0",
     "rimraf": "^2.6.3",
+    "snyk": "^1.193.1",
     "typescript": "^3.4.5"
   },
   "rnpm": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,7 +1265,7 @@ lodash.set@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
-lodash@^4, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.5:
+lodash@^4, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.5:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
@@ -2091,10 +2091,10 @@ snyk-try-require@1.3.1, snyk-try-require@^1.1.1, snyk-try-require@^1.3.1:
     lru-cache "^4.0.0"
     then-fs "^2.0.0"
 
-snyk@^1.192.3:
-  version "1.193.0"
-  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.193.0.tgz#1d4a3537fb523360ebed38af27e8aa01ca6c4832"
-  integrity sha512-/13XZFuiZB9VhByiabCGRc+6+voZn56fvbWgB/g9cfmPSkMVuqaFbJY+MPUbVo1jC7NqUJAUWEVNVbkjscSesg==
+snyk@^1.193.1:
+  version "1.193.2"
+  resolved "https://registry.yarnpkg.com/snyk/-/snyk-1.193.2.tgz#63d11f85e1ba7d003de520897f70326568f03bd5"
+  integrity sha512-v65VDFgBqUow+z+wcV01d0lijVesd0CfOywlNhDuWW3qbPVwd4lb6bNt5M9bSrgk7/76fbA33udanRnxXsOjSA==
   dependencies:
     "@snyk/dep-graph" "1.8.1"
     "@snyk/gemfile" "1.2.0"
@@ -2108,7 +2108,7 @@ snyk@^1.192.3:
     git-url-parse "11.1.2"
     glob "^7.1.3"
     inquirer "^6.2.2"
-    lodash "^4.17.13"
+    lodash "^4.17.14"
     needle "^2.2.4"
     opn "^5.5.0"
     os-name "^3.0.0"


### PR DESCRIPTION
as per [discussion](https://github.com/getsentry/sentry-react-native/issues/612#issuecomment-511434560) in #612 `snyk` automatically added itself as a `dependencies` in `package.json` as part of #615 yet it should be in the `devDependencies` so that downstream users do not have to install snyk as an (unused) dependency, and with it, it's own (transitive) dependencies.

I also noticed that snyk's lockfile entry was out of sync with it's entry in package.json. At a guess snyk bumped itself automatically in f57f8d35f36f5a725f46a7b173fa259408f24004 but I'm assuming it doesn't handle then updating the `yarn.lock` at the same time.

Snyk's use is only at development time and doesn't have any effect/use for library users directly