### PR TITLE
feat: Track touch events as breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Track interaction events as breadcrumbs #939
 - fix: Serialize the default user keys in setUser #926
 
 ## 1.4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: Track interaction events as breadcrumbs #939
+- feat: Track touch events as breadcrumbs #939
 - fix: Serialize the default user keys in setUser #926
 
 ## 1.4.5

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   "author": "Sentry",
   "license": "MIT",
   "peerDependencies": {
+    // Version to be compatible with RN
     "react": ">=16.4.1",
+    // When bumping, make sure to update the version above, i.e:  https://github.com/facebook/react-native/blob/v0.56.0/package.json
     "react-native": ">=0.56.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "Sentry",
   "license": "MIT",
   "peerDependencies": {
+    "react": ">=16.4.1",
     "react-native": ">=0.56.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
   },
   "author": "Sentry",
   "license": "MIT",
+  "//": [
+    "React version to be compatible with RN",
+    "When bumping make sure to update the version of react, i.e:  https://github.com/facebook/react-native/blob/v0.56.0/package.json"
+  ],
   "peerDependencies": {
-    // Version to be compatible with RN
     "react": ">=16.4.1",
-    // When bumping, make sure to update the version above, i.e:  https://github.com/facebook/react-native/blob/v0.56.0/package.json
     "react-native": ">=0.56.0"
   },
   "dependencies": {

--- a/sample/App.js
+++ b/sample/App.js
@@ -139,6 +139,7 @@ const App: () => React$Node = () => {
       <StatusBar barStyle="dark-content" />
       <SafeAreaView>
         <ScrollView
+          accessibilityLabel="ScrollView"
           contentInsetAdjustmentBehavior="automatic"
           style={styles.scrollView}>
           <Header />
@@ -151,6 +152,7 @@ const App: () => React$Node = () => {
             <View style={styles.sectionContainer}>
               <Text
                 style={styles.sectionTitle}
+                sentryID="captureMessage"
                 onPress={() => {
                   Sentry.captureMessage('React Native Test Message');
                 }}>
@@ -158,6 +160,7 @@ const App: () => React$Node = () => {
               </Text>
               <Text
                 style={styles.sectionTitle}
+                sentryID="captureException"
                 onPress={() => {
                   Sentry.captureException(new Error('captureException test'));
                 }}>
@@ -165,6 +168,7 @@ const App: () => React$Node = () => {
               </Text>
               <Text
                 style={styles.sectionTitle}
+                sentryID="throwNewError"
                 onPress={() => {
                   throw new Error('throw new error test');
                 }}>
@@ -172,15 +176,22 @@ const App: () => React$Node = () => {
               </Text>
               <Text
                 style={styles.sectionTitle}
+                sentryID="nativeCrash"
                 onPress={() => {
                   Sentry.nativeCrash();
                 }}>
                 nativeCrash
               </Text>
-              <Text style={styles.sectionTitle} onPress={setScopeProps}>
+              <Text
+                sentryID="setScopeProperties"
+                style={styles.sectionTitle}
+                onPress={setScopeProps}>
                 Set Scope Properties
               </Text>
-              <Text style={styles.sectionTitle} onPress={clearBreadcrumbs}>
+              <Text
+                sentryID="clearBreadcrumbs"
+                style={styles.sectionTitle}
+                onPress={clearBreadcrumbs}>
                 Clear Breadcrumbs
               </Text>
               <Text style={styles.sectionTitle}>Step One</Text>
@@ -254,4 +265,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default App;
+export default Sentry.withInteractionEventBoundary(App);

--- a/sample/App.js
+++ b/sample/App.js
@@ -14,6 +14,7 @@ import {
   View,
   Text,
   StatusBar,
+  TouchableOpacity,
 } from 'react-native';
 
 import {
@@ -46,6 +47,17 @@ Sentry.init({
   // For testing, session close when 5 seconds (instead of the default 30) in the background.
   sessionTrackingIntervalMillis: 5000,
 });
+
+const SetScopePropertiesButton = (props) => {
+  return (
+    <TouchableOpacity onPress={props.setScopeProps}>
+      <Text style={styles.sectionTitle}>Set Scope Properties</Text>
+    </TouchableOpacity>
+  );
+};
+
+SetScopePropertiesButton.displayName = 'SetScopeProperties';
+
 const App: () => React$Node = () => {
   const setScopeProps = React.useCallback(() => {
     const dateString = new Date().toString();
@@ -152,7 +164,6 @@ const App: () => React$Node = () => {
             <View style={styles.sectionContainer}>
               <Text
                 style={styles.sectionTitle}
-                sentryID="captureMessage"
                 onPress={() => {
                   Sentry.captureMessage('React Native Test Message');
                 }}>
@@ -160,7 +171,6 @@ const App: () => React$Node = () => {
               </Text>
               <Text
                 style={styles.sectionTitle}
-                sentryID="captureException"
                 onPress={() => {
                   Sentry.captureException(new Error('captureException test'));
                 }}>
@@ -168,7 +178,6 @@ const App: () => React$Node = () => {
               </Text>
               <Text
                 style={styles.sectionTitle}
-                sentryID="throwNewError"
                 onPress={() => {
                   throw new Error('throw new error test');
                 }}>
@@ -176,22 +185,13 @@ const App: () => React$Node = () => {
               </Text>
               <Text
                 style={styles.sectionTitle}
-                sentryID="nativeCrash"
                 onPress={() => {
                   Sentry.nativeCrash();
                 }}>
                 nativeCrash
               </Text>
-              <Text
-                sentryID="setScopeProperties"
-                style={styles.sectionTitle}
-                onPress={setScopeProps}>
-                Set Scope Properties
-              </Text>
-              <Text
-                sentryID="clearBreadcrumbs"
-                style={styles.sectionTitle}
-                onPress={clearBreadcrumbs}>
+              <SetScopePropertiesButton setScopeProps={setScopeProps} />
+              <Text onPress={clearBreadcrumbs} style={styles.sectionTitle}>
                 Clear Breadcrumbs
               </Text>
               <Text style={styles.sectionTitle}>Step One</Text>

--- a/sample/App.js
+++ b/sample/App.js
@@ -265,4 +265,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default Sentry.withInteractionEventBoundary(App);
+export default Sentry.withTouchEventBoundary(App);

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -38,7 +38,7 @@ export { ReactNativeBackend, ReactNativeOptions } from "./backend";
 export { ReactNativeClient } from "./client";
 export { init, setDist, setRelease, nativeCrash } from "./sdk";
 export { SDK_NAME, SDK_VERSION } from "./version";
-export { TouchEventBoundary, withTouchEventBoundary } from "./touchEvents";
+export { TouchEventBoundary, withTouchEventBoundary } from "./touchevents";
 
 import * as Integrations from "./integrations";
 export { Integrations };

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -38,6 +38,10 @@ export { ReactNativeBackend, ReactNativeOptions } from "./backend";
 export { ReactNativeClient } from "./client";
 export { init, setDist, setRelease, nativeCrash } from "./sdk";
 export { SDK_NAME, SDK_VERSION } from "./version";
+export {
+  InteractionEventBoundary,
+  withInteractionEventBoundary
+} from "./interactionevents";
 
 import * as Integrations from "./integrations";
 export { Integrations };

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -10,7 +10,7 @@ export {
   Stacktrace,
   Status,
   Thread,
-  User
+  User,
 } from "@sentry/types";
 
 export {
@@ -30,7 +30,7 @@ export {
   setTag,
   setTags,
   setUser,
-  withScope
+  withScope,
 } from "@sentry/core";
 
 import { Integrations as BrowserIntegrations } from "@sentry/browser";
@@ -38,10 +38,7 @@ export { ReactNativeBackend, ReactNativeOptions } from "./backend";
 export { ReactNativeClient } from "./client";
 export { init, setDist, setRelease, nativeCrash } from "./sdk";
 export { SDK_NAME, SDK_VERSION } from "./version";
-export {
-  InteractionEventBoundary,
-  withInteractionEventBoundary
-} from "./interactionevents";
+export { TouchEventBoundary, withTouchEventBoundary } from "./touchEvents";
 
 import * as Integrations from "./integrations";
 export { Integrations };

--- a/src/js/interactionevents.tsx
+++ b/src/js/interactionevents.tsx
@@ -1,18 +1,29 @@
 import { addBreadcrumb } from "@sentry/core";
-import { Breadcrumb, Severity } from "@sentry/types";
+import { Severity } from "@sentry/types";
 import * as React from "react";
 import { StyleSheet, View } from "react-native";
 
 // tslint:disable-next-line: interface-over-type-literal
 export type InteractionEventBoundaryProps = {
+  /**
+   * The category assigned to the breadcrumb that is logged by the touch event.
+   */
   breadcrumbCategory?: string;
+  /**
+   * The type assigned to the breadcrumb that is logged by the touch event.
+   */
   breadcrumbType?: string;
-};
-
-// tslint:disable-next-line: interface-over-type-literal
-type InteractionEventBoundaryDefaultProps = {
-  breadcrumbCategory: string;
-  breadcrumbType: string;
+  /**
+   * The max number of components to display when logging a touch's component tree.
+   */
+  maxComponentTreeSize?: number;
+  /**
+   * Component displayName(s) to ignore when logging the touch event. This prevents unhelpful logs such as
+   * "Touch event within element: View" where you still can't tell which View it occurred in.
+   *
+   * By default, only View and Text are ignored. If you pass this prop, don't forget to include them.
+   */
+  ignoredDisplayNames?: string[];
 };
 
 const interactionEventStyles = StyleSheet.create({
@@ -23,8 +34,8 @@ const interactionEventStyles = StyleSheet.create({
 
 const DEFAULT_BREADCRUMB_CATEGORY = "touch";
 const DEFAULT_BREADCRUMB_TYPE = "user";
-
-const DEFAULT_ELEMENT_DISPLAY_NAMES = ["View", "Text"];
+const DEFAULT_MAX_COMPONENT_TREE_SIZE = 20;
+const DEFAULT_IGNORED_DISPLAY_NAMES = ["View", "Text"];
 
 /**
  * Boundary to log breadcrumbs for interaction events.
@@ -32,47 +43,84 @@ const DEFAULT_ELEMENT_DISPLAY_NAMES = ["View", "Text"];
 class InteractionEventBoundary extends React.Component<
   InteractionEventBoundaryProps
 > {
-  public static defaultProps: InteractionEventBoundaryDefaultProps = {
+  public static displayName: string = "InteractionEventBoundary";
+  public static defaultProps: Partial<InteractionEventBoundaryProps> = {
     breadcrumbCategory: DEFAULT_BREADCRUMB_CATEGORY,
     breadcrumbType: DEFAULT_BREADCRUMB_TYPE,
+    ignoredDisplayNames: DEFAULT_IGNORED_DISPLAY_NAMES,
+    maxComponentTreeSize: DEFAULT_MAX_COMPONENT_TREE_SIZE,
   };
 
-  private readonly _logInteraction = (displayName: string): void => {
-    const breadcrumb: Breadcrumb = {
+  private readonly _logInteractionInElement = (displayName: string): void => {
+    addBreadcrumb({
       category: this.props.breadcrumbCategory,
-      type: this.props.breadcrumbType,
       level: Severity.Info,
       message: `Touch event within element: ${displayName}`,
-    };
+      type: this.props.breadcrumbType,
+    });
+  };
 
-    addBreadcrumb(breadcrumb);
+  private readonly _logInteractionInTree = (
+    componentTreeNames: string[]
+  ): void => {
+    addBreadcrumb({
+      category: this.props.breadcrumbCategory,
+      data: { componentTree: componentTreeNames },
+      level: Severity.Info,
+      message: `Touch event within component tree`,
+      type: this.props.breadcrumbType,
+    });
   };
 
   private readonly _onTouchStart = (e: any): void => {
     /* tslint:disable: no-unsafe-any */
     if (e._targetInst) {
       let currentInst = e._targetInst;
-      let name = null;
 
-      /* While there is an instance, and props do not contain the elementIdKey, we keep moving up the instance
-        tree to its parent until we find one with the prop key defined. We also fallback to accessibilityLabel. */
-      while (currentInst) {
-        if (
-          currentInst.elementType &&
-          typeof currentInst.elementType.displayName === "string" &&
-          !DEFAULT_ELEMENT_DISPLAY_NAMES.includes(
-            currentInst.elementType.displayName
-          )
-        ) {
-          name = currentInst.elementType.displayName;
-          break;
+      let displayName = null;
+      const componentTreeNames = [];
+
+      while (
+        currentInst &&
+        // maxComponentTreeSize will always be defined as we have a defaultProps. But ts needs a check so this is here.
+        this.props.maxComponentTreeSize &&
+        componentTreeNames.length < this.props.maxComponentTreeSize
+      ) {
+        if (currentInst.elementType) {
+          if (
+            // If the loop gets to the boundary itself, break.
+            currentInst.elementType.displayName ===
+            InteractionEventBoundary.displayName
+          ) {
+            break;
+          }
+
+          if (
+            typeof currentInst.elementType.displayName === "string" &&
+            // ignore some displayNames for ux
+            this.props.ignoredDisplayNames &&
+            !this.props.ignoredDisplayNames.includes(
+              currentInst.elementType.displayName
+            )
+          ) {
+            /* Break when a displayName is detected, we don't need to log the whole tree now. */
+            displayName = currentInst.elementType.displayName;
+            break;
+          }
+
+          if (typeof currentInst.elementType.name === "string") {
+            /* If this doesn't have a displayName, we log the name and keep going. */
+            componentTreeNames.push(currentInst.elementType.name);
+          }
         }
 
         currentInst = currentInst.return;
       }
 
-      if (name !== null) {
-        this._logInteraction(name);
+      if (displayName !== null) {
+        this._logInteractionInElement(displayName);
+      } else if (componentTreeNames.length > 0) {
+        this._logInteractionInTree(componentTreeNames);
       }
     }
     /* tslint:enable: no-unsafe-any */

--- a/src/js/interactionevents.tsx
+++ b/src/js/interactionevents.tsx
@@ -1,0 +1,125 @@
+import { addBreadcrumb } from "@sentry/core";
+import { Breadcrumb, Severity } from "@sentry/types";
+import * as React from "react";
+import { StyleSheet, View } from "react-native";
+
+// tslint:disable-next-line: interface-over-type-literal
+export type InteractionEventBoundaryProps = {
+  breadcrumbCategory?: string;
+  elementIdKey?: string;
+};
+
+// tslint:disable-next-line: interface-over-type-literal
+type InteractionEventBoundaryDefaultProps = {
+  breadcrumbCategory: string;
+  elementIdKey: string;
+};
+
+const interactionEventStyles = StyleSheet.create({
+  wrapperView: {
+    flex: 1,
+  },
+});
+
+const DEFAULT_BREADCRUMB_CATEGORY = "interaction";
+const DEFAULT_ELEMENT_ID_KEY = "sentryID";
+
+/**
+ * Boundary to log breadcrumbs for interaction events.
+ */
+class InteractionEventBoundary extends React.Component<
+  InteractionEventBoundaryProps
+> {
+  public static defaultProps: InteractionEventBoundaryDefaultProps = {
+    breadcrumbCategory: DEFAULT_BREADCRUMB_CATEGORY,
+    elementIdKey: DEFAULT_ELEMENT_ID_KEY,
+  };
+
+  private readonly _logInteraction = (
+    elementId: string,
+    source: "elementIdKey" | "accessibilityLabel"
+  ): void => {
+    const breadcrumb: Breadcrumb = {
+      category: this.props.breadcrumbCategory,
+      level: Severity.Info,
+      message:
+        source === "elementIdKey"
+          ? `Touch event within element: ${elementId}`
+          : `Touch event within element with accessibilityLabel: ${elementId}`,
+    };
+
+    addBreadcrumb(breadcrumb);
+  };
+
+  private readonly _onTouchStart = (e: any): void => {
+    /* tslint:disable: no-unsafe-any */
+    if (e._targetInst && this.props.elementIdKey) {
+      let currentInst = e._targetInst;
+
+      /* While there is an instance, and props do not contain the elementIdKey, we keep moving up the instance
+        tree to its parent until we find one with the prop key defined. We also fallback to accessibilityLabel. */
+      while (currentInst) {
+        if (
+          currentInst.memoizedProps &&
+          (typeof currentInst.memoizedProps[this.props.elementIdKey] !==
+            "undefined" ||
+            typeof currentInst.memoizedProps.accessibilityLabel !== "undefined")
+        ) {
+          break;
+        }
+
+        currentInst = currentInst.return;
+      }
+
+      if (currentInst && currentInst.memoizedProps) {
+        if (
+          typeof currentInst.memoizedProps[this.props.elementIdKey] !==
+          "undefined"
+        ) {
+          this._logInteraction(
+            currentInst.memoizedProps[this.props.elementIdKey],
+            "elementIdKey"
+          );
+        } else if (
+          typeof currentInst.memoizedProps.accessibilityLabel !== "undefined"
+        ) {
+          this._logInteraction(
+            currentInst.memoizedProps.accessibilityLabel,
+            "accessibilityLabel"
+          );
+        }
+      }
+    }
+    /* tslint:enable: no-unsafe-any */
+  };
+
+  // tslint:disable-next-line: completed-docs
+  public render(): React.ReactNode {
+    return (
+      <View
+        style={interactionEventStyles.wrapperView}
+        onTouchStart={this._onTouchStart}
+      >
+        {this.props.children}
+      </View>
+    );
+  }
+}
+
+/**
+ * Convenience Higher-Order-Component for InteractionEventBoundary
+ * @param WrappedComponent any React Component
+ * @param boundaryProps InteractionEventBoundaryProps
+ */
+const withInteractionEventBoundary = (
+  // tslint:disable-next-line: variable-name
+  WrappedComponent: React.ComponentType<any>,
+  boundaryProps: InteractionEventBoundaryProps
+) => (props: any) => (
+  <InteractionEventBoundary {...boundaryProps}>
+    {/* tslint:disable-next-line: no-unsafe-any */}
+    <WrappedComponent {...props} />
+  </InteractionEventBoundary>
+);
+
+export { InteractionEventBoundary, withInteractionEventBoundary };

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { StyleSheet, View } from "react-native";
 
 // tslint:disable-next-line: interface-over-type-literal
-export type InteractionEventBoundaryProps = {
+export type TouchEventBoundaryProps = {
   /**
    * The category assigned to the breadcrumb that is logged by the touch event.
    */
@@ -26,7 +26,7 @@ export type InteractionEventBoundaryProps = {
   ignoredDisplayNames?: string[];
 };
 
-const interactionEventStyles = StyleSheet.create({
+const touchEventStyles = StyleSheet.create({
   wrapperView: {
     flex: 1,
   },
@@ -40,18 +40,16 @@ const DEFAULT_IGNORED_DISPLAY_NAMES = ["View", "Text"];
 /**
  * Boundary to log breadcrumbs for interaction events.
  */
-class InteractionEventBoundary extends React.Component<
-  InteractionEventBoundaryProps
-> {
-  public static displayName: string = "InteractionEventBoundary";
-  public static defaultProps: Partial<InteractionEventBoundaryProps> = {
+class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
+  public static displayName: string = "TouchEventBoundary";
+  public static defaultProps: Partial<TouchEventBoundaryProps> = {
     breadcrumbCategory: DEFAULT_BREADCRUMB_CATEGORY,
     breadcrumbType: DEFAULT_BREADCRUMB_TYPE,
     ignoredDisplayNames: DEFAULT_IGNORED_DISPLAY_NAMES,
     maxComponentTreeSize: DEFAULT_MAX_COMPONENT_TREE_SIZE,
   };
 
-  private readonly _logInteractionInElement = (displayName: string): void => {
+  private readonly _logTouchInElement = (displayName: string): void => {
     addBreadcrumb({
       category: this.props.breadcrumbCategory,
       level: Severity.Info,
@@ -60,9 +58,7 @@ class InteractionEventBoundary extends React.Component<
     });
   };
 
-  private readonly _logInteractionInTree = (
-    componentTreeNames: string[]
-  ): void => {
+  private readonly _logTouchInTree = (componentTreeNames: string[]): void => {
     addBreadcrumb({
       category: this.props.breadcrumbCategory,
       data: { componentTree: componentTreeNames },
@@ -90,7 +86,7 @@ class InteractionEventBoundary extends React.Component<
           if (
             // If the loop gets to the boundary itself, break.
             currentInst.elementType.displayName ===
-            InteractionEventBoundary.displayName
+            TouchEventBoundary.displayName
           ) {
             break;
           }
@@ -118,9 +114,9 @@ class InteractionEventBoundary extends React.Component<
       }
 
       if (displayName !== null) {
-        this._logInteractionInElement(displayName);
+        this._logTouchInElement(displayName);
       } else if (componentTreeNames.length > 0) {
-        this._logInteractionInTree(componentTreeNames);
+        this._logTouchInTree(componentTreeNames);
       }
     }
     /* tslint:enable: no-unsafe-any */
@@ -130,7 +126,7 @@ class InteractionEventBoundary extends React.Component<
   public render(): React.ReactNode {
     return (
       <View
-        style={interactionEventStyles.wrapperView}
+        style={touchEventStyles.wrapperView}
         onTouchStart={this._onTouchStart}
       >
         {this.props.children}
@@ -140,19 +136,19 @@ class InteractionEventBoundary extends React.Component<
 }
 
 /**
- * Convenience Higher-Order-Component for InteractionEventBoundary
+ * Convenience Higher-Order-Component for TouchEventBoundary
  * @param WrappedComponent any React Component
- * @param boundaryProps InteractionEventBoundaryProps
+ * @param boundaryProps TouchEventBoundaryProps
  */
-const withInteractionEventBoundary = (
+const withTouchEventBoundary = (
   // tslint:disable-next-line: variable-name
   WrappedComponent: React.ComponentType<any>,
-  boundaryProps: InteractionEventBoundaryProps
+  boundaryProps: TouchEventBoundaryProps
 ) => (props: any) => (
-  <InteractionEventBoundary {...boundaryProps}>
+  <TouchEventBoundary {...boundaryProps}>
     {/* tslint:disable-next-line: no-unsafe-any */}
     <WrappedComponent {...props} />
-  </InteractionEventBoundary>
+  </TouchEventBoundary>
 );
 
-export { InteractionEventBoundary, withInteractionEventBoundary };
+export { TouchEventBoundary, withTouchEventBoundary };

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "lib": ["es7"],
+    "jsx": "react-native",
     "types": ["react-native"],
     "target": "es6",
     "module": "es6"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "exclude": ["dist"],
   "compilerOptions": {
     "rootDir": ".",
+    "jsx": "react-native",
     "types": ["jest"]
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
By wrapping the root component (or any part of the component tree if they really need to) with the `TouchEventBoundary` it would capture any touch events performed on any component and log either the component tree or a component with a `static displayName` property set. Also exported as a Higher-Order-Component for convenience as `withTouchEventBoundary`.

Note: If you look at the code for this, it uses `e._targetInst` which is not documented at all and not mentioned officially anywhere, so this could be a potential issue if the event payload ever changes without notice.

Example:
```js
import * as Sentry from '@sentry/react-native';
...
// Application root
    render() {
        return (
            <Sentry.InteractionEventBoundary>
               <App />
            </Sentry.InteractionEventBounaary>
        )
    }
...
// Some child component
    static displayName = "ComponentWithName"
    render() {
        <TouchableOpacity>
             <Text>
                 Add Activity
            <Text />
        < TouchableOpacity />
    }
```

Tapping on the view in the first example will be logged to Sentry as a breadcrumb like:
<img width="726" alt="Screen Shot 2020-06-24 at 4 33 42 PM" src="https://user-images.githubusercontent.com/30991498/85531225-c6536780-b638-11ea-9d97-ae1a5e528727.png">

The user can also specify the breadcrumb category and type they want to log it as (default is `touch`, and `user`) by passing the `breadcrumbCategory` and `breadcrumbType`  props to the `TouchEventBoundary` component.

Users can also customize the `maxComponentTreeSize` and `ignoredDisplayNames` (default are `View`, and `Text`) props.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows users to easily understand what interactions led to an error.

## :green_heart: How did you test it?

Used the HOC version in the sample app, and confirmed working with all event types.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps

Will need to write documentation on this feature.