### PR TITLE
fix: Serialize envelope payload when sending event on iOS

### DIFF
--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -64,11 +64,14 @@ export const NATIVE = {
       return RNSentry.captureEnvelope(envelopeString);
     }
 
+    // Serialize and remove any instances that will crash the native bridge such as Spans
+    const serializedPayload = JSON.parse(JSON.stringify(payload));
+
     // The envelope item is created (and its length determined) on the iOS side of the native bridge.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return RNSentry.captureEnvelope({
       header,
-      payload,
+      payload: serializedPayload,
     });
   },
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Serialize the envelope `payload` before sending it across the native bridge on iOS. This will remove class instances that will crash the native bridge such as spans. This is needed before the next tracing PR that will follow this soon.


## :green_heart: How did you test it?
Tested on sample app running on iOS emulator. Added tests to test class instance serialization. Includes a test for Android as well for good measure.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
