### PR TITLE
fix: Only call native deviceContexts on iOS

### DIFF
--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -126,6 +126,12 @@ export const NATIVE = {
     if (!this.isNativeClientAvailable()) {
       throw this._NativeClientError;
     }
+
+    if (this.platform !== "ios") {
+      // Only ios uses deviceContexts, return an empty object.
+      return {};
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return RNSentry.deviceContexts();
   },

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -9,7 +9,7 @@ jest.mock(
       RNSentry: {
         captureEnvelope: jest.fn((envelope) => Promise.resolve(envelope)),
         crash: jest.fn(),
-        deviceContexts: jest.fn(() => Promise.resolve({})),
+        deviceContexts: jest.fn(() => Promise.resolve({ someContext: 0  })),
         fetchRelease: jest.fn(() =>
           Promise.resolve({
             build: "1.0.0.1",
@@ -28,7 +28,7 @@ jest.mock(
       },
     },
     Platform: {
-      OS: "iOS",
+      OS: "ios",
     },
   }),
   /* virtual allows us to mock modules that aren't in package.json */
@@ -155,8 +155,13 @@ describe("Tests Native Wrapper", () => {
 
   describe("deviceContexts", () => {
     test("fetches the contexts from native", async () => {
-      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({});
+      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({ someContext: 0});
     });
+    test("returns empty object if not on ios", async () => {
+      NATIVE.platform = "android";
+
+      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({})
+    })
   });
 
   describe("isModuleLoaded", () => {

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -9,7 +9,7 @@ jest.mock(
       RNSentry: {
         captureEnvelope: jest.fn((envelope) => Promise.resolve(envelope)),
         crash: jest.fn(),
-        deviceContexts: jest.fn(() => Promise.resolve({ someContext: 0  })),
+        deviceContexts: jest.fn(() => Promise.resolve({ someContext: 0 })),
         fetchRelease: jest.fn(() =>
           Promise.resolve({
             build: "1.0.0.1",
@@ -154,14 +154,26 @@ describe("Tests Native Wrapper", () => {
   });
 
   describe("deviceContexts", () => {
-    test("fetches the contexts from native", async () => {
-      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({ someContext: 0});
+    test("returns context object from native module on ios", async () => {
+      const RN = require("react-native");
+
+      NATIVE.platform = "ios";
+
+      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({
+        someContext: 0,
+      });
+
+      expect(RN.NativeModules.RNSentry.deviceContexts).toBeCalled();
     });
-    test("returns empty object if not on ios", async () => {
+    test("returns empty object on android", async () => {
+      const RN = require("react-native");
+
       NATIVE.platform = "android";
 
-      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({})
-    })
+      await expect(NATIVE.deviceContexts()).resolves.toMatchObject({});
+
+      expect(RN.NativeModules.RNSentry.deviceContexts).not.toBeCalled();
+    });
   });
 
   describe("isModuleLoaded", () => {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
`RNSentry.deviceContexts` is not present on the android module. We shouldn't call it.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-react-native/issues/1050

## :green_heart: How did you test it?
Updated the wrapper tests to include a case for android platform.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
