### PR TITLE
meta: Add react native tools vscode settings to attach debugger to RN

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+      {
+          "name": "Attach to packager",
+          "cwd": "${workspaceFolder}",
+          "type": "reactnative",
+          "request": "attach"
+      },
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
     "editor.formatOnType": false,
     "editor.formatOnPaste": false,
     "editor.formatOnSave": false
-  }
+  },
+  "react-native-tools.projectRoot": "./sample"
 }


### PR DESCRIPTION
Add `launch.json` configuration and a setting to allow the react native tools vscode extension to work with the repo. This allows us to attach a debugger to the react native dev server.