### PR TITLE
Add event tags so users can easily determine and filter where events originate from.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Expose session timeout. #887
+- Added `event.origin` and `event.environment` tags to determine where events originate from. #890
 
 ## 1.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ New way to import and init the SDK:
 import * as Sentry from "@sentry/react-native";
 
 Sentry.init({
-  dsn: "DSN",
+  dsn: "DSN"
 });
 ```
 
@@ -370,7 +370,7 @@ To activate it set:
 
 ```js
 Sentry.config("___DSN___", {
-  deactivateStacktraceMerging: false,
+  deactivateStacktraceMerging: false
 });
 ```
 

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'Sentry', '~> 5.1.0'
+  s.dependency 'Sentry', '~> 5.1.1'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -28,9 +28,11 @@ import java.util.logging.Logger;
 import io.sentry.android.core.AnrIntegration;
 import io.sentry.android.core.NdkIntegration;
 import io.sentry.android.core.SentryAndroid;
+import io.sentry.core.Sentry;
 import io.sentry.core.Integration;
 import io.sentry.core.SentryOptions;
 import io.sentry.core.UncaughtExceptionHandlerIntegration;
+import io.sentry.core.protocol.SdkVersion;
 import io.sentry.core.protocol.SentryException;
 
 @ReactModule(name = RNSentryModule.NAME)
@@ -108,6 +110,29 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                 } catch (Exception e) {
                     // We do nothing
                 }
+
+                // Add on the correct event.origin tag.
+                // it needs to be here so we can determine where it originated from.
+                SdkVersion sdkVersion = event.getSdk();
+                if (sdkVersion != null) {
+                    String sdkName = sdkVersion.getName();
+                    if (sdkName != null) {
+                        switch (sdkName) {
+                            case "sentry.javascript.react-native":
+                                event.setTag("event.origin", "javascript");
+                                break;
+                            case "sentry.native":
+                                event.setTag("event.origin", "ndk");
+                                break;
+                            case "sentry.java.android":
+                                event.setTag("event.origin", "android");
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+
                 return event;
             });
 

--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -117,18 +117,16 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                 if (sdkVersion != null) {
                     String sdkName = sdkVersion.getName();
                     if (sdkName != null) {
-                        switch (sdkName) {
-                            case "sentry.javascript.react-native":
-                                event.setTag("event.origin", "javascript");
-                                break;
-                            case "sentry.native":
-                                event.setTag("event.origin", "ndk");
-                                break;
-                            case "sentry.java.android":
-                                event.setTag("event.origin", "android");
-                                break;
-                            default:
-                                break;
+                        if (sdkName.equals("sentry.javascript.react-native")) {
+                            event.setTag("event.origin", "javascript");
+                        } else if (sdkName.equals("sentry.java.android") || sdkName.equals("sentry.native")) {
+                            event.setTag("event.origin", "android");
+
+                            if (sdkName.equals("sentry.native")) {
+                                event.setTag("event.environment", "native");
+                            } else {
+                                event.setTag("event.environment", "java");
+                            }
                         }
                     }
                 }

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -46,6 +46,14 @@ RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *_Nonnull)options
             return nil;
         }
 
+        // set the event.origin tag to be ios if the event originated from the sentry-cocoa sdk.
+        if (event.sdk && [event.sdk[@"name"] isEqualToString:@"sentry.cocoa"]) {
+            NSMutableDictionary *newTags = [NSMutableDictionary new];
+            [newTags addEntriesFromDictionary:event.tags];
+            [newTags setValue:@"ios" forKey:@"event.origin"];
+            event.tags = newTags;
+        }
+
         return event;
     };
 

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -292,12 +292,12 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - RNSentry (1.3.9):
+  - RNSentry (1.4.1):
     - React
-    - Sentry (~> 5.1.0)
-  - Sentry (5.1.0):
-    - Sentry/Core (= 5.1.0)
-  - Sentry/Core (5.1.0)
+    - Sentry (~> 5.1.1)
+  - Sentry (5.1.1):
+    - Sentry/Core (= 5.1.1)
+  - Sentry/Core (5.1.1)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -458,11 +458,11 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNSentry: 20f609597e89e7a47a553e1e8a82abc0207a6bd9
-  Sentry: 01008d590825eb1c02a796cbdced2cd3625f61e4
+  RNSentry: 451cb0e69830a682d8ca33ead8e9953688a9eff8
+  Sentry: a8e37dc33aedb8a53540e36607fc2eaef7c31b4f
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 37ff82402d037e0662e07ec778dac86a7460fd84
+PODFILE CHECKSUM: 7d26d6f146f06216129da20c128ed24b666d4bb5
 
 COCOAPODS: 1.9.2

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -90,6 +90,9 @@ export function init(
   //   });
   // }
 
+  // set the event.origin tag.
+  getCurrentHub().setTag("event.origin", "javascript");
+
   // tslint:disable-next-line: no-unsafe-any
   if (getGlobalObject<any>().HermesInternal) {
     getCurrentHub().setTag("hermes", "true");


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Added a new tag `event.origin` to events with values
- `javascript`
- `ios`
- `android`

Along with an `event.environment` tag for native android events with values:
- `java`
- `native`

These tags are attached onto the event in the `beforeSend` function in both iOS and Android and determined using the SDK name. On javascript, the event is added to the scope on init.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change allows users to easily determine, search, and filter where the event originated in react native apps with native code running alongside javascript.

We use the simplified tag values above instead of the SDK names such as `sentry.java.android` or `sentry.javascript.react-native` as the goal is to make it easy to search and filter for the end-user.

## :green_heart: How did you test it?
Tested using the sample app by testing all the options, and confirmed that the tags log correctly on the Sentry Test Dashboard. All existing tests are passing.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
