### PR TITLE
fix: don't initiate DeviceContext if enableNative is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - fix: Use `LogBox` instead of `YellowBox` if possible. #989
+- fix: Don't add `DeviceContext` default integration if `enableNative` is set to `false`. #993
+- fix: Don't log "Native Sentry SDK is disabled" if `enableNativeNagger` is set to `false`. #993
 
 ## 1.6.3
 

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -65,20 +65,15 @@ export function init(
             }
           }
           return frame;
-        }
-      }),
-      new DeviceContext()
+        },
+      })
     );
+    if (options.enableNative) {
+      options.defaultIntegrations.push(new DeviceContext());
+    }
+    options = assignDefaultOptions(options);
   }
-  if (options.enableNative === undefined) {
-    options.enableNative = true;
-  }
-  if (options.enableNativeCrashHandling === undefined) {
-    options.enableNativeCrashHandling = true;
-  }
-  if (options.enableNativeNagger === undefined) {
-    options.enableNativeNagger = true;
-  }
+
   // tslint:enable: strict-comparisons
   initAndBind(ReactNativeClient, options);
 
@@ -124,4 +119,15 @@ export function nativeCrash(): void {
   if (client) {
     client.nativeCrash();
   }
+}
+
+function assignDefaultOptions(
+  providedOptions: ReactNativeOptions
+): ReactNativeOptions {
+  const defaultOptions: ReactNativeOptions = {
+    enableNative: true,
+    enableNativeCrashHandling: true,
+    enableNativeNagger: true,
+  };
+  return { ...defaultOptions, ...providedOptions };
 }

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -56,7 +56,9 @@ export const NATIVE = {
    * Starts native with the provided options.
    * @param options ReactNativeOptions
    */
-  async startWithOptions(options: ReactNativeOptions = {}): Promise<boolean> {
+  async startWithOptions(
+    options: ReactNativeOptions = { enableNative: true }
+  ): Promise<boolean> {
     if (!options.dsn) {
       logger.warn(
         "Warning: No DSN was provided. The Sentry SDK will be disabled. Native SDK will also not be initalized."
@@ -64,8 +66,10 @@ export const NATIVE = {
       return false;
     }
     if (!options.enableNative) {
+      if (!options.enableNativeNagger) {
+        logger.warn("Note: Native Sentry SDK is disabled.");
+      }
       this.enableNative = false;
-      logger.warn("Note: Native Sentry SDK is disabled.");
       return false;
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
`DeviceContext` calls into native, which can result in extraneous error logs if the user has already stated they don't want to enable the native SDK. 
I also silenced the console warning if `enableNativeNagger` is false

## :bulb: Motivation and Context
This is an issue for our integration of `sentry-expo` https://github.com/expo/sentry-expo/issues/120 


## :green_heart: How did you test it?
Ran `yarn test` and tested in an expo project with sentry, no more bad logs! 🎉 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
