### PR TITLE
ref: Rename shouldInitializeNativeSdk to autoInitializeNativeSdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: pas maxBreadcrumbs to Android init
 - feat: Allow disabling native SDK initialization but still use it #1259
+- ref: Rename shouldInitializeNativeSdk to autoInitializeNativeSdk #1275
 
 ## 2.1.0
 

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -31,7 +31,7 @@ export interface ReactNativeOptions extends BrowserOptions {
    *
    * @default true
    */
-  shouldInitializeNativeSdk?: boolean;
+  autoInitializeNativeSdk?: boolean;
 
   /** Maximum time to wait to drain the request queue, before the process is allowed to exit. */
   shutdownTimeout?: number;

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -23,7 +23,7 @@ const DEFAULT_OPTIONS: ReactNativeOptions = {
   enableNative: true,
   enableNativeCrashHandling: true,
   enableNativeNagger: true,
-  shouldInitializeNativeSdk: true,
+  autoInitializeNativeSdk: true,
 };
 
 /**

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -82,11 +82,11 @@ export const NATIVE = {
   async startWithOptions(_options: ReactNativeOptions): Promise<boolean> {
     const options = {
       enableNative: true,
-      shouldInitializeNativeSdk: true,
+      autoInitializeNativeSdk: true,
       ..._options,
     };
 
-    if (!options.shouldInitializeNativeSdk) {
+    if (!options.autoInitializeNativeSdk) {
       if (options.enableNativeNagger) {
         logger.warn("Note: Native Sentry SDK was not initialized.");
       }

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -93,7 +93,7 @@ describe("Tests Native Wrapper", () => {
       );
     });
 
-    test("does not initialize with shouldInitializeNativeSdk: false", async () => {
+    test("does not initialize with autoInitializeNativeSdk: false", async () => {
       const RN = require("react-native");
 
       RN.NativeModules.RNSentry.startWithOptions = jest.fn();
@@ -102,7 +102,7 @@ describe("Tests Native Wrapper", () => {
       await NATIVE.startWithOptions({
         dsn: "test",
         enableNative: true,
-        shouldInitializeNativeSdk: false,
+        autoInitializeNativeSdk: false,
       });
 
       expect(RN.NativeModules.RNSentry.startWithOptions).not.toBeCalled();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Renames the option introduced in #1259 from `shouldInitializeNativeSdk` to `autoInitializeNativeSdk`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-react-native/issues/1273#issuecomment-755766836

## :green_heart: How did you test it?
Updated the existing test to test for `autoInitializeNativeSdk`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes (Not breaking as we never released the former)