### PR TITLE
fix: Only set "event" type in envelope item and not the payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: pas maxBreadcrumbs to Android init
 - feat: Allow disabling native SDK initialization but still use it #1259
+- fix: Only set "event" type in envelope item and not the payload #1271
 
 ## 2.1.0
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -33,7 +33,6 @@ export const NATIVE = {
 
     const payload = {
       ...event,
-      type: event.type ?? 'event',
       message: {
         message: event.message,
       },
@@ -54,7 +53,7 @@ export const NATIVE = {
       const item = {
         content_type: "application/json",
         length,
-        type: payload.type,
+        type: payload.type ?? "event",
       };
 
       const itemString = JSON.stringify(item);

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -139,7 +139,6 @@ describe("Tests Native Wrapper", () => {
         },
         payload: {
           ...event,
-          type: "event",
           message: {
             message: event.message,
           },
@@ -173,7 +172,6 @@ describe("Tests Native Wrapper", () => {
         },
         payload: {
           ...event,
-          type: "event",
           message: {
             message: event.message,
           },
@@ -215,7 +213,6 @@ describe("Tests Native Wrapper", () => {
       });
       const payloadString = JSON.stringify({
         ...event,
-        type: "event",
         message: {
           message: event.message,
         },
@@ -245,7 +242,6 @@ describe("Tests Native Wrapper", () => {
         message: {
           message: event.message,
         },
-        type: "event",
       });
       const header = JSON.stringify({
         event_id: event.event_id,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Don't set `type: "event"` on the envelope payload if it is `undefined`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`"event"` is not a valid value for `type` in the envelope payload: https://github.com/getsentry/sentry-data-schemas/blob/main/relay/event.schema.json#L1194-L1206

Fixes #1174 where events sent from android have an `unknown` key.

## :green_heart: How did you test it?
Changed the existing tests to expect the payload type to be empty if none is present in the event.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
