### PR TITLE
fix: Filter out all init options that would crash native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Filtered out `options` keys passed to `init` that would crash native. #885
+
 ## 1.4.0
 
 - Remove usages of RNSentry to a native wrapper (#857)
@@ -128,7 +130,7 @@ New way to import and init the SDK:
 import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
-  dsn: "DSN",
+  dsn: "DSN"
 });
 ```
 
@@ -364,7 +366,7 @@ To activate it set:
 
 ```js
 Sentry.config("___DSN___", {
-  deactivateStacktraceMerging: false,
+  deactivateStacktraceMerging: false
 });
 ```
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -61,8 +61,18 @@ export const NATIVE = {
       );
     }
 
+    // filter out all the options that would crash native.
+    const {
+      beforeSend,
+      beforeBreadcrumb,
+      integrations,
+      defaultIntegrations,
+      transport,
+      ...filteredOptions
+    } = options;
+
     // tslint:disable-next-line: no-unsafe-any
-    return RNSentry.startWithOptions(options);
+    return RNSentry.startWithOptions(filteredOptions);
   },
 
   /**


### PR DESCRIPTION
Fixes #882
Fixes #883

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Filters out `beforeSend`, `beforeBreadcrumb`, `integrations`, `defaultIntegrations`, and `transport` before sending the options object to native.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some options weren't filtered out which were functions such as `beforeBreadcrumb` which would crash apps on startup.

## :green_heart: How did you test it?
All tests passing, tested on Android and iOS simulators.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
