### PR TITLE
fix: Don't prefix app:/// to "native" filename as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Don't prefix app:/// to "native" filename as well #957
+
 ## 1.6.1
 
 - Bump `sentry-cocoa` `5.1.8`

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -55,7 +55,7 @@ export function init(
               .replace(/^address at /, "")
               .replace(/^.*\/[^\.]+(\.app|CodePush|.*(?=\/))/, "");
 
-            if (frame.filename !== "[native code]") {
+            if (frame.filename !== "[native code]" && frame.filename !== "native") {
               const appPrefix = "app://";
               // We always want to have a triple slash
               frame.filename =


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds back in the check to not prefix `app:///` to stack trace frames "native".

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Found a case where a stack trace frame could be "native" instead of "[native code]" (#951) and we shouldn't be prefixing `app:///` to it

## :green_heart: How did you test it?
**Note:** I have yet to be able to reproduce a stack trace that says `native` instead of `[native code]` or have any idea where it's coming from, but we shouldn't be prefixing it anyways.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing


## :crystal_ball: Next steps
