### PR TITLE
docs: add instructions for self hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ npm install --save @sentry/react-native
 yarn add @sentry/react-native
 ```
 
+If you are using a version of React Native <= 0.60.x link the package using `react-native`.
+
+```sh
+react-native link @sentry/react-native
+# OR, if self hosting
+SENTRY_WIZARD_URL=http://sentry.acme.com/ react-native link @sentry/react-native
+```
+
 How to use it:
 
 ```javascript


### PR DESCRIPTION
Adds documentation for running the wizard when self hosting Sentry.

See https://github.com/getsentry/sentry-react-native/issues/311, https://github.com/getsentry/sentry-react-native/issues/17

Not sure how auto-linking affects these instructions.