### PR TITLE
feat: Log the component tree to all touch events, not just ones without a component with displayName.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: Log component tree with all touch events. #952
+
 ## 1.5.0
 
 - feat: Track touch events as breadcrumbs #939

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -41,7 +41,7 @@ const DEFAULT_IGNORED_DISPLAY_NAMES = ["View", "Text"];
  * Boundary to log breadcrumbs for interaction events.
  */
 class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
-  public static displayName: string = "TouchEventBoundary";
+  public static displayName: string = "__Sentry.TouchEventBoundary";
   public static defaultProps: Partial<TouchEventBoundaryProps> = {
     breadcrumbCategory: DEFAULT_BREADCRUMB_CATEGORY,
     breadcrumbType: DEFAULT_BREADCRUMB_TYPE,

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -49,21 +49,17 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
     maxComponentTreeSize: DEFAULT_MAX_COMPONENT_TREE_SIZE,
   };
 
-  private readonly _logTouchInElement = (displayName: string): void => {
-    addBreadcrumb({
-      category: this.props.breadcrumbCategory,
-      level: Severity.Info,
-      message: `Touch event within element: ${displayName}`,
-      type: this.props.breadcrumbType,
-    });
-  };
-
-  private readonly _logTouchInTree = (componentTreeNames: string[]): void => {
+  private readonly _logTouchEvent = (
+    componentTreeNames: string[],
+    displayName: string | null
+  ): void => {
     addBreadcrumb({
       category: this.props.breadcrumbCategory,
       data: { componentTree: componentTreeNames },
       level: Severity.Info,
-      message: `Touch event within component tree`,
+      message: displayName
+        ? `Touch event within element: ${displayName}`
+        : `Touch event within component tree`,
       type: this.props.breadcrumbType,
     });
   };
@@ -91,21 +87,18 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
             break;
           }
 
-          if (
-            typeof currentInst.elementType.displayName === "string" &&
-            // ignore some displayNames for ux
-            this.props.ignoredDisplayNames &&
-            !this.props.ignoredDisplayNames.includes(
-              currentInst.elementType.displayName
-            )
-          ) {
-            /* Break when a displayName is detected, we don't need to log the whole tree now. */
-            displayName = currentInst.elementType.displayName;
-            break;
-          }
+          if (typeof currentInst.elementType.displayName === "string") {
+            if (
+              Array.isArray(this.props.ignoredDisplayNames) &&
+              !this.props.ignoredDisplayNames.includes(
+                currentInst.elementType.displayName
+              )
+            ) {
+              displayName = currentInst.elementType.displayName;
+            }
 
-          if (typeof currentInst.elementType.name === "string") {
-            /* If this doesn't have a displayName, we log the name and keep going. */
+            componentTreeNames.push(currentInst.elementType.displayName);
+          } else if (typeof currentInst.elementType.name === "string") {
             componentTreeNames.push(currentInst.elementType.name);
           }
         }
@@ -113,10 +106,8 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
         currentInst = currentInst.return;
       }
 
-      if (displayName !== null) {
-        this._logTouchInElement(displayName);
-      } else if (componentTreeNames.length > 0) {
-        this._logTouchInTree(componentTreeNames);
+      if (componentTreeNames.length > 0 || displayName) {
+        this._logTouchEvent(componentTreeNames, displayName);
       }
     }
     /* tslint:enable: no-unsafe-any */


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Currently we only log the whole touch component tree when we couldn't find a component with a `displayName` set. This changes it so the component tree is logged every time:
<img width="983" alt="Screen Shot 2020-07-06 at 2 59 03 PM" src="https://user-images.githubusercontent.com/30991498/86569846-3d71ef80-bf99-11ea-8ffb-0fbe3bfcc1f8.png">


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was done because we can't be sure which components have a `displayName` set. Any component from any library can have it set, looking at an example issue here: https://github.com/getsentry/sentry-react-native/issues/950 where it looks like the user is using an Svg library where they have a component with the `displayName` set to `Svg` and it doesn't log the user's component. It would be useful to just log the whole tree in the case that the touch event runs into a component with a `displayName` not set by the user.

## :green_heart: How did you test it?
Tested on sample app and verified on `sentry.io` dashboard.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
