### PR TITLE
fix: Move exceptions to threads field on Android

### DIFF
--- a/android/src/main/java/io/sentry/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/RNSentryModule.java
@@ -144,9 +144,9 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                     }
                 }
 
-                // If there are exceptions, move it to threads.
+                // If there are exceptions and the event originated from js, move it to threads.
                 // This is due to `threads` taking precedent over `exception` on the dashboard, hiding the JS Stack Trace.
-                if (event.getExceptions() != null) {
+                if (event.getTag("event.origin") != null && event.getTag("event.origin").equals("javascript") && event.getExceptions() != null) {
                     List<SentryThread> threads = new ArrayList<SentryThread>();
 
                     for (SentryException exception : event.getExceptions()) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Add a if block in the Android side of the native bridge in the case that if an event has exceptions (`exception` field) (where the JS stack trace would be) we would copy it over to `threads` instead.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The thread's stracktrace was taking precedence over the JS stack trace on the dashboard, even though the JS stack trace wasn't being overwritten.

## :green_heart: How did you test it?
Called every type of error on the sample app, ensured that only happens to JS errors and not native iOS/Android errors.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
