### PR TITLE
fix(breadcrumbs): Fix missing `type`, miscast `status_code` entries in Android breadcrumbs

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -185,6 +185,10 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                 if (breadcrumb.hasKey("category")) {
                     breadcrumbBuilder.setCategory(breadcrumb.getString("category"));
                 }
+                
+                if (breadcrumb.hasKey("type")) {
+                    breadcrumbBuilder.setType(breadcrumb.getString("type"));
+                }
 
                 try {
                     if (breadcrumb.hasKey("data") && breadcrumb.getMap("data") != null) {
@@ -192,6 +196,16 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                         for (Map.Entry<String, Object> data : ((ReadableNativeMap)breadcrumb.getMap("data")).toHashMap().entrySet()) {
                             newData.put(data.getKey(), data.getValue() != null ? data.getValue().toString() : null);
                         }
+                        
+                        // in case a `status_code` entry got accidentally stringified as a float
+                        if (newData.containsKey("status_code")) {
+                              String value = newData.get("status_code");
+                              newData.put(
+                                  "status_code",
+                                  value.endsWith(".0") ? value.replace(".0", "") : value
+                              );
+                        }
+                        
                         breadcrumbBuilder.setData(newData);
                     }
                 } catch (UnexpectedNativeTypeException e) {


### PR DESCRIPTION
This PR fixes two small bugs in our handling of Android breadcrumbs.

1) Currently, Android breadcrumbs miss copying over the `type` attribute of breadcrumbs, leading all breadcrumbs to be of type `"default"`. Among other things, this affects their display in the UI:

Without `type`:

![image](https://user-images.githubusercontent.com/14812505/66494805-17043f80-ea6d-11e9-8070-afcb98b385ef.png)

With `type`:

![image](https://user-images.githubusercontent.com/14812505/66494845-2a170f80-ea6d-11e9-939e-277e965e3e31.png)

2) Somehow or other, the response status code for XHR requests is getting cast as a double (you can see it in the first screenshot above), which is confusing people. This strips the decimals off so that the status again appears like `200` rather than `200.0`.