### PR TITLE
feat: Include @sentry/tracing and expose startTransaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@sentry/hub": "5.27.4",
     "@sentry/integrations": "5.27.4",
     "@sentry/react": "5.27.4",
+    "@sentry/tracing": "5.27.4",
     "@sentry/types": "5.27.4",
     "@sentry/utils": "5.27.4",
     "@sentry/wizard": "^1.1.4"

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -31,8 +31,11 @@ export {
   setTag,
   setTags,
   setUser,
+  startTransaction,
   withScope,
 } from "@sentry/core";
+
+import "@sentry/tracing";
 
 export {
   Integrations as BrowserIntegrations,

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -35,6 +35,8 @@ export {
   withScope,
 } from "@sentry/core";
 
+// We need to import it so we patch the hub with global functions
+// aka. this has side effects
 import "@sentry/tracing";
 
 export {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Import `@sentry/tracing` and expose `startTransaction`. Or should we only expose `startTransaction` and have users manually install and import `@sentry/tracing`?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Following this up with a PR for a new sample app that showcases tracing.
