### PR TITLE
fix: Fix Native Wrapper not checking enableNative setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Fix Native Wrapper not checking enableNative setting #919
+
 ## 1.4.4
 
 - Bump cocoa 5.1.4

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -51,12 +51,8 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
     // This is a workaround for now using fetch on RN, this is a known issue in react-native and only generates a warning
     YellowBox.ignoreWarnings(["Require cycle:"]);
 
-    if (this._options.enableNative) {
-      // tslint:disable-next-line: no-floating-promises
-      this._startWithOptions();
-    } else {
-      NATIVE.disableNative();
-    }
+    // tslint:disable-next-line: no-floating-promises
+    this._startWithOptions();
   }
 
   /**

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -55,7 +55,7 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
       // tslint:disable-next-line: no-floating-promises
       this._startWithOptions();
     } else {
-      this._showCannotConnectDialog();
+      NATIVE.disableNative();
     }
   }
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -16,7 +16,7 @@ export const NATIVE = {
    */
   async sendEvent(event: Event): Promise<Response> {
     if (!this.enableNative) {
-      return Promise.reject("Native Disabled");
+      throw this._DisabledNativeError;
     }
     if (!this.isNativeClientAvailable()) {
       throw this._NativeClientError;
@@ -90,28 +90,28 @@ export const NATIVE = {
     id: string;
     version: string;
   }> {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.fetchRelease();
+    if (!this.enableNative) {
+      throw this._DisabledNativeError;
     }
-    return Promise.reject();
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+    // tslint:disable-next-line: no-unsafe-any
+    return RNSentry.fetchRelease();
   },
 
   /**
    * Fetches the device contexts. Not used on Android.
    */
   async deviceContexts(): Promise<object> {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.deviceContexts();
+    if (!this.enableNative) {
+      throw this._DisabledNativeError;
     }
-    return Promise.reject("Native Disabled");
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+    // tslint:disable-next-line: no-unsafe-any
+    return RNSentry.deviceContexts();
   },
 
   /**
@@ -119,13 +119,15 @@ export const NATIVE = {
    * @param level number
    */
   setLogLevel(level: number): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.setLogLevel(level);
+    if (!this.enableNative) {
+      return;
     }
+
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.setLogLevel(level);
   },
 
   /**
@@ -133,13 +135,14 @@ export const NATIVE = {
    * Use this only for testing purposes.
    */
   crash(): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.crash();
+    if (!this.enableNative) {
+      return;
     }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.crash();
   },
 
   /**
@@ -149,28 +152,29 @@ export const NATIVE = {
    * @param value string
    */
   setUser(user: User | null): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-
-      // separate and serialze all non-default user keys.
-      let defaultUserKeys = null;
-      let otherUserKeys = null;
-      if (user) {
-        const { id, ip_address, email, username, ...otherKeys } = user;
-        defaultUserKeys = {
-          email,
-          id,
-          ip_address,
-          username,
-        };
-        otherUserKeys = this._serializeObject(otherKeys);
-      }
-
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.setUser(defaultUserKeys, otherUserKeys);
+    if (!this.enableNative) {
+      return;
     }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+
+    // separate and serialze all non-default user keys.
+    let defaultUserKeys = null;
+    let otherUserKeys = null;
+    if (user) {
+      const { id, ip_address, email, username, ...otherKeys } = user;
+      defaultUserKeys = {
+        email,
+        id,
+        ip_address,
+        username,
+      };
+      otherUserKeys = this._serializeObject(otherKeys);
+    }
+
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.setUser(defaultUserKeys, otherUserKeys);
   },
 
   /**
@@ -179,18 +183,19 @@ export const NATIVE = {
    * @param value string
    */
   setTag(key: string, value: string): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-
-      const stringifiedValue =
-        // tslint:disable-next-line: strict-type-predicates
-        typeof value === "string" ? value : JSON.stringify(value);
-
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.setTag(key, stringifiedValue);
+    if (!this.enableNative) {
+      return;
     }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+
+    const stringifiedValue =
+      // tslint:disable-next-line: strict-type-predicates
+      typeof value === "string" ? value : JSON.stringify(value);
+
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.setTag(key, stringifiedValue);
   },
 
   /**
@@ -200,18 +205,19 @@ export const NATIVE = {
    * @param extra any
    */
   setExtra(key: string, extra: any): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-
-      // we stringify the extra as native only takes in strings.
-      const stringifiedExtra =
-        typeof extra === "string" ? extra : JSON.stringify(extra);
-
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.setExtra(key, stringifiedExtra);
+    if (!this.enableNative) {
+      return;
     }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+
