### PR TITLE
fix: Fix appending app:/// prefix to [native code]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Fix appending app:/// prefix to [native code] #946
+
 ## 1.5.0
 
 - feat: Track touch events as breadcrumbs #939

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -55,16 +55,14 @@ export function init(
               .replace(/^address at /, "")
               .replace(/^.*\/[^\.]+(\.app|CodePush|.*(?=\/))/, "");
 
-            if (frame.filename === "native") {
-              frame.in_app = false;
+            if (frame.filename !== "[native code]") {
+              const appPrefix = "app://";
+              // We always want to have a triple slash
+              frame.filename =
+                frame.filename.indexOf("/") === 0
+                  ? `${appPrefix}${frame.filename}`
+                  : `${appPrefix}/${frame.filename}`;
             }
-
-            const appPrefix = "app://";
-            // We always want to have a tripple slash
-            frame.filename =
-              frame.filename.indexOf("/") === 0
-                ? `${appPrefix}${frame.filename}`
-                : `${appPrefix}/${frame.filename}`;
           }
           return frame;
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes a bug where we append the `app:///` prefix to calls to native code `[native code]`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was causing event grouping issues which spams users with emails. (Of which brought me here)

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
