### PR TITLE
chore(dependencies): Bump sentry-javascript packages to 5.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
     "react-native": ">=0.56.0"
   },
   "dependencies": {
-    "@sentry/browser": "^5.6.3",
-    "@sentry/core": "^5.6.2",
-    "@sentry/integrations": "^5.6.1",
-    "@sentry/types": "^5.6.1",
-    "@sentry/utils": "^5.6.1",
+    "@sentry/browser": "^5.7.1",
+    "@sentry/core": "^5.7.1",
+    "@sentry/integrations": "^5.7.1",
+    "@sentry/types": "^5.7.1",
+    "@sentry/utils": "^5.7.1",
     "@sentry/wizard": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To take advantage of the changes in [5.7.0](https://github.com/getsentry/sentry-javascript/releases/tag/5.7.0).