### PR TITLE
Add enableAutoSessionTracking to ReactNativeOptions interface

### DIFF
--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -31,6 +31,9 @@ export interface ReactNativeOptions extends BrowserOptions {
 
   /** Should the native nagger alert be shown or not. */
   enableNativeNagger?: boolean;
+  
+  /** Should sessions be tracked to Sentry Health or not. */
+  enableAutoSessionTracking?: boolean;
 }
 
 /** The Sentry ReactNative SDK Backend. */


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Adds missing `enableAutoSessionTracking` type to `ReactNativeOptions` interface.


## :bulb: Motivation and Context
This fixes #879 . The definition was missing in the `1.4.0` update


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
