### PR TITLE
docs: Fix MD034 Bare URL used in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -428,7 +428,7 @@ export SENTRY_PROPERTIES=sentry.properties
 
 ## v0.31.0
 
-- Use https://github.com/getsentry/sentry-wizard for setup process
+- Use <https://github.com/getsentry/sentry-wizard> for setup process
 
 ## v0.30.3
 
@@ -498,7 +498,7 @@ We are looking into ways making this more stable and plan to re-enable it again 
 
 ## v0.24.2
 
-- Fixed https://github.com/getsentry/react-native-sentry/issues/241
+- Fixed <https://github.com/getsentry/react-native-sentry/issues/241>
 
 ## v0.24.1
 
@@ -753,7 +753,7 @@ Update Podspec to use `Sentry/KSCrash`
 
 ## v0.11.5
 
-- Fix https://github.com/getsentry/react-native-sentry/issues/77
+- Fix <https://github.com/getsentry/react-native-sentry/issues/77>
 
 ## v0.11.4
 
@@ -775,13 +775,13 @@ Update Podspec to use `Sentry/KSCrash`
 
 This is a big release because we switched our internal iOS client from swift to objc which drastically improve the setup experience and compatibility.
 
-We also added support for codepush, please check the docs https://docs.sentry.io/clients/react-native/codepush/ for more information.
+We also added support for codepush, please check the docs <https://docs.sentry.io/clients/react-native/codepush/> for more information.
 
 After updating run `react-native unlink react-native-sentry` and `react-native link react-native-sentry` again in order to setup everything correctly.
 
 ## v0.10.0
 
-- Greatly improved the linking process. Check out our docs for more information https://docs.sentry.io/clients/react-native/
+- Greatly improved the linking process. Check out our docs for more information <https://docs.sentry.io/clients/react-native/>
 
 ## v0.9.1
 
@@ -852,7 +852,7 @@ Alot of API changes to more like `raven-js`
 
 ## v0.5.0
 
-- Added support for installation with cocoapods see https://docs.sentry.io/clients/react-native/#setup-with-cocoapods
+- Added support for installation with cocoapods see <https://docs.sentry.io/clients/react-native/#setup-with-cocoapods>
 - Lowered minimum version requirement for `react-native` to `0.38.0`
 
 ## v0.4.0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
The Changelog contains several markdown lint warnings `MD034 - Bare URL used`. This is fixed now.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
It's a Changelog

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
