### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
 
   s.preserve_paths = '*.js'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'Sentry', '~> 5.2.0'
 
   s.source_files = 'ios/RNSentry.{h,m}'


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
According to https://github.com/facebook/react-native/issues/29633#issuecomment-694187116 - "React pod is in fact really only an umbrella dependency for pure JS applications to depend on, whereas the native APIs that these libraries rely on actually reside in the React-Core pod." This PR updates the dependency from `React` to `React-Core`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Xcode 12 fails to build if a module depends on React instead of React-Core. 
More info: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## :green_heart: How did you test it?

Use this branch to install with an app running on Xcode 12 or Xcode11. Both versions will work.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes
