### PR TITLE
Update RNSentry.podspec

### DIFF
--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React'
-  s.dependency 'Sentry', '~> 5.1.8'
+  s.dependency 'Sentry', '~> 5.2.0'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'


### PR DESCRIPTION
Bump `sentry-cocoa` to version `5.2` 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Quickfix for not using private API on mac catalyst: https://github.com/getsentry/sentry-cocoa/pull/652


## :bulb: Motivation and Context
Using Sentry in react native mac catalyst app


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