+    // we stringify the extra as native only takes in strings.
+    const stringifiedExtra =
+      typeof extra === "string" ? extra : JSON.stringify(extra);
+
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.setExtra(key, stringifiedExtra);
   },
 
   /**
@@ -219,33 +225,35 @@ export const NATIVE = {
    * @param breadcrumb Breadcrumb
    */
   addBreadcrumb(breadcrumb: Breadcrumb): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.addBreadcrumb({
-        ...breadcrumb,
-        data: breadcrumb.data
-          ? this._serializeObject(breadcrumb.data)
-          : undefined,
-      });
+    if (!this.enableNative) {
+      return;
     }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.addBreadcrumb({
+      ...breadcrumb,
+      data: breadcrumb.data
+        ? this._serializeObject(breadcrumb.data)
+        : undefined,
+    });
   },
 
   /**
    * Clears breadcrumsb on the native scope.
    */
   clearBreadcrumbs(): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
-
-      // tslint:disable-next-line: no-unsafe-any
-      return RNSentry.clearBreadcrumbs();
+    if (!this.enableNative) {
+      return;
     }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
+
+    // tslint:disable-next-line: no-unsafe-any
+    RNSentry.clearBreadcrumbs();
   },
 
   /**
@@ -254,21 +262,22 @@ export const NATIVE = {
    * @param context key-value map
    */
   setContext(key: string, context: { [key: string]: any } | null): void {
-    if (this.enableNative) {
-      if (!this.isNativeClientAvailable()) {
-        throw this._NativeClientError;
-      }
+    if (!this.enableNative) {
+      return;
+    }
+    if (!this.isNativeClientAvailable()) {
+      throw this._NativeClientError;
+    }
 
-      if (this.platform === "android") {
-        // setContext not available on the Android SDK yet.
-        this.setExtra(key, context);
-      } else {
-        // tslint:disable-next-line: no-unsafe-any
-        RNSentry.setContext(
-          key,
-          context !== null ? this._serializeObject(context) : null
-        );
-      }
+    if (this.platform === "android") {
+      // setContext not available on the Android SDK yet.
+      this.setExtra(key, context);
+    } else {
+      // tslint:disable-next-line: no-unsafe-any
+      RNSentry.setContext(
+        key,
+        context !== null ? this._serializeObject(context) : null
+      );
     }
   },
 
@@ -318,6 +327,8 @@ export const NATIVE = {
     // tslint:disable-next-line: no-unsafe-any
     return this.isModuleLoaded() && RNSentry.nativeTransport;
   },
+
+  _DisabledNativeError: new SentryError("Native is disabled"),
 
   _NativeClientError: new SentryError(
     "Native Client is not available, can't start on native."

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -118,7 +118,7 @@ describe("Tests Native Wrapper", () => {
         await NATIVE.sendEvent({});
       } catch (e) {
         // tslint:disable-next-line: no-unsafe-any
-        expect(e).toMatch("Native Disabled");
+        expect(e.message).toMatch("Native is disabled");
       }
       /* tslint:disable: no-unsafe-any */
       expect(RN.NativeModules.RNSentry.sendEvent).not.toBeCalled();

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -39,7 +39,7 @@ describe("Tests Native Wrapper", () => {
     test("calls native module", async () => {
       const RN = require("react-native");
 
-      await NATIVE.startWithOptions({ dsn: "test" });
+      await NATIVE.startWithOptions({ dsn: "test", enableNative: true });
 
       expect(RN.NativeModules.RNSentry.startWithOptions).toBeCalled();
     });
@@ -48,7 +48,7 @@ describe("Tests Native Wrapper", () => {
       const RN = require("react-native");
       console.warn = jest.fn();
 
-      await NATIVE.startWithOptions({});
+      await NATIVE.startWithOptions({ enableNative: true });
 
       expect(RN.NativeModules.RNSentry.startWithOptions).toBeCalled();
       expect(console.warn).toBeCalled();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fix the native wrapper not checking for `enableNative` option in the init options. Also does not display the warning to use `enableNative: false` if it is already set to false.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses https://github.com/expo/sentry-expo/issues/112#issuecomment-639845260
Also #920

## :green_heart: How did you test it?
Ran on both iOS and Android simulators that no warnings/errors appear when setting scope, or any of the functions in the sample app with either `enableNative:false` and `enableNative:true`. All events show up on sentry.io other than the native crash which is disabled.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
