### PR TITLE
fix: Fix parseErrorStack that only takes string in DebugSymbolicator event processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: pas maxBreadcrumbs to Android init
 - feat: Allow disabling native SDK initialization but still use it #1259
+- fix: Fix parseErrorStack that only takes string in DebugSymbolicator event processor #1274
 
 ## 2.1.0
 

--- a/src/js/integrations/debugsymbolicator.ts
+++ b/src/js/integrations/debugsymbolicator.ts
@@ -57,7 +57,14 @@ export class DebugSymbolicator implements Integration {
 
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const parseErrorStack = require("react-native/Libraries/Core/Devtools/parseErrorStack");
-      const stack = parseErrorStack(reactError);
+
+      let stack;
+      try {
+        stack = parseErrorStack(reactError);
+      } catch (e) {
+        // In RN 0.64 `parseErrorStack` now only takes a string
+        stack = parseErrorStack(reactError.stack);
+      }
 
       // Ideally this should go into contexts but android sdk doesn't support it
       event.extra = {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
If `parseErrorStack` throws when passed the full error object we catch it and try again but only with the stack.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In 0.64-rc.1 and above, the internal React Native method that we use to parse error stacks while in debug mode with `DebugSymbolicator` was changed to only accept strings: https://github.com/facebook/react-native/commit/9edfc43aad2f68be8a37c916779681cd9ad13fee

Sending any event from the SDK will throw an error: https://github.com/getsentry/sentry-react-native/issues/1262#issuecomment-754047470

## :green_heart: How did you test it?
Working on iOS simulator running React Native 0.64-rc.2 with hermes enabled.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes
