### PR TITLE
add missing breaks to log level switch

### DIFF
--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -94,10 +94,13 @@ RCT_EXPORT_METHOD(setLogLevel:(int)level)
     switch (level) {
         case 1:
             cocoaLevel = kSentryLogLevelError;
+            break;
         case 2:
             cocoaLevel = kSentryLogLevelDebug;
+            break;
         case 3:
             cocoaLevel = kSentryLogLevelVerbose;
+            break;
         default:
             cocoaLevel = kSentryLogLevelNone;
     }

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -103,6 +103,7 @@ RCT_EXPORT_METHOD(setLogLevel:(int)level)
             break;
         default:
             cocoaLevel = kSentryLogLevelNone;
+            break; 
     }
     [SentrySDK setLogLevel:cocoaLevel];
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Setting the log level didn't work, because the switch would always fall through to `kSentryLogLevelNone`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
