### PR TITLE
fix: Don't attach Android Threads

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -64,7 +64,9 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     public void startWithOptions(final ReadableMap rnOptions, Promise promise) {
         SentryAndroid.init(this.getReactApplicationContext(), options -> {
             if (rnOptions.hasKey("dsn") && rnOptions.getString("dsn") != null) {
-                options.setDsn(rnOptions.getString("dsn"));
+                String dsn = rnOptions.getString("dsn");
+                logger.info(String.format("Starting with DSN: '%s'", dsn));
+                options.setDsn(dsn);
             } else {
                 // SentryAndroid needs an empty string fallback for the dsn.
                 options.setDsn("");
@@ -81,6 +83,10 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             if (rnOptions.hasKey("dist") && rnOptions.getString("dist") != null) {
                 options.setDist(rnOptions.getString("dist"));
             }
+
+            // JS use top level stacktraces and android attaches Threads which hides them so by default we hide.
+            boolean attachThreads = rnOptions.hasKey("attachThreads") && rnOptions.getBoolean("attachThreads");
+            options.setAttachThreads(attachThreads);
 
             options.setBeforeSend((event, hint) -> {
                 // React native internally throws a JavascriptException
@@ -111,10 +117,6 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             logger.info(String.format("Native Integrations '%s'", options.getIntegrations().toString()));
             sentryOptions = options;
         });
-
-        if (rnOptions.hasKey("dsn")) {
-            logger.info(String.format("startWithDsnString '%s'", rnOptions.getString("dsn")));
-        }
 
         promise.resolve(true);
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Unless explicitly passed in via configuration, attachThreads will be `false`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JS sends event.stacktrace (see getsentry/sentry-javascript#2605 and `sentry-android` attaches event.threads and the UI picks the threads instead. But that means the stacktrace unrelated to any thread doesn't render, and the Java threads are irrelevant (in fact they don't include any frame). Lastly threads don't seem to be useful in this context

## :green_heart: How did you test it?
Used the sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing


## :crystal_ball: Next steps
