### PR TITLE
Remove usages of RNSentry to a native wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
       "**/*.test.ts"
     ],
     "globals": {
+      "__DEV__": true,
       "ts-jest": {
         "tsConfig": "./tsconfig.json",
         "diagnostics": false

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -48,11 +48,7 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
     YellowBox.ignoreWarnings(["Require cycle:"]);
 
     // tslint:disable: no-unsafe-any
-    if (
-      RNSentry &&
-      RNSentry.nativeClientAvailable &&
-      _options.enableNative !== false
-    ) {
+    if (NATIVE.isNativeClientAvailable() && _options.enableNative !== false) {
       RNSentry.startWithDsnString(_options.dsn, _options).then(() => {
         RNSentry.setLogLevel(_options.debug ? 2 : 1);
       });
@@ -96,14 +92,11 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
    * If true, native client is availabe and active
    */
   private _isNativeTransportAvailable(): boolean {
-    // tslint:disable: no-unsafe-any
     return (
-      this._options.enableNative &&
-      RNSentry &&
-      RNSentry.nativeClientAvailable &&
-      RNSentry.nativeTransport
+      this._options.enableNative === true &&
+      NATIVE.isNativeClientAvailable() &&
+      NATIVE.isNativeTransportAvailable()
     );
-    // tslint:enable: no-unsafe-any
   }
 
   /**

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -2,12 +2,10 @@ import { BrowserOptions, Transports } from "@sentry/browser";
 import { BrowserBackend } from "@sentry/browser/dist/backend";
 import { BaseBackend, NoopTransport } from "@sentry/core";
 import { Event, EventHint, Severity, Transport } from "@sentry/types";
-import { Alert, NativeModules, YellowBox } from "react-native";
+import { Alert, YellowBox } from "react-native";
 
 import { NativeTransport } from "./transports/native";
 import { NATIVE } from "./wrapper";
-
-const { RNSentry } = NativeModules;
 
 /**
  * Configuration options for the Sentry ReactNative SDK.
@@ -47,10 +45,13 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
     // This is a workaround for now using fetch on RN, this is a known issue in react-native and only generates a warning
     YellowBox.ignoreWarnings(["Require cycle:"]);
 
-    // tslint:disable: no-unsafe-any
-    if (NATIVE.isNativeClientAvailable() && _options.enableNative !== false) {
-      RNSentry.startWithDsnString(_options.dsn, _options).then(() => {
-        RNSentry.setLogLevel(_options.debug ? 2 : 1);
+    if (_options.enableNative !== false && NATIVE.isNativeClientAvailable()) {
+      // tslint:disable-next-line: no-floating-promises
+      NATIVE.startWithDsnString(
+        typeof _options.dsn === "string" ? _options.dsn : "",
+        _options
+      ).then(() => {
+        NATIVE.setLogLevel(_options.debug ? 2 : 1);
       });
     } else {
       if (__DEV__ && _options.enableNativeNagger) {
@@ -60,7 +61,6 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
         );
       }
     }
-    // tslint:enable: no-unsafe-any
   }
 
   /**

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -45,21 +45,39 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
     // This is a workaround for now using fetch on RN, this is a known issue in react-native and only generates a warning
     YellowBox.ignoreWarnings(["Require cycle:"]);
 
-    if (_options.enableNative !== false && NATIVE.isNativeClientAvailable()) {
+    if (this._options.enableNative) {
       // tslint:disable-next-line: no-floating-promises
-      NATIVE.startWithDsnString(
-        typeof _options.dsn === "string" ? _options.dsn : "",
-        _options
-      ).then(() => {
-        NATIVE.setLogLevel(_options.debug ? 2 : 1);
-      });
+      this._startWithDsnString();
     } else {
-      if (__DEV__ && _options.enableNativeNagger) {
-        Alert.alert(
-          "Sentry",
-          "Warning, could not connect to Sentry native SDK.\nIf you do not want to use the native component please pass `enableNative: false` in the options.\nVisit: https://docs.sentry.io/platforms/react-native/#linking for more details."
-        );
-      }
+      this._showCannotConnectDialog();
+    }
+  }
+
+  /**
+   * Starts native client with dsn and options
+   */
+  private _startWithDsnString(): Promise<void> {
+    return NATIVE.startWithDsnString(
+      typeof this._options.dsn === "string" ? this._options.dsn : "",
+      this._options
+    )
+      .then(() => {
+        NATIVE.setLogLevel(this._options.debug ? 2 : 1);
+      })
+      .catch(() => {
+        this._showCannotConnectDialog();
+      });
+  }
+
+  /**
+   * If the user is in development mode, and the native nagger is enabled then it will show an alert.
+   */
+  private _showCannotConnectDialog(): void {
+    if (__DEV__ && this._options.enableNativeNagger) {
+      Alert.alert(
+        "Sentry",
+        "Warning, could not connect to Sentry native SDK.\nIf you do not want to use the native component please pass `enableNative: false` in the options.\nVisit: https://docs.sentry.io/platforms/react-native/#linking for more details."
+      );
     }
   }
 

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -56,17 +56,16 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
   /**
    * Starts native client with dsn and options
    */
-  private _startWithDsnString(): Promise<void> {
-    return NATIVE.startWithDsnString(
-      typeof this._options.dsn === "string" ? this._options.dsn : "",
-      this._options
-    )
-      .then(() => {
-        NATIVE.setLogLevel(this._options.debug ? 2 : 1);
-      })
-      .catch(() => {
-        this._showCannotConnectDialog();
-      });
+  private async _startWithDsnString(): Promise<void> {
+    try {
+      await NATIVE.startWithDsnString(
+        typeof this._options.dsn === "string" ? this._options.dsn : "",
+        this._options
+      );
+      NATIVE.setLogLevel(this._options.debug ? 2 : 1);
+    } catch (_) {
+      this._showCannotConnectDialog();
+    }
   }
 
   /**

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -5,6 +5,7 @@ import { Event, EventHint, Severity, Transport } from "@sentry/types";
 import { Alert, NativeModules, YellowBox } from "react-native";
 
 import { NativeTransport } from "./transports/native";
+import { NATIVE } from "./wrapper";
 
 const { RNSentry } = NativeModules;
 
@@ -111,8 +112,7 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
    */
   public nativeCrash(): void {
     if (this._options.enableNative) {
-      // tslint:disable-next-line: no-unsafe-any
-      RNSentry.crash();
+      NATIVE.crash();
     }
   }
 

--- a/src/js/integrations/devicecontext.ts
+++ b/src/js/integrations/devicecontext.ts
@@ -1,9 +1,8 @@
 import { addGlobalEventProcessor, getCurrentHub } from "@sentry/core";
 import { Event, Integration } from "@sentry/types";
 import { logger } from "@sentry/utils";
-import { NativeModules } from "react-native";
 
-const { RNSentry } = NativeModules;
+import { NATIVE } from "../wrapper";
 
 /** Load device context from native. */
 export class DeviceContext implements Integration {
@@ -27,8 +26,7 @@ export class DeviceContext implements Integration {
       }
 
       try {
-        // tslint:disable-next-line: no-unsafe-any
-        const deviceContexts = await RNSentry.deviceContexts();
+        const deviceContexts = await NATIVE.deviceContexts();
         event.contexts = { ...deviceContexts, ...event.contexts };
       } catch (e) {
         logger.log(`Failed to get device context from native: ${e}`);

--- a/src/js/integrations/release.ts
+++ b/src/js/integrations/release.ts
@@ -1,8 +1,7 @@
 import { addGlobalEventProcessor, getCurrentHub } from "@sentry/core";
 import { Event, Integration } from "@sentry/types";
-import { NativeModules } from "react-native";
 
-const { RNSentry } = NativeModules;
+import { NATIVE } from "../wrapper";
 
 /** Release integration responsible to load release from file. */
 export class Release implements Integration {
@@ -27,11 +26,7 @@ export class Release implements Integration {
 
       try {
         // tslint:disable-next-line: no-unsafe-any
-        const release = (await RNSentry.fetchRelease()) as {
-          build: string;
-          id: string;
-          version: string;
-        };
+        const release = await NATIVE.fetchRelease();
         if (release) {
           event.release = `${release.id}@${release.version}+${release.build}`;
           event.dist = `${release.build}`;

--- a/src/js/integrations/release.ts
+++ b/src/js/integrations/release.ts
@@ -25,7 +25,6 @@ export class Release implements Integration {
       }
 
       try {
-        // tslint:disable-next-line: no-unsafe-any
         const release = await NATIVE.fetchRelease();
         if (release) {
           event.release = `${release.id}@${release.version}+${release.build}`;

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -57,5 +57,21 @@ export const NATIVE = {
     return !!RNSentry;
   },
 
+  /**
+   *  Checks whether the RNSentry module is loaded and the native client is available
+   */
+  isNativeClientAvailable(): boolean {
+    // tslint:disable-next-line: no-unsafe-any
+    return this.isModuleLoaded() && RNSentry.nativeClientAvailable;
+  },
+
+  /**
+   *  Checks whether the RNSentry module is loaded and native transport is available
+   */
+  isNativeTransportAvailable(): boolean {
+    // tslint:disable-next-line: no-unsafe-any
+    return this.isModuleLoaded() && RNSentry.nativeTransport;
+  },
+
   platform: Platform.OS
 };

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -39,5 +39,23 @@ export const NATIVE = {
     return RNSentry.sendEvent(event);
   },
 
+  /**
+   * Triggers a native crash.
+   * Use this only for testing purposes.
+   */
+  crash(): void {
+    if (this.isModuleLoaded()) {
+      // tslint:disable-next-line: no-unsafe-any
+      RNSentry.crash();
+    }
+  },
+
+  /**
+   * Checks whether the RNSentry module is loaded.
+   */
+  isModuleLoaded(): boolean {
+    return !!RNSentry;
+  },
+
   platform: Platform.OS
 };

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -49,7 +49,7 @@ export const NATIVE = {
   async startWithDsnString(
     dsn: string,
     options: ReactNativeOptions
-  ): Promise<Response> {
+  ): Promise<boolean> {
     if (this.isNativeClientAvailable()) {
       // tslint:disable-next-line: no-unsafe-any
       return RNSentry.startWithDsnString(dsn, options);

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -50,8 +50,26 @@ export const NATIVE = {
     dsn: string,
     options: ReactNativeOptions
   ): Promise<Response> {
-    // tslint:disable-next-line: no-unsafe-any
-    return RNSentry.startWithDsnString(dsn, options);
+    if (this.isNativeClientAvailable()) {
+      // tslint:disable-next-line: no-unsafe-any
+      return RNSentry.startWithDsnString(dsn, options);
+    }
+    return Promise.reject();
+  },
+
+  /**
+   * Fetches the release from native
+   */
+  async fetchRelease(): Promise<{
+    build: string;
+    id: string;
+    version: string;
+  }> {
+    if (this.isNativeClientAvailable()) {
+      // tslint:disable-next-line: no-unsafe-any
+      return RNSentry.fetchRelease();
+    }
+    return Promise.reject();
   },
 
   /**
@@ -68,7 +86,7 @@ export const NATIVE = {
    * Use this only for testing purposes.
    */
   crash(): void {
-    if (this.isModuleLoaded()) {
+    if (this.isNativeClientAvailable()) {
       // tslint:disable-next-line: no-unsafe-any
       RNSentry.crash();
     }

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -1,6 +1,8 @@
 import { Event, Response } from "@sentry/types";
 import { NativeModules, Platform } from "react-native";
 
+import { ReactNativeOptions } from "./backend";
+
 const { RNSentry } = NativeModules;
 
 /**
@@ -37,6 +39,28 @@ export const NATIVE = {
     }
     // tslint:disable-next-line: no-unsafe-any
     return RNSentry.sendEvent(event);
+  },
+
+  /**
+   * Starts native with dsn string and options.
+   * @param dsn string
+   * @param options ReactNativeOptions
+   */
+  async startWithDsnString(
+    dsn: string,
+    options: ReactNativeOptions
+  ): Promise<Response> {
+    // tslint:disable-next-line: no-unsafe-any
+    return RNSentry.startWithDsnString(dsn, options);
+  },
+
+  /**
+   * Sets log level in native
+   * @param level number
+   */
+  setLogLevel(level: number): void {
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.setLogLevel(level);
   },
 
   /**

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -73,6 +73,17 @@ export const NATIVE = {
   },
 
   /**
+   * Fetches the device contexts. Not used on Android.
+   */
+  async deviceContexts(): Promise<object> {
+    if (this.isNativeClientAvailable()) {
+      // tslint:disable-next-line: no-unsafe-any
+      return RNSentry.deviceContexts();
+    }
+    return Promise.reject();
+  },
+
+  /**
    * Sets log level in native
    * @param level number
    */

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -1,0 +1,36 @@
+import { ReactNativeBackend } from "../src/js/backend";
+
+jest.mock(
+  "react-native",
+  () => ({
+    NativeModules: {
+      RNSentry: {
+        crash: jest.fn()
+      }
+    },
+    Platform: {
+      OS: "mock"
+    },
+    YellowBox: {
+      ignoreWarnings: jest.fn()
+    }
+  }),
+  /* virtual allows us to mock modules that aren't in package.json */
+  { virtual: true }
+);
+
+describe("Tests ReactNativeBackend", () => {
+  describe("nativeCrash", () => {
+    test("calls NativeModules crash", () => {
+      const RN = require("react-native");
+
+      const backend = new ReactNativeBackend({
+        enableNative: true
+      });
+      backend.nativeCrash();
+
+      // tslint:disable-next-line: no-unsafe-any
+      expect(RN.NativeModules.RNSentry.crash).toBeCalled();
+    });
+  });
+});

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -1,11 +1,22 @@
 import { ReactNativeBackend } from "../src/js/backend";
+import { SentryError } from "@sentry/utils";
+
+const EXAMPLE_DSN =
+  "https://6890c2f6677340daa4804f8194804ea2@o19635.ingest.sentry.io/148053";
 
 jest.mock(
   "react-native",
   () => ({
     NativeModules: {
       RNSentry: {
-        crash: jest.fn()
+        crash: jest.fn(),
+        setLogLevel: jest.fn(),
+        startWithDsnString: jest.fn((dsn) => {
+          if (typeof dsn !== "string") {
+            throw new Error();
+          }
+          return Promise.resolve();
+        })
       }
     },
     Platform: {
@@ -20,6 +31,42 @@ jest.mock(
 );
 
 describe("Tests ReactNativeBackend", () => {
+  describe("initializing the backend", () => {
+    test("backend initializes", async () => {
+      const backend = new ReactNativeBackend({
+        dsn: EXAMPLE_DSN,
+        enableNative: true
+      });
+
+      await expect(backend.eventFromMessage("test")).resolves.toBeDefined();
+    });
+
+    test("invalid dsn is thrown", () => {
+      try {
+        // tslint:disable-next-line: no-unused-expression
+        new ReactNativeBackend({
+          dsn: "not a dsn",
+          enableNative: true
+        });
+      } catch (e) {
+        // tslint:disable-next-line: no-unsafe-any
+        expect(e.message).toBe("Invalid Dsn");
+      }
+    });
+
+    test("undefined dsn doesn't crash", () => {
+      expect(() => {
+        // tslint:disable-next-line: no-unused-expression
+        const backend = new ReactNativeBackend({
+          dsn: undefined,
+          enableNative: true
+        });
+
+        return expect(backend.eventFromMessage("test")).resolves.toBeDefined();
+      }).not.toThrow();
+    });
+  });
+
   describe("nativeCrash", () => {
     test("calls NativeModules crash", () => {
       const RN = require("react-native");

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -11,6 +11,8 @@ jest.mock(
       RNSentry: {
         crash: jest.fn(),
         setLogLevel: jest.fn(),
+        nativeClientAvailable: true,
+        nativeTransport: true,
         startWithDsnString: jest.fn((dsn) => {
           if (typeof dsn !== "string") {
             throw new Error();

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -5,7 +5,9 @@ jest.mock(
   () => ({
     NativeModules: {
       RNSentry: {
-        crash: jest.fn()
+        crash: jest.fn(),
+        nativeClientAvailable: true,
+        nativeTransport: true
       }
     },
     Platform: {
@@ -22,6 +24,7 @@ describe("Tests Native Wrapper", () => {
       expect(NATIVE.isModuleLoaded()).toBe(true);
     });
   });
+
   describe("crash", () => {
     test("calls the native crash", () => {
       const RN = require("react-native");
@@ -30,6 +33,18 @@ describe("Tests Native Wrapper", () => {
 
       // tslint:disable-next-line: no-unsafe-any
       expect(RN.NativeModules.RNSentry.crash).toBeCalled();
+    });
+  });
+
+  describe("isNativeClientAvailable", () => {
+    test("checks if native client is available", () => {
+      expect(NATIVE.isNativeClientAvailable()).toBe(true);
+    });
+  });
+
+  describe("isNativeTransportAvailable", () => {
+    test("checks if native transport is available", () => {
+      expect(NATIVE.isNativeTransportAvailable()).toBe(true);
     });
   });
 });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -5,6 +5,13 @@ jest.mock(
   () => ({
     NativeModules: {
       RNSentry: {
+        fetchRelease: jest.fn(() =>
+          Promise.resolve({
+            build: "1.0.0.1",
+            id: "test-mock",
+            version: "1.0.0"
+          })
+        ),
         crash: jest.fn(),
         nativeClientAvailable: true,
         nativeTransport: true
@@ -19,6 +26,16 @@ jest.mock(
 );
 
 describe("Tests Native Wrapper", () => {
+  describe("fetchRelease", () => {
+    test("fetches the release from native", async () => {
+      await expect(NATIVE.fetchRelease()).resolves.toMatchObject({
+        build: "1.0.0.1",
+        id: "test-mock",
+        version: "1.0.0"
+      });
+    });
+  });
+
   describe("isModuleLoaded", () => {
     test("returns true when module is loaded", () => {
       expect(NATIVE.isModuleLoaded()).toBe(true);

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -5,6 +5,7 @@ jest.mock(
   () => ({
     NativeModules: {
       RNSentry: {
+        crash: jest.fn(),
         fetchRelease: jest.fn(() =>
           Promise.resolve({
             build: "1.0.0.1",
@@ -12,7 +13,6 @@ jest.mock(
             version: "1.0.0"
           })
         ),
-        crash: jest.fn(),
         nativeClientAvailable: true,
         nativeTransport: true
       }

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -1,0 +1,35 @@
+import { NATIVE } from "../src/js/wrapper";
+
+jest.mock(
+  "react-native",
+  () => ({
+    NativeModules: {
+      RNSentry: {
+        crash: jest.fn()
+      }
+    },
+    Platform: {
+      OS: "mock"
+    }
+  }),
+  /* virtual allows us to mock modules that aren't in package.json */
+  { virtual: true }
+);
+
+describe("Tests Native Wrapper", () => {
+  describe("isModuleLoaded", () => {
+    test("returns true when module is loaded", () => {
+      expect(NATIVE.isModuleLoaded()).toBe(true);
+    });
+  });
+  describe("crash", () => {
+    test("calls the native crash", () => {
+      const RN = require("react-native");
+
+      NATIVE.crash();
+
+      // tslint:disable-next-line: no-unsafe-any
+      expect(RN.NativeModules.RNSentry.crash).toBeCalled();
+    });
+  });
+});

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -6,6 +6,7 @@ jest.mock(
     NativeModules: {
       RNSentry: {
         crash: jest.fn(),
+        deviceContexts: jest.fn(() => Promise.resolve({})),
         fetchRelease: jest.fn(() =>
           Promise.resolve({
             build: "1.0.0.1",
@@ -33,6 +34,12 @@ describe("Tests Native Wrapper", () => {
         id: "test-mock",
         version: "1.0.0"
       });
+    });
+  });
+
+  describe("deviceContexts", () => {
+    test("fetches the contexts from native", async () => {
+      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({});
     });
   });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Wrote functions to mirror the native modules in a wrapper. Added tests to test the basic functionality of the wrapper along with testing for initializing the backend.

Removed all usages of `RNSentry` outside of the native wrapper.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is for the migration of all usages of `RNSentry` to a native wrapper to allow for more extensive testing of the SDK.


## :green_heart: How did you test it?
Wrote new tests in Jest.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
