### PR TITLE
build: Bump @sentry/javascript dependencies to 5.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- build: Bump @sentry/javascript dependencies to 5.24.2 #1091
+- fix: Add a check that `performance` exists before using it. #1091
+
 ## 1.8.1
 
 - build: Bump @sentry/javascript dependencies to 5.24.1 #1088

--- a/package.json
+++ b/package.json
@@ -40,18 +40,18 @@
     "react-native": ">=0.56.0"
   },
   "dependencies": {
-    "@sentry/browser": "^5.24.1",
-    "@sentry/core": "^5.24.1",
-    "@sentry/hub": "^5.24.1",
-    "@sentry/integrations": "^5.24.1",
-    "@sentry/react": "^5.24.1",
-    "@sentry/types": "^5.24.1",
-    "@sentry/utils": "^5.24.1",
+    "@sentry/browser": "^5.24.2",
+    "@sentry/core": "^5.24.2",
+    "@sentry/hub": "^5.24.2",
+    "@sentry/integrations": "^5.24.2",
+    "@sentry/react": "^5.24.2",
+    "@sentry/types": "^5.24.2",
+    "@sentry/utils": "^5.24.2",
     "@sentry/wizard": "^1.1.4"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "^5.24.1",
-    "@sentry-internal/eslint-plugin-sdk": "^5.24.1",
+    "@sentry-internal/eslint-config-sdk": "^5.24.2",
+    "@sentry-internal/eslint-plugin-sdk": "^5.24.2",
     "@sentry/typescript": "^5.20.0",
     "@types/jest": "^25.1.4",
     "@types/react": "^16.9.49",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1112,13 +1112,13 @@
     sudo-prompt "^9.0.0"
     wcwidth "^1.0.1"
 
-"@sentry-internal/eslint-config-sdk@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-5.24.1.tgz#6b2d32963ad08c29e48a05df58faa19bcc4f960a"
-  integrity sha512-FPeZIzQ9q1ww5/wq/rn3wn7g2wsDdcNql7Vj6MnWpUuNC07lHSAeD5j+7v9AipsPlSEXGFVJsBUOQ57NOAIhnA==
+"@sentry-internal/eslint-config-sdk@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-5.24.2.tgz#4c2b6aaffab2e215cb57be9c54afbeb910026eae"
+  integrity sha512-zAW99gv8xw0qWNjPB7bJ4puqKv53Wbt0e3czqSCVB7+3xRoebP2T297CyZjMl5l3qoNCjHoA2wnQw8yWffaTnA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "5.24.1"
-    "@sentry-internal/typescript" "5.24.1"
+    "@sentry-internal/eslint-plugin-sdk" "5.24.2"
+    "@sentry-internal/typescript" "5.24.2"
     "@typescript-eslint/eslint-plugin" "^3.9.0"
     "@typescript-eslint/parser" "^3.9.0"
     eslint-config-prettier "^6.11.0"
@@ -1127,29 +1127,29 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@5.24.1", "@sentry-internal/eslint-plugin-sdk@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-5.24.1.tgz#52210e3e6fcd9beec8fc169eb772d03b8eaf7cda"
-  integrity sha512-NfsMuzGAfjPxyJj8bAh6a5/ziRVM0H0zzMxcAbz1wdGKut+lldGnEg+dFB8d8pf+q1O5uZpa+lMNZSP8p7BXAQ==
+"@sentry-internal/eslint-plugin-sdk@5.24.2", "@sentry-internal/eslint-plugin-sdk@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-5.24.2.tgz#882bfd35269a9b7eeab64adb01f7c2b166e1be01"
+  integrity sha512-D2W9/HsoZxiXSJNKHqZpqGXx7fbJqIs5TfThhibCWg6qqwMPcqkdh+KtIUgnM8NUsUSQYR/ayHt7c+TGyiqRyQ==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/typescript@5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-5.24.1.tgz#c8f39ffccda8e7d79523e0618b782cccd76d9410"
-  integrity sha512-JSWd946kNi+mOi92mFk+j1clAASx43+3H5RDU2LJft3yADWnQuJtukP0CIxAr7NDe6vLXeI++cP3qjl1nbgeXw==
+"@sentry-internal/typescript@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-5.24.2.tgz#7171a3c03ca1422df67f7a8436323920b1639117"
+  integrity sha512-La/C66vxsZQMcJ5JqtXXDF703+nyU7zhNdIlL6rIh8hucS3Vm1kxMCoL+bDoweKqteS1U/CXndrVgCR2QwcuVw==
   dependencies:
     tslint-config-prettier "^1.18.0"
     tslint-consistent-codestyle "^1.15.1"
 
-"@sentry/browser@5.24.1", "@sentry/browser@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.24.1.tgz#d73f2aa9caba1314e5bafd1f9b0583478d737e55"
-  integrity sha512-Uw76n6rYtR9Lsu5GaLHFx419icj8ZGJpycE1MbyF+sOPQ6H7nxkYVHf44qlc3FFwsDI/Ys1h+MkwSJims9n9Jw==
+"@sentry/browser@5.24.2", "@sentry/browser@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.24.2.tgz#e2c2786dbf07699ee12f12babf0138d633abc494"
+  integrity sha512-P/uZC/VrLRpU7MVEJnlZK5+AkEmuHu+mns5gC91Z4gjn7GamjR/CaXVedHGw/15ZrsQiAiwoWwuxpv4Ypd/+SA==
   dependencies:
-    "@sentry/core" "5.24.1"
-    "@sentry/types" "5.24.1"
-    "@sentry/utils" "5.24.1"
+    "@sentry/core" "5.24.2"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
     tslib "^1.9.3"
 
 "@sentry/cli@^1.52.4":
@@ -1163,61 +1163,61 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@5.24.1", "@sentry/core@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.24.1.tgz#963560a97106e53f06cab239305db1c2e53e682e"
-  integrity sha512-MENluJrPOl2X4VBVbtQhXJiLfXlUfRdKihq5N9RffWr3vNEF7bshr3wClcIU082VHUs+obzR+w06N+U6uLIzsw==
+"@sentry/core@5.24.2", "@sentry/core@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.24.2.tgz#1724652855c0887a690c3fc6acd2519d4072b511"
+  integrity sha512-nuAwCGU1l9hgMinl5P/8nIQGRXDP2FI9cJnq5h1qiP/XIOvJkJz2yzBR6nTyqr4vBth0tvxQJbIpDNGd7vHJLg==
   dependencies:
-    "@sentry/hub" "5.24.1"
-    "@sentry/minimal" "5.24.1"
-    "@sentry/types" "5.24.1"
-    "@sentry/utils" "5.24.1"
+    "@sentry/hub" "5.24.2"
+    "@sentry/minimal" "5.24.2"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
     tslib "^1.9.3"
 
-"@sentry/hub@5.24.1", "@sentry/hub@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.24.1.tgz#0fa4b07a3601ee45dcc64dc5c7ad2dee5fbe7816"
-  integrity sha512-ItTD7VtAgy4OldmgWa1f9qZkrCQDkmPJhg86x/hhr4tzqqv+d+xw4o/+1vL4ZrrsEdgRDC1cZjZXsVJ/L47JDQ==
+"@sentry/hub@5.24.2", "@sentry/hub@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.24.2.tgz#64a02fd487599945e488ae23aba4ce4df44ee79e"
+  integrity sha512-xmO1Ivvpb5Qr9WgekinuZZlpl9Iw7iPETUe84HQOhUrXf+2gKO+LaUYMMsYSVDwXQEmR6/tTMyOtS6iavldC6w==
   dependencies:
-    "@sentry/types" "5.24.1"
-    "@sentry/utils" "5.24.1"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
     tslib "^1.9.3"
 
-"@sentry/integrations@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.24.1.tgz#2680c9dc9d7b14fc2e93b62bca33aeb12fd27e5c"
-  integrity sha512-OZpBJBynzf/uEq8kZMYvFJjoO0h50esgz21eFReF7lPbtBtJannFUoGmYgou9fqZx77x5r+7OwZsaKn9edFVzA==
+"@sentry/integrations@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.24.2.tgz#cfb14c64465d6acbb279994b8a87a8ef72776320"
+  integrity sha512-b0upZS+xvONwxkLL6apSSgseR1e6dtq7wAGHefnPa5ckTwIoUkboL/dqiTNmFj1xXnWb87WDX1ZcIx7nfEqw6A==
   dependencies:
-    "@sentry/types" "5.24.1"
-    "@sentry/utils" "5.24.1"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
     localforage "1.8.1"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.24.1.tgz#7b80c90fb2557c339835c2c439335f58303292ad"
-  integrity sha512-kB9Ww/7U3VwQ7fCyBkhuDwAmIwndmJGIs2VRzIUY93Q7cDTlNFvlWPyscqE27qT5Q7O1EKYhZE15Vr6phyiDVg==
+"@sentry/minimal@5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.24.2.tgz#14e8b136842398a32987459f0574359b6dc57a1f"
+  integrity sha512-biFpux5bI3R8xiD/Zzvrk1kRE6bqPtfWXmZYAHRtaUMCAibprTKSY9Ta8QYHynOAEoJ5Akedy6HUsEkK5DoZfA==
   dependencies:
-    "@sentry/hub" "5.24.1"
-    "@sentry/types" "5.24.1"
+    "@sentry/hub" "5.24.2"
+    "@sentry/types" "5.24.2"
     tslib "^1.9.3"
 
-"@sentry/react@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.24.1.tgz#8233cfa99981a19cc1a0dc3fada8964323b21ad8"
-  integrity sha512-NdLmJtAVoWW13ZWeK+uMcnTEcjmTyCB6Xm9UeK4I3c4kLnDI7v/uQwmQqiGADRZ+PXgFrunmoRHDjSnPap196w==
+"@sentry/react@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.24.2.tgz#781ae4274ad5c3148b8f80b613c1b0a73f763e47"
+  integrity sha512-iVti69qCMFztgP2E0LMx6V+3+ppKdylMJalWnwMt4LyL9idnnuiwFzMCA9g3QEvXRCTSuqEO39Dk4XYXyxi8pA==
   dependencies:
-    "@sentry/browser" "5.24.1"
-    "@sentry/minimal" "5.24.1"
-    "@sentry/types" "5.24.1"
-    "@sentry/utils" "5.24.1"
+    "@sentry/browser" "5.24.2"
+    "@sentry/minimal" "5.24.2"
+    "@sentry/types" "5.24.2"
+    "@sentry/utils" "5.24.2"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/types@5.24.1", "@sentry/types@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.24.1.tgz#7f39f1344fd8cbe8c82b5488250a489dc753dc5f"
-  integrity sha512-t31eVrBPFLhhKJnIwyOhfibS/Sm9U81Sp2hxh1SZfkW1pdVrYOBY+BxO/zK3ChUTIR0BONcL2Its7JqAl0SZgg==
+"@sentry/types@5.24.2", "@sentry/types@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.24.2.tgz#e2c25d1e75d8dbec5dbbd9a309a321425b61c2ca"
+  integrity sha512-HcOK00R0tQG5vzrIrqQ0jC28+z76jWSgQCzXiessJ5SH/9uc6NzdO7sR7K8vqMP2+nweCHckFohC8G0T1DLzuQ==
 
 "@sentry/typescript@^5.20.0":
   version "5.20.1"
@@ -1227,12 +1227,12 @@
     tslint-config-prettier "^1.18.0"
     tslint-consistent-codestyle "^1.15.1"
 
-"@sentry/utils@5.24.1", "@sentry/utils@^5.24.1":
-  version "5.24.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.24.1.tgz#bbcff3bca09f6d03f002929767ab284944714ccd"
-  integrity sha512-9e87L0yxiJuSNuv9l7C/mGfqxSrxj9h8rF3IRoyu34DqpUNvpgMfURjBd3AZoVA7eFiiVN3racLSnjhMuoZqZQ==
+"@sentry/utils@5.24.2", "@sentry/utils@^5.24.2":
+  version "5.24.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.24.2.tgz#90b7dff939bbbf4bb8edcac6aac2d04a0552af80"
+  integrity sha512-oPGde4tNEDHKk0Cg9q2p0qX649jLDUOwzJXHKpd0X65w3A6eJByDevMr8CSzKV9sesjrUpxqAv6f9WWlz185tA==
   dependencies:
-    "@sentry/types" "5.24.1"
+    "@sentry/types" "5.24.2"
     tslib "^1.9.3"
 
 "@sentry/wizard@^1.1.4":


### PR DESCRIPTION
Checks that `performance` actually exists (doesn't exist in RN <0.63) before calling it.

Fixes #1090 and #1089 