### PR TITLE
Only if lower than 0.60

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install --save @sentry/react-native
 yarn add @sentry/react-native
 ```
 
-If you are using a version of React Native <= 0.60.x link the package using `react-native`.
+If you are using a version of React Native < 0.60 link the package using `react-native`.
 
 ```sh
 react-native link @sentry/react-native


### PR DESCRIPTION
On the website it's correctly documented though: https://docs.sentry.io/platforms/react-native/#linking