### PR TITLE
fix: Envelope header bytes length

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.sentry:sentry-android:2.0.0-rc04'
+    implementation 'io.sentry:sentry-android:2.0.0'
 }

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -147,7 +147,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void getStringBytesLength(String str) {
+    public int getStringBytesLength(String str) {
         return str.getBytes("UTF-8").length;
     }
 

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -146,6 +146,11 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
         promise.resolve(true);
     }
 
+    @ReactMethod
+    public void getStringBytesLength(String str) {
+        return str.getBytes("UTF-8").length;
+    }
+
     private static PackageInfo getPackageInfo(Context ctx) {
         try {
             return ctx.getPackageManager().getPackageInfo(ctx.getPackageName(), 0);

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -15,6 +15,7 @@ import com.facebook.react.module.annotations.ReactModule;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -147,8 +148,12 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public int getStringBytesLength(String str) {
-        return str.getBytes("UTF-8").length;
+    public void getStringBytesLength(String payload, Promise promise) {
+        try {
+            promise.resolve(payload.getBytes("UTF-8").length);
+        } catch (UnsupportedEncodingException e) {
+            promise.reject(e);
+        }
     }
 
     private static PackageInfo getPackageInfo(Context ctx) {

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -21,7 +21,7 @@ export const NATIVE = {
       const payload = JSON.stringify(event);
       const item = JSON.stringify({
         content_type: "application/json",
-        length: payload.length,
+        length: RNSentry.getStringBytesLength(payload),
         type: "event"
       });
       const envelope = `${header}\n${item}\n${payload}`;

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -20,11 +20,9 @@ export const NATIVE = {
       };
       const payload = JSON.stringify(event);
       let length = payload.length;
-      console.log(length, "pre");
       try {
         // tslint:disable-next-line: no-unsafe-any
         length = await RNSentry.getStringBytesLength(payload);
-        console.log(length, "post");
       } catch {
         // The native call failed, we do nothing, we have payload.length as a fallback
       }

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -11,7 +11,7 @@ export const NATIVE = {
    * Sending the event over the bridge to native
    * @param event Event
    */
-  sendEvent(event: Event): PromiseLike<Response> {
+  async sendEvent(event: Event): Promise<Response> {
     if (NATIVE.platform === "android") {
       const header = JSON.stringify({ event_id: event.event_id });
 
@@ -19,9 +19,18 @@ export const NATIVE = {
         message: event.message
       };
       const payload = JSON.stringify(event);
+      let length = payload.length;
+      console.log(length, "pre");
+      try {
+        // tslint:disable-next-line: no-unsafe-any
+        length = await RNSentry.getStringBytesLength(payload);
+        console.log(length, "post");
+      } catch {
+        // The native call failed, we do nothing, we have payload.length as a fallback
+      }
       const item = JSON.stringify({
         content_type: "application/json",
-        length: RNSentry.getStringBytesLength(payload),
+        length,
         type: "event"
       });
       const envelope = `${header}\n${item}\n${payload}`;


### PR DESCRIPTION
@HazAT it was supposed to be a draft PR but.. This is an attempt (untested) to fix: https://github.com/getsentry/sentry-android/issues/273

The size issue exists because currently, we use the string length which is the number of characters. The envelope spec expects the number of bytes (which in UTF-8 vary depending on the character).

Ideally, we'd implement this in Java (we need it there anyway given the new hybrid spec) and RN will just call in with the event.

Fixes: https://github.com/getsentry/sentry-react-native/issues/775