### PR TITLE
meta(issue template): Add SDK version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ OS:
 - [ ]  MacOS
 - [ ]  Linux
 
-_Platform:_
+Platform:
 - [ ]  iOS
 - [ ]  Android
 
@@ -13,6 +13,7 @@ SDK:
 - [ ]  `react-native-sentry`
 
 
+SDK version: 0.0.0
 `react-native` version: 0.0.0
 
 Init Code:


### PR DESCRIPTION
People often confuse the `React Native version` field with a (heretofore non-existent) `react-native-sentry / @sentry/react-native version` field. It's helpful to have both, so let's explicitly ask for them.

Also removes the italics from the `Platform` heading, to match the headings before and after.