### PR TITLE
fix: Strip a bogus function name suffix from Hermes frames

### DIFF
--- a/src/js/integrations/debugsymbolicator.ts
+++ b/src/js/integrations/debugsymbolicator.ts
@@ -63,9 +63,7 @@ export class DebugSymbolicator implements Integration {
         jsEngine: reactError.jsEngine
       };
 
-      if (__DEV__) {
-        await self._symbolicate(event, stack);
-      }
+      await self._symbolicate(event, stack);
       if (reactError.jsEngine === "hermes") {
         const convertedFrames = await this._convertReactNativeFramesToSentryFrames(
           stack
@@ -123,9 +121,7 @@ export class DebugSymbolicator implements Integration {
   ): Promise<StackFrame[]> {
     let getDevServer: any;
     try {
-      if (__DEV__) {
-        getDevServer = require("react-native/Libraries/Core/Devtools/getDevServer");
-      }
+      getDevServer = require("react-native/Libraries/Core/Devtools/getDevServer");
     } catch (_oO) {
       // We can't load devserver URL
     }
@@ -151,7 +147,20 @@ export class DebugSymbolicator implements Integration {
             platform: inApp ? "javascript" : "node" // :HACK
           };
 
-          if (inApp && __DEV__) {
+          // The upstream `react-native@0.61` delegates parsing of stacks to `stacktrace-parser`, which is buggy and
+          // leaves a trailing `(address at` in the function name.
+          // `react-native@0.62` seems to have custom logic to parse hermes frames specially.
+          // Anyway, all we do here is throw away the bogus suffix.
+          if (newFrame.function) {
+            const addressAtPos = newFrame.function.indexOf("(address at");
+            if (addressAtPos >= 0) {
+              newFrame.function = newFrame.function
+                .substr(0, addressAtPos)
+                .trim();
+            }
+          }
+
+          if (inApp) {
             // tslint:disable-next-line: no-unsafe-any
             await this._addSourceContext(newFrame, getDevServer);
           }

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -42,8 +42,12 @@ export function init(
       new Integrations.Breadcrumbs({
         console: false, // If this in enabled it causes problems to native calls on >= RN 0.60
         fetch: false
-      }),
-      new DebugSymbolicator(),
+      })
+    ];
+    if (__DEV__) {
+      options.defaultIntegrations.push(new DebugSymbolicator());
+    }
+    options.defaultIntegrations.push(
       new RewriteFrames({
         iteratee: (frame: StackFrame) => {
           if (frame.filename) {
@@ -63,7 +67,7 @@ export function init(
         }
       }),
       new DeviceContext()
-    ];
+    );
   }
   if (options.enableNative === undefined) {
     options.enableNative = true;


### PR DESCRIPTION
... and also avoid using the DebugSymbolicator in release mode.