### PR TITLE
fix: Don't send over Log and Critical levels over native bridge

### DIFF
--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -1,3 +1,4 @@
+import { Severity } from "@sentry/types";
 import { logger } from "@sentry/utils";
 
 import { NATIVE } from "../src/js/wrapper";
@@ -7,6 +8,7 @@ jest.mock(
   () => ({
     NativeModules: {
       RNSentry: {
+        addBreadcrumb: jest.fn(),
         captureEnvelope: jest.fn((envelope) => Promise.resolve(envelope)),
         crash: jest.fn(),
         deviceContexts: jest.fn(() => Promise.resolve({})),
@@ -218,6 +220,20 @@ describe("Tests Native Wrapper", () => {
         },
         {}
       );
+    });
+  });
+
+  describe("_processLevel", () => {
+    test("converts deprecated levels", () => {
+      expect(NATIVE._processLevel(Severity.Log)).toBe(Severity.Debug);
+      expect(NATIVE._processLevel(Severity.Critical)).toBe(Severity.Fatal);
+    });
+    test("returns non-deprecated levels", () => {
+      expect(NATIVE._processLevel(Severity.Debug)).toBe(Severity.Debug);
+      expect(NATIVE._processLevel(Severity.Fatal)).toBe(Severity.Fatal);
+      expect(NATIVE._processLevel(Severity.Info)).toBe(Severity.Info);
+      expect(NATIVE._processLevel(Severity.Warning)).toBe(Severity.Warning);
+      expect(NATIVE._processLevel(Severity.Error)).toBe(Severity.Error);
     });
   });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds a `_processLevel` method to the native wrapper to convert `Severity.Log` and `Severity.Critical` levels to `Severity.Debug` and `Severity.Fatal` respectively. This method is called in `sendEvent` and `addBreadcrumb` in the native wrapper.

This is to handle this issue for now until we remove these levels from the javascript SDK. This also means that we can remove `Log` and `Critical` from android, @marandaneto.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/getsentry/sentry-react-native/issues/1055

## :green_heart: How did you test it?

Added tests for `_processLevel`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
