### PR TITLE
build(android): Bump `sentry-android` to 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-- build(android): Bump `sentry-android` to 3.2.1
+- build(android): Bump `sentry-android` to 3.2.1 #1296
 ## 2.1.0
 
 - feat: Include @sentry/tracing and expose startTransaction #1167

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+- build(android): Bump `sentry-android` to 3.2.1
 ## 2.1.0
 
 - feat: Include @sentry/tracing and expose startTransaction #1167

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:3.2.0'
+    api 'io.sentry:sentry-android:3.2.1'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Bump `sentry-android` to version 3.2.1

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Includes this fix https://github.com/getsentry/sentry-java/pull/1064 that pertains to RN on Android where it includes an exception from the `FileObserver.java` which is where the SDK reads the envelope and not relevant to the user event.

## :green_heart: How did you test it?

Tested on Android emulator, sent an event, made sure that the above issue was fixed.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
