### PR TITLE
fix: Add fallback envelope item type to iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - ref: Rename shouldInitializeNativeSdk to autoInitializeNativeSdk #1275
 - fix: Fix parseErrorStack that only takes string in DebugSymbolicator event processor #1274
 - fix: Only set "event" type in envelope item and not the payload #1271
+- fix: Add fallback envelope item type to iOS. #1283
 
 ## 2.1.0
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -134,7 +134,13 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSDictionary * _Nonnull)envelopeDict
             reject(@"SentryReactNative", @"Cannot serialize event", error);
         }
 
-        SentryEnvelopeItemHeader *envelopeItemHeader = [[SentryEnvelopeItemHeader alloc] initWithType:envelopeDict[@"payload"][@"type"] length:envelopeItemData.length];
+        NSString *itemType = envelopeDict[@"payload"][@"type"];
+        if (itemType == nil) {
+            // Default to event type.
+            itemType = @"event";
+        }
+
+        SentryEnvelopeItemHeader *envelopeItemHeader = [[SentryEnvelopeItemHeader alloc] initWithType:itemType length:envelopeItemData.length];
         SentryEnvelopeItem *envelopeItem = [[SentryEnvelopeItem alloc] initWithHeader:envelopeItemHeader data:envelopeItemData];
 
         SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader singleItem:envelopeItem];


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Add a default envelope item type to be "event" on the iOS side of the native bridge.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When we removed the item type from the payload in this PR: https://github.com/getsentry/sentry-react-native/pull/1271 for Android, this caused a regression in iOS where envelopes were discarded. This is because on iOS we took the item type from the payload which is different than on Android.

## :green_heart: How did you test it?
Ran iOS simulator and passing e2e tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
