### PR TITLE
fix: Serialize the default user keys in setUser

### DIFF
--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -166,12 +166,12 @@ export const NATIVE = {
     let otherUserKeys = null;
     if (user) {
       const { id, ip_address, email, username, ...otherKeys } = user;
-      defaultUserKeys = {
+      defaultUserKeys = this._serializeObject({
         email,
         id,
         ip_address,
         username,
-      };
+      });
       otherUserKeys = this._serializeObject(otherKeys);
     }
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -21,6 +21,9 @@ jest.mock(
         nativeClientAvailable: true,
         nativeTransport: true,
         sendEvent: jest.fn(() => Promise.resolve()),
+        setUser: jest.fn(() => {
+          return;
+        }),
         startWithOptions: jest.fn((options) => Promise.resolve(options))
       }
     },
@@ -174,6 +177,29 @@ describe("Tests Native Wrapper", () => {
       NATIVE.crash();
       // tslint:disable-next-line: no-unsafe-any
       expect(RN.NativeModules.RNSentry.crash).not.toBeCalled();
+    });
+  });
+
+  describe("setUser", () => {
+    test("serializes all user object keys", async () => {
+      const RN = require("react-native");
+
+      NATIVE.setUser({
+        email: "hello@sentry.io",
+        // @ts-ignore
+        id: 3.14159265359,
+        unique: 123,
+      });
+      // tslint:disable-next-line: no-unsafe-any
+      expect(RN.NativeModules.RNSentry.setUser).toBeCalledWith(
+        {
+          email: "hello@sentry.io",
+          id: "3.14159265359",
+        },
+        {
+          unique: "123",
+        }
+      );
     });
   });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Passes the default user keys to the serialization helper before passing it to native.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users would be able to use non-strings such as ints or _doubles_ as user ids or in any other default user field.
Fixes #922

## :green_heart: How did you test it?
Tested by passing `3.14159265359` as a user id on both Android and iOS, performed native crashes and assured that the user is correct on the Sentry dashboard.

Also added a test that `setUser` serializes all object keys and splits into a second data object.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
