### PR TITLE
fix: Handle auto session tracking start on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - build: Bump JS dependencies to 5.30.0 #1282
 - fix: Add fallback envelope item type to iOS. #1283
 - feat: Auto performance tracing with XHR/fetch, and routing instrumentation #1230
+- build(ios): Bump sentry-cocoa to 6.1.4 #1308
+- fix: Handle auto session tracking start on iOS #1308
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- build(ios): Bump sentry-cocoa to 6.1.4 #1308
+- fix: Handle auto session tracking start on iOS #1308
+
 ## 2.2.0-beta.0
 
 - build(ios): Bump sentry-cocoa to 6.1.3 #1293
@@ -13,8 +16,6 @@
 - build: Bump JS dependencies to 5.30.0 #1282
 - fix: Add fallback envelope item type to iOS. #1283
 - feat: Auto performance tracing with XHR/fetch, and routing instrumentation #1230
-- build(ios): Bump sentry-cocoa to 6.1.4 #1308
-- fix: Handle auto session tracking start on iOS #1308
 
 ## 2.1.1
 

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'Sentry', '6.1.3'
+  s.dependency 'Sentry', '6.1.4'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -8,12 +8,11 @@
 
 #import <Sentry/Sentry.h>
 
-@interface RNSentry()
+@implementation RNSentry {
+   bool sentHybridSdkDidBecomeActive;
+}
 
-@end
 
-
-@implementation RNSentry
 
 - (dispatch_queue_t)methodQueue
 {
@@ -65,6 +64,15 @@ RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *_Nonnull)options
         return;
     }
     [SentrySDK startWithOptionsObject:sentryOptions];
+
+    // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.
+    if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:@"SentryHybridSdkDidBecomeActive"
+            object:nil];
+
+        sentHybridSdkDidBecomeActive = true;
+    }
 
     resolve(@YES);
 }

--- a/sample/ios/Podfile.lock
+++ b/sample/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - CocoaAsyncSocket (7.6.4)
+  - CocoaAsyncSocket (7.6.5)
   - CocoaLibEvent (1.0.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.63.3)
@@ -306,12 +306,12 @@ PODS:
     - React
   - RNScreens (2.10.1):
     - React
-  - RNSentry (2.1.0):
+  - RNSentry (2.2.0-beta.0):
     - React-Core
-    - Sentry (= 6.1.3)
-  - Sentry (6.1.3):
-    - Sentry/Core (= 6.1.3)
-  - Sentry/Core (6.1.3)
+    - Sentry (= 6.1.4)
+  - Sentry (6.1.4):
+    - Sentry/Core (= 6.1.4)
+  - Sentry/Core (6.1.4)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -455,7 +455,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
+  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 878b59e31113e289e275165efbe4b54fa614d43d
@@ -495,11 +495,11 @@ SPEC CHECKSUMS:
   RNGestureHandler: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
   RNReanimated: 89f5e0a04d1dd52fbf27e7e7030d8f80a646a3fc
   RNScreens: b748efec66e095134c7166ca333b628cd7e6f3e2
-  RNSentry: 5674057510cde1582063fd4fa150194ba5042e92
-  Sentry: 5b741b3c932fa293c28ba6a6f510b72bd63c9993
+  RNSentry: b894f70e20c276e175d8083aa424d2b5fd2d4128
+  Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: 9d75e167307300a63add2b53a03e1d19bb02cd35
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.9.3


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Posts a `SentryHybridSdkDidBecomeActive` notification once if the app is active, on iOS SDK init to start a session on iOS.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-react-native/issues/1292

## :green_heart: How did you test it?
Tested on sample app and verified that sessions get sent on initial app launch.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
