### PR TITLE
fix: Fix failing end to end tests

### DIFF
--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -29,6 +29,7 @@ beforeAll(async () => {
           deviceName: 'iPhone 11',
           platformName: 'iOS',
           newCommandTimeout: 600000,
+          automationName: 'XCUITest',
         };
 
   await driver.init(config);

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -10,7 +10,7 @@ const PORT = 4723;
 const driver = wd.promiseChainRemote('localhost', PORT);
 
 // 20 min timeout why not
-jest.setTimeout(600000);
+jest.setTimeout(1.2e6);
 
 beforeAll(async () => {
   const config =

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -28,7 +28,6 @@ beforeAll(async () => {
             '/Users/runner/Library/Developer/Xcode/DerivedData/sample-dnujahkswllvjvfnwwwzqheuvdsm/Build/Products/Release-iphonesimulator/sample.app',
           deviceName: 'iPhone 11',
           platformName: 'iOS',
-          platformVersion: '13.6',
           newCommandTimeout: 600000,
         };
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Fixes failing end to end tests due to an Xcode update deprecating UIAutomation. Also actually made the timeout 20 minutes as stated in the comment.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
