### PR TITLE
meta: Disable changelog requirement on Danger for PRs created by bots

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -36,8 +36,9 @@ async function containsChangelog(path) {
 async function checkChangelog() {
   const skipChangelog =
     danger.github && (danger.github.pr.body + "").includes("#skip-changelog");
+  const isBot = danger.github && danger.github.pr.user.type === "Bot";
 
-  if (skipChangelog) {
+  if (skipChangelog || isBot) {
     return;
   }
 


### PR DESCRIPTION
This way we stop getting spammed by failed CI on every dependabot PR due to no changelog.

Reference: https://danger.systems/js/reference.html#GitHubUser

#skip-changelog
