### PR TITLE
feat: Allow disabling native SDK initialization but still use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Unreleased
 
 - fix: pas maxBreadcrumbs to Android init
+- feat: Allow disabling native SDK initialization but still use it #1259
 
 ## 2.1.0
 

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -20,6 +20,12 @@ export interface ReactNativeOptions extends BrowserOptions {
    */
   enableNativeCrashHandling?: boolean;
 
+  /** Initializes the native SDK on init.
+   * Set this to `false` if you have an existing native SDK and don't want to re-initialize.
+   * @default true
+   */
+  shouldInitializeNativeSdk?: boolean;
+
   /** Maximum time to wait to drain the request queue, before the process is allowed to exit. */
   shutdownTimeout?: number;
 

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -20,8 +20,15 @@ export interface ReactNativeOptions extends BrowserOptions {
    */
   enableNativeCrashHandling?: boolean;
 
-  /** Initializes the native SDK on init.
+  /**
+   * Initializes the native SDK on init.
    * Set this to `false` if you have an existing native SDK and don't want to re-initialize.
+   *
+   * NOTE: Be careful and only use this if you know what you are doing.
+   * If you use this flag, make sure a native SDK is running before the JS Engine initializes or events might not be captured.
+   * Also, make sure the DSN on both the React Native side and the native side are the same one.
+   * We strongly recommend checking the documentation if you need to use this.
+   *
    * @default true
    */
   shouldInitializeNativeSdk?: boolean;

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -23,6 +23,7 @@ const DEFAULT_OPTIONS: ReactNativeOptions = {
   enableNative: true,
   enableNativeCrashHandling: true,
   enableNativeNagger: true,
+  shouldInitializeNativeSdk: true,
 };
 
 /**

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -79,9 +79,19 @@ export const NATIVE = {
    * Starts native with the provided options.
    * @param options ReactNativeOptions
    */
-  async startWithOptions(
-    options: ReactNativeOptions = { enableNative: true }
-  ): Promise<boolean> {
+  async startWithOptions(_options: ReactNativeOptions): Promise<boolean> {
+    const options = {
+      enableNative: true,
+      shouldInitializeNativeSdk: true,
+      ..._options,
+    };
+
+    if (!options.shouldInitializeNativeSdk) {
+      if (options.enableNativeNagger) {
+        logger.warn("Note: Native Sentry SDK was not initialized.");
+      }
+      return false;
+    }
     if (!options.dsn) {
       logger.warn(
         "Warning: No DSN was provided. The Sentry SDK will be disabled. Native SDK will also not be initalized."

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -92,6 +92,29 @@ describe("Tests Native Wrapper", () => {
         "Note: Native Sentry SDK is disabled."
       );
     });
+
+    test("does not initialize with shouldInitializeNativeSdk: false", async () => {
+      const RN = require("react-native");
+
+      RN.NativeModules.RNSentry.startWithOptions = jest.fn();
+      logger.warn = jest.fn();
+
+      await NATIVE.startWithOptions({
+        dsn: "test",
+        enableNative: true,
+        shouldInitializeNativeSdk: false,
+      });
+
+      expect(RN.NativeModules.RNSentry.startWithOptions).not.toBeCalled();
+
+      await NATIVE.addBreadcrumb({
+        message: "test",
+      });
+
+      expect(RN.NativeModules.RNSentry.addBreadcrumb).toBeCalledWith({
+        message: "test",
+      });
+    });
   });
 
   describe("sendEvent", () => {
@@ -222,7 +245,7 @@ describe("Tests Native Wrapper", () => {
         message: {
           message: event.message,
         },
-        type: 'event',
+        type: "event",
       });
       const header = JSON.stringify({
         event_id: event.event_id,
@@ -231,7 +254,7 @@ describe("Tests Native Wrapper", () => {
       const item = JSON.stringify({
         content_type: "application/json",
         length: 1,
-        type: 'event',
+        type: "event",
       });
 
       await expect(NATIVE.sendEvent(event)).resolves.toMatch(


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Allows the user to disable the initialization of the Native SDK in the case that they already have one initialized themselves. We do this by adding the `shouldInitializeNativeSdk` key to `ReactNativeOptions`. This is not breaking as it will default to `true`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
User has an app that is extensively native iOS and the React Native section is only run way later: https://github.com/getsentry/sentry-react-native/issues/1248

## :green_heart: How did you test it?
Wrote a new test in `wrapper.ts`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Should add documentation on this option.