### PR TITLE
Refactored startWithDsnString to be startWithOptions.

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -61,10 +61,14 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void startWithDsnString(String dsnString, final ReadableMap rnOptions, Promise promise) {
+    public void startWithOptions(final ReadableMap rnOptions, Promise promise) {
         SentryAndroid.init(this.getReactApplicationContext(), options -> {
-            options.setDsn(dsnString);
-
+            if (rnOptions.hasKey("dsn") && rnOptions.getString("dsn") != null) {
+                options.setDsn(rnOptions.getString("dsn"));
+            } else {
+                // SentryAndroid needs an empty string fallback for the dsn.
+                options.setDsn("");
+            }
             if (rnOptions.hasKey("debug") && rnOptions.getBoolean("debug")) {
                 options.setDebug(true);
             }
@@ -108,7 +112,10 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             sentryOptions = options;
         });
 
-        logger.info(String.format("startWithDsnString '%s'", dsnString));
+        if (rnOptions.hasKey("dsn")) {
+            logger.info(String.format("startWithDsnString '%s'", rnOptions.getString("dsn")));
+        }
+
         promise.resolve(true);
     }
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -31,8 +31,7 @@ RCT_EXPORT_MODULE()
     return @{@"nativeClientAvailable": @YES, @"nativeTransport": @YES};
 }
 
-RCT_EXPORT_METHOD(startWithDsnString:(NSString * _Nonnull)dsnString
-                  options:(NSDictionary *_Nonnull)options
+RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *_Nonnull)options
                   resolve:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -47,7 +47,7 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
 
     if (this._options.enableNative) {
       // tslint:disable-next-line: no-floating-promises
-      this._startWithDsnString();
+      this._startWithOptions();
     } else {
       this._showCannotConnectDialog();
     }
@@ -56,12 +56,9 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
   /**
    * Starts native client with dsn and options
    */
-  private async _startWithDsnString(): Promise<void> {
+  private async _startWithOptions(): Promise<void> {
     try {
-      await NATIVE.startWithDsnString(
-        typeof this._options.dsn === "string" ? this._options.dsn : "",
-        this._options
-      );
+      await NATIVE.startWithOptions(this._options);
       NATIVE.setLogLevel(this._options.debug ? 2 : 1);
     } catch (_) {
       this._showCannotConnectDialog();

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -1,8 +1,8 @@
 import { Event, Response } from "@sentry/types";
+import { SentryError } from "@sentry/utils";
 import { NativeModules, Platform } from "react-native";
 
 import { ReactNativeOptions } from "./backend";
-import { SentryError } from "@sentry/utils";
 
 const { RNSentry } = NativeModules;
 
@@ -47,19 +47,22 @@ export const NATIVE = {
   },
 
   /**
-   * Starts native with dsn string and options.
-   * @param dsn string
+   * Starts native with the provided options.
    * @param options ReactNativeOptions
    */
-  async startWithDsnString(
-    dsn: string,
-    options: ReactNativeOptions
-  ): Promise<boolean> {
+  async startWithOptions(options: ReactNativeOptions = {}): Promise<boolean> {
     if (!this.isNativeClientAvailable()) {
       throw this._NativeClientError;
     }
+
+    if (__DEV__ && !options.dsn) {
+      console.warn(
+        "Warning: No DSN was provided. The Sentry SDK will be disabled."
+      );
+    }
+
     // tslint:disable-next-line: no-unsafe-any
-    return RNSentry.startWithDsnString(dsn, options);
+    return RNSentry.startWithOptions(options);
   },
 
   /**

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -5,6 +5,7 @@ jest.mock(
   () => ({
     NativeModules: {
       RNSentry: {
+        captureEnvelope: jest.fn((envelope) => Promise.resolve(envelope)),
         crash: jest.fn(),
         deviceContexts: jest.fn(() => Promise.resolve({})),
         fetchRelease: jest.fn(() =>
@@ -14,11 +15,11 @@ jest.mock(
             version: "1.0.0"
           })
         ),
+        getStringBytesLength: jest.fn(() => Promise.resolve(1)),
         nativeClientAvailable: true,
         nativeTransport: true,
         sendEvent: jest.fn(() => Promise.resolve()),
-        getStringBytesLength: jest.fn(() => Promise.resolve(1)),
-        captureEnvelope: jest.fn((envelope) => Promise.resolve(envelope))
+        startWithOptions: jest.fn((options) => Promise.resolve(options))
       }
     },
     Platform: {
@@ -34,6 +35,26 @@ beforeEach(() => {
 });
 
 describe("Tests Native Wrapper", () => {
+  describe("startWithOptions", () => {
+    test("calls native module", async () => {
+      const RN = require("react-native");
+
+      await NATIVE.startWithOptions({ dsn: "test" });
+
+      expect(RN.NativeModules.RNSentry.startWithOptions).toBeCalled();
+    });
+
+    test("warns if there is no dsn", async () => {
+      const RN = require("react-native");
+      console.warn = jest.fn();
+
+      await NATIVE.startWithOptions({});
+
+      expect(RN.NativeModules.RNSentry.startWithOptions).toBeCalled();
+      expect(console.warn).toBeCalled();
+    });
+  });
+
   describe("sendEvent", () => {
     test("calls sendEvent on iOS", async () => {
       const RN = require("react-native");


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Refactored the `startWithDsnString` method in the native wrapper to be `startWithOptions`. If a DSN is not provided to Android an empty string will be the fallback. Added a warning message if a DSN is not provided.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Having the DSN is a separate parameter was redundant as it's already included in the options passed.

## :green_heart: How did you test it?
Wrote two Jests tests to test that it calls the native module, and that the warning is logged when a DSN was not provided. Tested on the sample iOS and Android with emulators, with DSN provided and no DSN provided.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
