### PR TITLE
fix: Use the release and dist set in init options over native release

### DIFF
--- a/src/js/integrations/release.ts
+++ b/src/js/integrations/release.ts
@@ -34,12 +34,22 @@ export class Release implements Integration {
         // Something went wrong, we just continue
       }
 
-      // If __sentry_release or __sentry_dist it should be stronger because the user set it
-      if (event.extra && event.extra.__sentry_release) {
+      const options = getCurrentHub().getClient()?.getOptions();
+
+      /*
+        __sentry_release and __sentry_dist is set by the user with setRelease and setDist. If this is used then this is the strongest.
+        Otherwise we check for the release and dist in the options passed on init, as this is stronger than the release/dist from the native build.
+      */
+      if (typeof event.extra?.__sentry_release === "string") {
         event.release = `${event.extra.__sentry_release}`;
+      } else if (typeof options?.release === "string") {
+        event.release = options.release;
       }
-      if (event.extra && event.extra.__sentry_dist) {
+
+      if (typeof event.extra?.__sentry_dist === "string") {
         event.dist = `${event.extra.__sentry_dist}`;
+      } else if (typeof options?.dist === "string") {
+        event.dist = options.dist;
       }
 
       return event;

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -100,14 +100,16 @@ export function init(
 }
 
 /**
- * Sets the release on the event.
+ * Legacy. Sets the release on the event.
+ * NOTE: Does not set the release on sessions.
  */
 export function setRelease(release: string): void {
   setExtra("__sentry_release", release);
 }
 
 /**
- * Sets the dist on the event.
+ * Legacy. Sets the dist on the event.
+ * NOTE: Does not set the dist on sessions.
  */
 export function setDist(dist: string): void {
   setExtra("__sentry_dist", dist);

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -100,16 +100,18 @@ export function init(
 }
 
 /**
- * Legacy. Sets the release on the event.
+ * Deprecated. Sets the release on the event.
  * NOTE: Does not set the release on sessions.
+ * @deprecated
  */
 export function setRelease(release: string): void {
   setExtra("__sentry_release", release);
 }
 
 /**
- * Legacy. Sets the dist on the event.
+ * Deprecated. Sets the dist on the event.
  * NOTE: Does not set the dist on sessions.
+ * @deprecated
  */
 export function setDist(dist: string): void {
   setExtra("__sentry_dist", dist);

--- a/test/integrations/release.test.ts
+++ b/test/integrations/release.test.ts
@@ -1,0 +1,109 @@
+import { addGlobalEventProcessor, getCurrentHub } from "@sentry/core";
+import { EventProcessor } from "@sentry/types";
+
+import { Release } from "../../src/js/integrations/release";
+
+jest.mock("@sentry/core", () => {
+  const client = {
+    getOptions: jest.fn(),
+  };
+
+  const hub = {
+    getClient: () => client,
+    getIntegration: () => Release,
+  };
+
+  return {
+    addGlobalEventProcessor: jest.fn(),
+    getCurrentHub: () => hub,
+  };
+});
+
+jest.mock("../../src/js/wrapper", () => ({
+  NATIVE: {
+    fetchRelease: async () => ({
+      build: "native_build",
+      id: "native_id",
+      version: "native_version",
+    }),
+  },
+}));
+
+describe("Tests the Release integration", () => {
+  test("Uses release from native SDK if release/dist are not present in options.", async () => {
+    const releaseIntegration = new Release();
+
+    let eventProcessor: EventProcessor = () => null;
+    // @ts-expect-error
+    // tslint:disable-next-line: no-unsafe-any
+    addGlobalEventProcessor.mockImplementation((e) => (eventProcessor = e));
+    releaseIntegration.setupOnce();
+
+    expect(addGlobalEventProcessor).toBeCalled();
+
+    const client = getCurrentHub().getClient();
+    // @ts-expect-error
+    // tslint:disable-next-line: no-unsafe-any
+    client.getOptions.mockImplementation(() => ({}));
+
+    const event = await eventProcessor({});
+
+    expect(event?.release).toBe(`native_id@native_version+native_build`);
+    expect(event?.dist).toBe("native_build");
+  });
+
+  test("Uses release and dist from options", async () => {
+    const releaseIntegration = new Release();
+
+    let eventProcessor: EventProcessor = () => null;
+    // @ts-expect-error
+    // tslint:disable-next-line: no-unsafe-any
+    addGlobalEventProcessor.mockImplementation((e) => (eventProcessor = e));
+    releaseIntegration.setupOnce();
+
+    expect(addGlobalEventProcessor).toBeCalled();
+
+    const client = getCurrentHub().getClient();
+    // @ts-expect-error
+    // tslint:disable-next-line: no-unsafe-any
+    client.getOptions.mockImplementation(() => ({
+      dist: "options_dist",
+      release: "options_release",
+    }));
+
+    const event = await eventProcessor({});
+
+    expect(event?.release).toBe("options_release");
+    expect(event?.dist).toBe("options_dist");
+  });
+
+  test("Uses __sentry_release and __sentry_dist over everything else.", async () => {
+    const releaseIntegration = new Release();
+
+    let eventProcessor: EventProcessor = () => null;
+    // @ts-expect-error
+    // tslint:disable-next-line: no-unsafe-any
+    addGlobalEventProcessor.mockImplementation((e) => (eventProcessor = e));
+    releaseIntegration.setupOnce();
+
+    expect(addGlobalEventProcessor).toBeCalled();
+
+    const client = getCurrentHub().getClient();
+    // @ts-expect-error
+    // tslint:disable-next-line: no-unsafe-any
+    client.getOptions.mockImplementation(() => ({
+      dist: "options_dist",
+      release: "options_release",
+    }));
+
+    const event = await eventProcessor({
+      extra: {
+        __sentry_dist: "sentry_dist",
+        __sentry_release: "sentry_release",
+      },
+    });
+
+    expect(event?.release).toBe("sentry_release");
+    expect(event?.dist).toBe("sentry_dist");
+  });
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The `release` and `dist` set in the init options are now used over the native build's release. However we keep `setRelease` and `setDist` as legacy methods to support users who currently use it along with users who use `codePush.getMetadata` to set their release later in the session rather than at the start. We will migrate the documentation to prefer setting the release and dist in init options over using `setRelease` and `setDist` and list the downside of using them.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using `setRelease` and `setDist` does not set the release on the native Android/Cocoa SDKs, causing release health and sessions to be attributed to the build's release. This is not ideal for apps that use custom release versions such as apps with CodePushed bundles. 

## :green_heart: How did you test it?
Wrote `release.test.ts`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Will be followed up with a docs pr