### PR TITLE
Fix path to Hermes build source map on RN 62.2

### DIFF
--- a/sentry.gradle
+++ b/sentry.gradle
@@ -209,7 +209,7 @@ static extractBundleTaskArguments(cmdArgs, Project project) {
         if (matcher.find()) {
             project.logger.info("sourcemapOutput has the wrong path, let's fix it.")
             // replacing from bundleOutput which is more reliable
-            sourcemapOutput = bundleOutput.replaceAll("(/|\\\\)generated\\1assets\\1react\\1", "\$1generated\$1sourcemaps\$1react\$1") + ".map"
+            sourcemapOutput = bundleOutput.replaceAll("(/|\\\\)generated\\1assets\\1react\\1", "\$1intermediates\$1sourcemaps\$1react\$1") + ".packager.map"
             project.logger.info("sourcemapOutput new path: `${sourcemapOutput}`")
         }
     }


### PR DESCRIPTION
This PR fixes the build that is failing with Hermes enabled on RN 62.2 due to the source map file was renamed and also the generated path.

Issue Related:
https://github.com/getsentry/sentry-react-native/issues/822