### PR TITLE
fix: assign default options before enableNative check

### DIFF
--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -71,10 +71,10 @@ export function init(
         },
       })
     );
+    options = assignDefaultOptions(options);
     if (options.enableNative) {
       options.defaultIntegrations.push(new DeviceContext());
     }
-    options = assignDefaultOptions(options);
   }
 
   // tslint:enable: strict-comparisons

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -38,6 +38,10 @@ export function init(
 ): void {
   const reactNativeHub = new Hub(undefined, new ReactNativeScope());
   makeMain(reactNativeHub);
+  options = {
+    ...DEFAULT_OPTIONS,
+    ...options
+  }
 
   // tslint:disable: strict-comparisons
   if (options.defaultIntegrations === undefined) {
@@ -76,10 +80,6 @@ export function init(
         },
       })
     );
-    options = {
-        ...DEFAULT_OPTIONS,
-        ...options
-    }
     if (options.enableNative) {
       options.defaultIntegrations.push(new DeviceContext());
     }

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -21,6 +21,11 @@ const IGNORED_DEFAULT_INTEGRATIONS = [
   "GlobalHandlers", // We will use the react-native internal handlers
   "TryCatch", // We don't need this
 ];
+const DEFAULT_OPTIONS: ReactNativeOptions = {
+  enableNative: true,
+  enableNativeCrashHandling: true,
+  enableNativeNagger: true,
+};
 
 /**
  * Inits the SDK
@@ -71,7 +76,10 @@ export function init(
         },
       })
     );
-    options = assignDefaultOptions(options);
+    options = {
+        ...DEFAULT_OPTIONS,
+        ...options
+    }
     if (options.enableNative) {
       options.defaultIntegrations.push(new DeviceContext());
     }
@@ -122,15 +130,4 @@ export function nativeCrash(): void {
   if (client) {
     client.nativeCrash();
   }
-}
-
-function assignDefaultOptions(
-  providedOptions: ReactNativeOptions
-): ReactNativeOptions {
-  const defaultOptions: ReactNativeOptions = {
-    enableNative: true,
-    enableNativeCrashHandling: true,
-    enableNativeNagger: true,
-  };
-  return { ...defaultOptions, ...providedOptions };
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
the changes i made in https://github.com/getsentry/sentry-react-native/pull/993 result in `deviceContext` not initializing by default, since the default `enableNative:true` isn't set until right after


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-react-native/pull/993#issuecomment-665649047

## :green_heart: How did you test it?
existing tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
