### PR TITLE
don't run SentryUpload on disabled bundle tasks

### DIFF
--- a/sentry.gradle
+++ b/sentry.gradle
@@ -34,7 +34,7 @@ gradle.projectsEvaluated {
     // separately we then hook into the bundle task of react native to inject
     // sourcemap generation parameters.  In case for whatever reason no release
     // was found for the asset folder we just bail.
-    def bundleTasks = tasks.findAll { task -> task.name.startsWith("bundle") && task.name.endsWith("JsAndAssets") && !task.name.contains("Debug") }
+    def bundleTasks = tasks.findAll { task -> task.name.startsWith("bundle") && task.name.endsWith("JsAndAssets") && !task.name.contains("Debug") && task.enabled }
     bundleTasks.each { bundleTask ->
         def shouldCleanUp
         def sourcemapOutput


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

The `SentryUpload` task was added to disabled bundle tasks, and it would fail when running `assemble` or `install`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See [this issue](https://github.com/getsentry/sentry-react-native/issues/1142).

## :green_heart: How did you test it?

I've tested it on a react native application I'm working on.
Now `./gradlew assembleCustom` (where custom is a debug variant) does not fail, while `./gradlew assembleRelease` still works.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
