### PR TITLE
fix: Attach sdk field to envelope header instead of sdk_info

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:2.2.0'
+    api 'io.sentry:sentry-android:2.2.2'
 }

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -25,7 +25,7 @@ export const NATIVE = {
     if (NATIVE.platform === "android") {
       const header = JSON.stringify({
         event_id: event.event_id,
-        sdk_info: event.sdk,
+        sdk: event.sdk,
       });
 
       (event as any).message = {

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -116,7 +116,7 @@ describe("Tests Native Wrapper", () => {
       });
       const header = JSON.stringify({
         event_id: event.event_id,
-        sdk_info: event.sdk,
+        sdk: event.sdk,
       });
       const item = JSON.stringify({
         content_type: "application/json",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes incorrect `sdk_info` spec and bump android to `2.2.2` so it actually is used.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
