### PR TITLE
fix: React Navigation Instrumentation starts initial transaction before navigator mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - build(ios): Bump sentry-cocoa to 6.1.4 #1308
 - fix: Handle auto session tracking start on iOS #1308
 - feat: Use beforeNavigate in routing instrumentation to match behavior on JS #1313
+- fix: React Navigation Instrumentation starts initial transaction before navigator mount #1315
 
 ## 2.2.0-beta.0
 

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -104,7 +104,7 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
    */
   private _handleInitialState(): void {
     this._latestTransaction = this.onRouteWillChange(
-      BLANK_TRANSACTION_CONTEXT_V4
+      INITIAL_TRANSACTION_CONTEXT_V4
     );
 
     // We set this to true so when registerAppContainer is called, the transaction gets updated with the actual route data
@@ -261,8 +261,8 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
   };
 }
 
-const BLANK_TRANSACTION_CONTEXT_V4 = {
-  name: "Route Change",
+const INITIAL_TRANSACTION_CONTEXT_V4 = {
+  name: "App Launch",
   op: "navigation",
   tags: {
     "routing.instrumentation":
@@ -271,4 +271,4 @@ const BLANK_TRANSACTION_CONTEXT_V4 = {
   data: {},
 };
 
-export { ReactNavigationV4Instrumentation, BLANK_TRANSACTION_CONTEXT_V4 };
+export { ReactNavigationV4Instrumentation, INITIAL_TRANSACTION_CONTEXT_V4 };

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -72,7 +72,9 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
    * and gets the route information from there, @see _onStateChange
    */
   private _onDispatch(): void {
-    this._latestTransaction = this.onRouteWillChange(BLANK_TRANSACTION_CONTEXT);
+    this._latestTransaction = this.onRouteWillChange(
+      BLANK_TRANSACTION_CONTEXT_V5
+    );
 
     this._stateChangeTimeout = setTimeout(
       this._discardLatestTransaction.bind(this),
@@ -93,7 +95,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
         this._latestTransaction &&
         (!previousRoute || previousRoute.key !== route.key)
       ) {
-        const originalContext = this._latestTransaction.toContext() as typeof BLANK_TRANSACTION_CONTEXT;
+        const originalContext = this._latestTransaction.toContext() as typeof BLANK_TRANSACTION_CONTEXT_V5;
         const routeHasBeenSeen = this._recentRouteKeys.includes(route.key);
 
         const updatedContext: ReactNavigationTransactionContext = {
@@ -176,7 +178,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
   }
 }
 
-export const BLANK_TRANSACTION_CONTEXT = {
+export const BLANK_TRANSACTION_CONTEXT_V5 = {
   name: "Route Change",
   op: "navigation",
   tags: {

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -3,7 +3,7 @@ import { Transaction } from "@sentry/tracing";
 
 import {
   AppContainerInstance,
-  BLANK_TRANSACTION_CONTEXT_V4,
+  INITIAL_TRANSACTION_CONTEXT_V4,
   NavigationRouteV4,
   NavigationStateV4,
   ReactNavigationV4Instrumentation,
@@ -18,7 +18,7 @@ const initialRoute = {
 };
 
 const getMockTransaction = () => {
-  const transaction = new Transaction(BLANK_TRANSACTION_CONTEXT_V4);
+  const transaction = new Transaction(INITIAL_TRANSACTION_CONTEXT_V4);
 
   transaction.sampled = false;
 
@@ -106,7 +106,7 @@ describe("ReactNavigationV4Instrumentation", () => {
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(instrumentation.onRouteWillChange).toHaveBeenLastCalledWith(
-      BLANK_TRANSACTION_CONTEXT_V4
+      INITIAL_TRANSACTION_CONTEXT_V4
     );
 
     expect(mockTransaction.name).toBe(firstRoute.routeName);

--- a/test/tracing/reactnavigationv5.test.ts
+++ b/test/tracing/reactnavigationv5.test.ts
@@ -2,7 +2,7 @@
 import { Transaction } from "@sentry/tracing";
 
 import {
-  BLANK_TRANSACTION_CONTEXT,
+  BLANK_TRANSACTION_CONTEXT_V5,
   NavigationRouteV5,
   ReactNavigationV5Instrumentation,
 } from "../../src/js/tracing/reactnavigationv5";
@@ -24,7 +24,7 @@ class MockNavigationContainer {
 }
 
 const getMockTransaction = () => {
-  const transaction = new Transaction(BLANK_TRANSACTION_CONTEXT);
+  const transaction = new Transaction(BLANK_TRANSACTION_CONTEXT_V5);
 
   transaction.sampled = false;
 
@@ -52,7 +52,7 @@ describe("ReactNavigationV5Instrumentation", () => {
 
     expect(mockTransaction.name).toBe(dummyRoute.name);
     expect(mockTransaction.tags).toStrictEqual({
-      ...BLANK_TRANSACTION_CONTEXT.tags,
+      ...BLANK_TRANSACTION_CONTEXT_V5.tags,
       "routing.route.name": dummyRoute.name,
     });
     expect(mockTransaction.data).toStrictEqual({
@@ -107,7 +107,7 @@ describe("ReactNavigationV5Instrumentation", () => {
 
         expect(mockTransaction.name).toBe(route.name);
         expect(mockTransaction.tags).toStrictEqual({
-          ...BLANK_TRANSACTION_CONTEXT.tags,
+          ...BLANK_TRANSACTION_CONTEXT_V5.tags,
           "routing.route.name": route.name,
         });
         expect(mockTransaction.data).toStrictEqual({
@@ -210,10 +210,10 @@ describe("ReactNavigationV5Instrumentation", () => {
       setTimeout(() => {
         expect(mockTransaction.sampled).toBe(false);
         expect(mockTransaction.name).toStrictEqual(
-          BLANK_TRANSACTION_CONTEXT.name
+          BLANK_TRANSACTION_CONTEXT_V5.name
         );
         expect(mockTransaction.tags).toStrictEqual(
-          BLANK_TRANSACTION_CONTEXT.tags
+          BLANK_TRANSACTION_CONTEXT_V5.tags
         );
         expect(mockTransaction.data).toStrictEqual({});
         resolve();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

On V5, the initial blank transaction is now set on the routing instrumentation register instead of the navigator mount, this way it gets set on the scope before the app component is mounted. Then, once the navigator is mounted, `beforeNavigate` is called, and the transaction on the scope is updated with the new context.

On V4, the same strategy is adopted as V5. This means that now V4 has the option of updating a transaction on the scope instead of just setting a new one. For V4 however, this behavior is only used on the initial transaction and nothing is changed by this PR for subsequent route changes.

```js
// Root App component

React.useEffect(() => {
    // This gets called before the next useEffect block, however, the transaction will already exist
    const transaction = Sentry.getCurrentHub().getScope().getTransaction(); // defined

    console.log(`Transaction exists: ${!!transaction}`); // "Transaction exists: true" <- Fixed from prior
}, []);

React.useEffect(() => {
    reactNavigationInstrumentation.registerNavigationContainer(navigation);
}, []);
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1314 

## :green_heart: How did you test it?
Updated V4 tests to account for these changes. Ran V5 on simulator, needs testing for V4.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
