### PR TITLE
sentry-cocoa 5.0

### DIFF
--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'Sentry', '~> 4.4.0'
+  s.dependency 'Sentry', '~> 5.0.2'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -32,7 +32,6 @@ import io.sentry.core.SentryOptions;
 import io.sentry.core.UncaughtExceptionHandlerIntegration;
 import io.sentry.core.protocol.SentryException;
 
-
 @ReactModule(name = RNSentryModule.NAME)
 public class RNSentryModule extends ReactContextBaseJavaModule {
 
@@ -94,14 +93,12 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                 return event;
             });
 
-
-            for (Iterator<Integration> iterator = options.getIntegrations().iterator(); iterator.hasNext(); ) {
-            Integration integration = iterator.next();
-                if (rnOptions.hasKey("enableNativeCrashHandling") &&
-                        !rnOptions.getBoolean("enableNativeCrashHandling")) {
-                    if (integration instanceof UncaughtExceptionHandlerIntegration ||
-                            integration instanceof AnrIntegration ||
-                            integration instanceof NdkIntegration) {
+            for (Iterator<Integration> iterator = options.getIntegrations().iterator(); iterator.hasNext();) {
+                Integration integration = iterator.next();
+                if (rnOptions.hasKey("enableNativeCrashHandling")
+                        && !rnOptions.getBoolean("enableNativeCrashHandling")) {
+                    if (integration instanceof UncaughtExceptionHandlerIntegration
+                            || integration instanceof AnrIntegration || integration instanceof NdkIntegration) {
                         iterator.remove();
                     }
                 }
@@ -138,7 +135,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     public void captureEnvelope(String envelope, Promise promise) {
         try {
             File installation = new File(sentryOptions.getOutboxPath(), UUID.randomUUID().toString());
-            try(FileOutputStream out = new FileOutputStream(installation)) {
+            try (FileOutputStream out = new FileOutputStream(installation)) {
                 out.write(envelope.getBytes(Charset.forName("UTF-8")));
             }
         } catch (Exception e) {

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -31,56 +31,58 @@ RCT_EXPORT_MODULE()
     return @{@"nativeClientAvailable": @YES, @"nativeTransport": @YES};
 }
 
-RCT_EXPORT_METHOD(crashedLastLaunch:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject) {
-    NSNumber *crashedLastLaunch = @NO;
-    if (SentryClient.sharedClient && [SentryClient.sharedClient crashedLastLaunch]) {
-        crashedLastLaunch = @YES;
-    }
-    resolve(crashedLastLaunch);
-}
-
 RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString
                   options:(NSDictionary *_Nonnull)options
                   resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSError *error = nil;
-    SentryClient *client = [[SentryClient alloc] initWithDsn:dsnString didFailWithError:&error];
-    client.shouldSendEvent = ^BOOL(SentryEvent * _Nonnull event) {
+    
+    SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:options didFailWithError:&error];
+    if (error) {
+        reject(@"SentryReactNative", error.localizedDescription, error);
+        return;
+    }
+    
+    SentryBeforeSendEventCallback beforeSend = ^SentryEvent*(SentryEvent *event) {
         // We don't want to send an event after startup that came from a Unhandled JS Exception of react native
         // Because we sent it already before the app crashed.
         if (nil != event.exceptions.firstObject.type &&
             [event.exceptions.firstObject.type rangeOfString:@"Unhandled JS Exception"].location != NSNotFound) {
             NSLog(@"Unhandled JS Exception");
-            return NO;
+            return nil;
         }
-        return YES;
+        return event;
     };
-    [SentryClient setSharedClient:client];
-    if ([[options objectForKey:@"enableNativeCrashHandling"] boolValue]) {
-        [SentryClient.sharedClient startCrashHandlerWithError:&error];
-    }
-    if (nil != [options objectForKey:@"environment"]) {
-        SentryClient.sharedClient.environment = [NSString stringWithFormat:@"%@", [options objectForKey:@"environment"]];
-    }
-    if (nil != [options objectForKey:@"release"]) {
-        SentryClient.sharedClient.releaseName = [NSString stringWithFormat:@"%@", [options objectForKey:@"release"]];
-    }
-    if (nil != [options objectForKey:@"dist"]) {
-        SentryClient.sharedClient.dist = [NSString stringWithFormat:@"%@", [options objectForKey:@"dist"]];
-    }
-    if (error) {
-        reject(@"SentryReactNative", error.localizedDescription, error);
-        return;
-    }
+    
+    [options setValue:beforeSend forKey:@"beforeSend"];
+    
+    [SentrySDK startWithOptionsObject:sentryOptions];
+
     resolve(@YES);
 }
 
-RCT_EXPORT_METHOD(deviceContexts:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
+// TODO: Need to expose device context from sentry-cocoa
+////RCT_EXPORT_METHOD(deviceContexts:(RCTPromiseResolveBlock)resolve
+////                  rejecter:(RCTPromiseRejectBlock)reject)
+////{
+////    resolve([[[SentryContext alloc] init] serialize]);
+////}
+
+RCT_EXPORT_METHOD(setLogLevel:(int)level)
 {
-    resolve([[[SentryContext alloc] init] serialize]);
+    SentryLogLevel cocoaLevel;
+    switch (level) {
+        case 1:
+            cocoaLevel = kSentryLogLevelError;
+        case 2:
+            cocoaLevel = kSentryLogLevelDebug;
+        case 3:
+            cocoaLevel = kSentryLogLevelVerbose;
+        default:
+            cocoaLevel = kSentryLogLevelNone;
+    }
+    [SentrySDK setLogLevel:cocoaLevel];
 }
 
 RCT_EXPORT_METHOD(fetchRelease:(RCTPromiseResolveBlock)resolve
@@ -94,12 +96,6 @@ RCT_EXPORT_METHOD(fetchRelease:(RCTPromiseResolveBlock)resolve
               });
 }
 
-
-RCT_EXPORT_METHOD(setLogLevel:(int)level)
-{
-    [SentryClient setLogLevel:[SentryJavaScriptBridgeHelper sentryLogLevelFromJavaScriptLevel:level]];
-}
-
 RCT_EXPORT_METHOD(sendEvent:(NSDictionary * _Nonnull)event
                   resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
@@ -111,13 +107,8 @@ RCT_EXPORT_METHOD(sendEvent:(NSDictionary * _Nonnull)event
                                                                  error:nil];
 
             SentryEvent *sentryEvent = [[SentryEvent alloc] initWithJSON:jsonData];
-            [SentryClient.sharedClient sendEvent:sentryEvent withCompletionHandler:^(NSError * _Nullable error) {
-                if (nil != error) {
-                    reject(@"SentryReactNative", error.localizedDescription, error);
-                } else {
-                    resolve(@YES);
-                }
-            }];
+            [SentrySDK captureEvent:sentryEvent];
+            resolve(@YES);
         } else {
             reject(@"SentryReactNative", @"Cannot serialize event", nil);
         }
@@ -126,7 +117,7 @@ RCT_EXPORT_METHOD(sendEvent:(NSDictionary * _Nonnull)event
 
 RCT_EXPORT_METHOD(crash)
 {
-    [SentryClient.sharedClient crash];
+    [SentrySDK crash];
 }
 
 @end

--- a/sample/App.js
+++ b/sample/App.js
@@ -31,6 +31,14 @@ Sentry.init({
     // Replace the example DSN below with your own DSN:
     'https://6890c2f6677340daa4804f8194804ea2@o19635.ingest.sentry.io/148053',
   debug: true,
+  beforeSend: e => {
+    if (!e.tags) {
+      e.tags = {};
+    }
+    e.tags["beforeSend"] = "JS layer";
+    return e;
+  },
+  enableAutoSessionTracking: true
 });
 const App: () => React$Node = () => {
   return (

--- a/sample/android/.project
+++ b/sample/android/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sample</name>
+	<comment>Project android_ created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/sample/android/.settings/org.eclipse.buildship.core.prefs
+++ b/sample/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_221.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/sample/android/app/.classpath
+++ b/sample/android/app/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/sample/android/app/.project
+++ b/sample/android/app/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app</name>
+	<comment>Project app created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+</projectDescription>

--- a/sample/android/app/.settings/org.eclipse.buildship.core.prefs
+++ b/sample/android/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1

--- a/sample/android/app/src/main/java/com/sample/MainApplication.java
+++ b/sample/android/app/src/main/java/com/sample/MainApplication.java
@@ -26,8 +26,7 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-//           packages.add(new RNSentryPackage());
+          packages.add(new RNSentryPackage());
           return packages;
         }
 

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -294,10 +294,10 @@ PODS:
     - ReactCommon/callinvoker (= 0.62.2)
   - RNSentry (1.3.7):
     - React
-    - Sentry (~> 4.4.0)
-  - Sentry (4.4.3):
-    - Sentry/Core (= 4.4.3)
-  - Sentry/Core (4.4.3)
+    - Sentry (~> 5.0.2)
+  - Sentry (5.0.2):
+    - Sentry/Core (= 5.0.2)
+  - Sentry/Core (5.0.2)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -458,8 +458,8 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNSentry: 370623102247ebea20191b5fb549ecc7a275b324
-  Sentry: 14bdd673870e8cf64932b149fad5bbbf39a9b390
+  RNSentry: cccb458cbe1851a32776b2e2eecaf9b1157832f3
+  Sentry: 5cec6146fff65c11080f78e8128582727c076e12
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -292,7 +292,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - RNSentry (1.3.7):
+  - RNSentry (1.3.8):
     - React
     - Sentry (~> 5.0.2)
   - Sentry (5.0.2):
@@ -458,7 +458,7 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNSentry: cccb458cbe1851a32776b2e2eecaf9b1157832f3
+  RNSentry: b246443bf53b1c2faa145b936fb257c750dda8a9
   Sentry: 5cec6146fff65c11080f78e8128582727c076e12
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -38,10 +38,10 @@ export class ReactNativeClient extends BaseClient<
         ...((event.sdk && event.sdk.packages) || []),
         {
           name: "npm:@sentry/react-native",
-          version: SDK_VERSION
-        }
+          version: SDK_VERSION,
+        },
       ],
-      version: SDK_VERSION
+      version: SDK_VERSION,
     };
 
     return super._prepareEvent(event, scope, hint);

--- a/src/js/integrations/devicecontext.ts
+++ b/src/js/integrations/devicecontext.ts
@@ -1,5 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from "@sentry/core";
 import { Event, Integration } from "@sentry/types";
+import { logger } from "@sentry/utils";
 import { NativeModules } from "react-native";
 
 const { RNSentry } = NativeModules;
@@ -29,8 +30,8 @@ export class DeviceContext implements Integration {
         // tslint:disable-next-line: no-unsafe-any
         const deviceContexts = await RNSentry.deviceContexts();
         event.contexts = { ...deviceContexts, ...event.contexts };
-      } catch (_Oo) {
-        // Something went wrong, we just continue
+      } catch (e) {
+        logger.log(`Failed to get device context from native: ${e}`);
       }
 
       return event;


### PR DESCRIPTION
To note:

 * Even though not public API in react-native, it was public on the bridge but now removed:
`crashedLastLaunch`

* Now passing the whole dictionary of options which might not be wise. Needs a review. Should we whitelist what can go through? Or perhaps blacklist what we know should only stay at the JS layer?
* Dropping `enableNativeCrashHandling` which means we're always bringing in native crashes. Can we get feedback on this? Is it a real use case where users need only JS crashes?

TODO:
- [x] Pending adding `deviceContexts` to get context added on JS-only errors.
- [ ] `setLogLevel` should be removed. Other SDKs have `DiagnosticLevel` to configure the level when `Debug=true`.
- [ ] Implement `captureEnvelope` to replace `captureEvent`
- [ ] Review files to ignore e.g: `sample/android/.project`, `sample/android/.settings/`