### PR TITLE
fix: Fix failing touchevents test

### DIFF
--- a/test/touchevents.test.tsx
+++ b/test/touchevents.test.tsx
@@ -1,9 +1,9 @@
-import * as minimal from "@sentry/minimal";
+import * as core from "@sentry/core";
 import { Severity } from "@sentry/types";
 
 import { TouchEventBoundary } from "../src/js/touchevents";
 
-const addBreadcrumb = jest.spyOn(minimal, "addBreadcrumb");
+const addBreadcrumb = jest.spyOn(core, "addBreadcrumb");
 
 afterEach(() => {
   jest.resetAllMocks();


### PR DESCRIPTION
Fixes failing touch events test on ci due to mocking `addBreadcrumb` minimal instead of core.