### PR TITLE
fix: We only store the event in release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.4.4
 
-- Bump cocoa 5.1.3
+- Bump cocoa 5.1.4
 - fix(ios): We only store the event in release mode #917
 
 ## 1.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 1.4.4
+
+- Bump cocoa 5.1.3
+- fix(ios): We only store the event in release mode #917
+
 ## 1.4.3
 
 - Extend Scope methods to set native scope too. #902

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'SentrySDK', '~> 5.1.3'
+  s.dependency 'SentrySDK', '~> 5.1.4'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'SentrySDK', '~> 5.1.4'
+  s.dependency 'Sentry', '~> 5.1.4'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -130,7 +130,9 @@ RCT_EXPORT_METHOD(sendEvent:(NSDictionary * _Nonnull)event
 #else
         // We check this against the dictionary
         if ([event[@"level"] isEqualToString:@"fatal"]) {
-            // In release for fatal crashes the only thing we do is store the event to send it after restart
+            // captureEvent queues the event for submission, so storing to disk happens asynchronously
+            // We need to make sure the event is written to disk before resolving the promise.
+            // This could be replaced by SentrySDK.flush() when available.
             [[[[SentrySDK currentHub] getClient] fileManager] storeEvent:sentryEvent];
         } else {
             [SentrySDK captureEvent:sentryEvent];

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -292,12 +292,12 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - RNSentry (1.4.2):
+  - RNSentry (1.4.3):
     - React
-    - Sentry (~> 5.1.3)
-  - Sentry (5.1.3):
-    - Sentry/Core (= 5.1.3)
-  - Sentry/Core (5.1.3)
+    - Sentry (~> 5.1.4)
+  - Sentry (5.1.4):
+    - Sentry/Core (= 5.1.4)
+  - Sentry/Core (5.1.4)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -458,8 +458,8 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNSentry: fc9db7b0c9c380e2f4aaf6d9bc8d3c8ce35f8471
-  Sentry: 2bf356fe999e4fb1a727f87ef54fec11db628ffc
+  RNSentry: 915bd0630246a63b375d60bd367aabba4ec2eb86
+  Sentry: 74f2ad93a20a5567a1badaedf5b3f60b142ad082
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
We only want to store "fatal" events in Release mode to make sure we use fewer resources. We can't rely on always sending it. That means after a restart we will pick up the event and send it.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Potential fix for https://github.com/getsentry/sentry-react-native/issues/911 in combination with https://github.com/getsentry/sentry-cocoa/pull/571
## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
