### PR TITLE
fix(ios): Bump sentry-cocoa to 6.0.8 and remove private imports 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - build(ios): Bump `sentry-cocoa` to 6.0.8
 - fix(ios): Remove private imports and call `storeEnvelope` on the client.
+- fix(ios): Lock specific version in podspec.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - build(ios): Bump `sentry-cocoa` to 6.0.8
+- fix(ios): Remove private imports and call `storeEnvelope` on the client.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-- build(ios): Bump `sentry-cocoa` to 6.0.8
-- fix(ios): Remove private imports and call `storeEnvelope` on the client.
-- fix(ios): Lock specific version in podspec.
+- build(ios): Bump `sentry-cocoa` to 6.0.8. #1188
+- fix(ios): Remove private imports and call `storeEnvelope` on the client. #1188
+- fix(ios): Lock specific version in podspec. #1188
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- build(ios): Bump `sentry-cocoa` to 6.0.8
+
 ## 2.0.0
 
 - build(android): Changes android package name from `io.sentry.RNSentryPackage` to `io.sentry.react.RNSentryPackage` (Breaking). #1131

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'Sentry', '~> 6.0.3'
+  s.dependency 'Sentry', '~> 6.0.8'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'Sentry', '~> 6.0.8'
+  s.dependency 'Sentry', '6.0.8'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -7,8 +7,6 @@
 #endif
 
 #import <Sentry/Sentry.h>
-#import <Sentry/SentrySdkInfo.h>
-#import <Sentry/SentryFileManager.h>
 
 @interface RNSentry()
 
@@ -148,7 +146,7 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSDictionary * _Nonnull)envelopeDict
                 // Storing to disk happens asynchronously with captureEnvelope
                 // We need to make sure the event is written to disk before resolving the promise.
                 // This could be replaced by SentrySDK.flush() when available.
-                [[[[SentrySDK currentHub] getClient] fileManager] storeEnvelope:envelope];
+                [[[SentrySDK currentHub] getClient] storeEnvelope:envelope];
             } else {
                 [[[SentrySDK currentHub] getClient] captureEnvelope: envelope];
             }

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -148,7 +148,7 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSDictionary * _Nonnull)envelopeDict
                 // This could be replaced by SentrySDK.flush() when available.
                 [[[SentrySDK currentHub] getClient] storeEnvelope:envelope];
             } else {
-                [[[SentrySDK currentHub] getClient] captureEnvelope: envelope];
+                [[[SentrySDK currentHub] getClient] captureEnvelope:envelope];
             }
         #endif
         resolve(@YES);

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -298,7 +298,7 @@ PODS:
     - React-jsi (= 0.63.1)
   - RNSentry (2.0.0):
     - React-Core
-    - Sentry (~> 6.0.8)
+    - Sentry (= 6.0.8)
   - Sentry (6.0.8):
     - Sentry/Core (= 6.0.8)
   - Sentry/Core (6.0.8)
@@ -465,11 +465,11 @@ SPEC CHECKSUMS:
   React-RCTText: 4f95d322b7e6da72817284abf8a2cdcec18b9cd8
   React-RCTVibration: f3a9123c244f35c40d3c9f3ec3f0b9e5717bb292
   ReactCommon: 2905859f84a94a381bb0d8dd3921ccb1a0047cb8
-  RNSentry: b03cee5511678074ca8e7755f366fed9db9ab48a
+  RNSentry: 1c93d9d6b68748a6857d49e26c3e88fbe983caba
   Sentry: 6ab9f44a413dec7ebf5e82b166048afb5f60b895
   Yoga: d5bd05a2b6b94c52323745c2c2b64557c8c66f64
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 9d75e167307300a63add2b53a03e1d19bb02cd35
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.9.2

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -296,12 +296,12 @@ PODS:
     - React-Core (= 0.63.1)
     - React-cxxreact (= 0.63.1)
     - React-jsi (= 0.63.1)
-  - RNSentry (1.9.0):
+  - RNSentry (2.0.0):
     - React-Core
-    - Sentry (~> 6.0.3)
-  - Sentry (6.0.3):
-    - Sentry/Core (= 6.0.3)
-  - Sentry/Core (6.0.3)
+    - Sentry (~> 6.0.8)
+  - Sentry (6.0.8):
+    - Sentry/Core (= 6.0.8)
+  - Sentry/Core (6.0.8)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -465,8 +465,8 @@ SPEC CHECKSUMS:
   React-RCTText: 4f95d322b7e6da72817284abf8a2cdcec18b9cd8
   React-RCTVibration: f3a9123c244f35c40d3c9f3ec3f0b9e5717bb292
   ReactCommon: 2905859f84a94a381bb0d8dd3921ccb1a0047cb8
-  RNSentry: 967713f6aac06484165449067160494529cb90d3
-  Sentry: 286e33636e0be9b559e2ebe2eae63ec53f83816e
+  RNSentry: b03cee5511678074ca8e7755f366fed9db9ab48a
+  Sentry: 6ab9f44a413dec7ebf5e82b166048afb5f60b895
   Yoga: d5bd05a2b6b94c52323745c2c2b64557c8c66f64
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Remove private imports from sentry-cocoa and call storeEnvelope on the client instead of through fileManager like before.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users were having issues with `use_frameworks!` in their Podfile.
https://github.com/getsentry/sentry-react-native/issues/1171

## :green_heart: How did you test it?
Confirmed that the app builds with the `use_frameworks!` tag in the Podfile. Tested that unhandled fatal errors are still stored and sent as needed.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
