### PR TITLE
fix(performance): Handle edge cases in React Navigation routing instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(performance): Handle edge cases in React Navigation routing instrumentation.
+- fix(performance): Handle edge cases in React Navigation routing instrumentation. #1365
 
 ## 2.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix(performance): Handle edge cases in React Navigation routing instrumentation.
+
 ## 2.2.2
 
 - fix: Fix unhandled promise rejections not being tracked #1367

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -60,15 +60,19 @@ Sentry.init({
 const Stack = createStackNavigator();
 
 const App = () => {
-  const navigation = React.createRef<NavigationContainerRef>();
+  const navigation = React.useRef<NavigationContainerRef>();
 
-  React.useEffect(() => {
-    reactNavigationV5Instrumentation.registerNavigationContainer(navigation);
-  }, []);
+  React.useEffect(() => {}, []);
 
   return (
     <Provider store={store}>
-      <NavigationContainer ref={navigation}>
+      <NavigationContainer
+        ref={navigation}
+        onReady={() => {
+          reactNavigationV5Instrumentation.registerNavigationContainer(
+            navigation,
+          );
+        }}>
         <Stack.Navigator>
           <Stack.Screen name="Home" component={HomeScreen} />
           <Stack.Screen name="Tracker" component={TrackerScreen} />

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -62,8 +62,6 @@ const Stack = createStackNavigator();
 const App = () => {
   const navigation = React.useRef<NavigationContainerRef>();
 
-  React.useEffect(() => {}, []);
-
   return (
     <Provider store={store}>
       <NavigationContainer

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -45,22 +45,9 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
 
   private _latestRoute?: NavigationRouteV5;
   private _latestTransaction?: TransactionType;
-  private _shouldUpdateLatestTransactionOnRef: boolean = false;
+  private _shouldUpdateLatestTransactionOnRef: boolean = true;
   private _stateChangeTimeout?: number | undefined;
   private _recentRouteKeys: string[] = [];
-
-  /**
-   * Extends by calling _handleInitialState at the end.
-   */
-  public registerRoutingInstrumentation(
-    listener: TransactionCreator,
-    beforeNavigate: BeforeNavigate
-  ): void {
-    super.registerRoutingInstrumentation(listener, beforeNavigate);
-
-    // Need to handle the initial state as the navigation container listeners will only start transactions on subsequent route changes.
-    this._handleInitialState();
-  }
 
   /**
    * Pass the ref to the navigation container to register it to the instrumentation
@@ -79,10 +66,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
       this._onStateChange.bind(this)
     );
 
-    if (this._shouldUpdateLatestTransactionOnRef) {
-      this._onStateChange();
-      this._shouldUpdateLatestTransactionOnRef = false;
-    }
+    this._handleInitialState();
   }
 
   /**
@@ -90,9 +74,12 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
    */
   private _handleInitialState(): void {
     // This will set a transaction for the initial screen.
-    this._onDispatch();
+    if (this._shouldUpdateLatestTransactionOnRef) {
+      this._onDispatch();
+      this._onStateChange();
 
-    this._shouldUpdateLatestTransactionOnRef = true;
+      this._shouldUpdateLatestTransactionOnRef = false;
+    }
   }
 
   /**

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -58,6 +58,12 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
     // We create an initial state here to ensure a transaction gets created before the first route mounts.
     if (!this._initialStateHandled) {
       this._onDispatch();
+      if (this._navigationContainer) {
+        // Navigation container already registered, just populate with route state
+        this._onStateChange();
+
+        this._initialStateHandled = true;
+      }
     }
   }
 
@@ -96,13 +102,9 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
           if (this._latestTransaction) {
             // If registerRoutingInstrumentation was called first _onDispatch has already been called
             this._onStateChange();
-          } else {
-            logger.log(
-              "[ReactNavigationV5Instrumentation] Navigation mounted before integration was setup. Initial route transaction was not created."
-            );
-          }
 
-          this._initialStateHandled = true;
+            this._initialStateHandled = true;
+          }
         }
 
         _global.__sentry_rn_v5_registered = true;

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -1,11 +1,7 @@
 import { Transaction as TransactionType } from "@sentry/types";
 import { logger } from "@sentry/utils";
 
-import { BeforeNavigate } from "./reactnativetracing";
-import {
-  RoutingInstrumentation,
-  TransactionCreator,
-} from "./routingInstrumentation";
+import { RoutingInstrumentation } from "./routingInstrumentation";
 import { ReactNavigationTransactionContext } from "./types";
 
 export interface NavigationRouteV5 {
@@ -54,19 +50,26 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
    * @param navigationContainerRef Ref to a `NavigationContainer`
    */
   public registerNavigationContainer(
-    navigationContainerRef: NavigationContainerV5Ref
+    navigationContainerRef: NavigationContainerV5Ref | NavigationContainerV5
   ): void {
-    this._navigationContainerRef = navigationContainerRef;
-    navigationContainerRef.current?.addListener(
-      "__unsafe_action__", // This action is emitted on every dispatch
-      this._onDispatch.bind(this)
-    );
-    navigationContainerRef.current?.addListener(
-      "state", // This action is emitted on every state change
-      this._onStateChange.bind(this)
-    );
+    if ("current" in navigationContainerRef) {
+      this._navigationContainerRef = navigationContainerRef;
+    } else {
+      this._navigationContainerRef.current = navigationContainerRef;
+    }
 
-    this._handleInitialState();
+    if (this._navigationContainerRef.current) {
+      this._navigationContainerRef.current.addListener(
+        "__unsafe_action__", // This action is emitted on every dispatch
+        this._onDispatch.bind(this)
+      );
+      this._navigationContainerRef.current.addListener(
+        "state", // This action is emitted on every state change
+        this._onStateChange.bind(this)
+      );
+
+      this._handleInitialState();
+    }
   }
 
   /**

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -56,19 +56,10 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
   ): void {
     super.registerRoutingInstrumentation(listener, beforeNavigate);
 
-    logger.log(
-      "[ReactNavigationV5Instrumentation] Routing Instrumentation Registered"
-    );
     // We create an initial state here to ensure a transaction gets created before the first route mounts.
     if (!this._initialStateHandled) {
-      logger.log(
-        "[ReactNavigationV5Instrumentation] Routing Instrumentation Initial Dispatch"
-      );
       this._onDispatch();
       if (this._navigationContainer) {
-        logger.log(
-          "[ReactNavigationV5Instrumentation] Routing Instrumentation Initial State Change due to navigation container set"
-        );
         // Navigation container already registered, just populate with route state
         this._onStateChange();
 
@@ -110,27 +101,26 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
 
         if (!this._initialStateHandled) {
           if (this._latestTransaction) {
-            logger.log(
-              "[ReactNavigationV5Instrumentation] Routing Instrumentation Initial State Change in registerNavigationContainer"
-            );
             // If registerRoutingInstrumentation was called first _onDispatch has already been called
             this._onStateChange();
 
             this._initialStateHandled = true;
           }
           logger.log(
-            "[ReactNavigationV5Instrumentation] Routing Instrumentation initial state has not been handled, but dispatch has not been called"
+            "[ReactNavigationV5Instrumentation] Navigation container registered, but integration has not been setup yet."
           );
         }
 
         _global.__sentry_rn_v5_registered = true;
       } else {
         logger.log(
-          "[ReactNavigationV5Instrumentation] Invalid Navigation Container Ref"
+          "[ReactNavigationV5Instrumentation] Received invalid navigation container ref!"
         );
       }
     } else {
-      logger.log("[ReactNavigationV5Instrumentation] Not registered");
+      logger.log(
+        "[ReactNavigationV5Instrumentation] Instrumentation already exists, but register has been called again, doing nothing."
+      );
     }
   }
 

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -192,16 +192,17 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
           };
         }
 
-        if (finalContext.sampled) {
+        // Note: finalContext.sampled will be false at this point only if the user sets it to be so in beforeNavigate.
+        if (finalContext.sampled === false) {
+          logger.log(
+            `[ReactNavigationV5Instrumentation] Will not send transaction "${finalContext.name}" due to beforeNavigate.`
+          );
+        } else {
           // Clear the timeout so the transaction does not get cancelled.
           if (typeof this._stateChangeTimeout !== "undefined") {
             clearTimeout(this._stateChangeTimeout);
             this._stateChangeTimeout = undefined;
           }
-        } else {
-          logger.log(
-            `[ReactNavigationV5Instrumentation] Will not send transaction "${finalContext.name}" due to beforeNavigate.`
-          );
         }
 
         this._latestTransaction.updateWithContext(finalContext);

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -118,10 +118,19 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
 
             this._initialStateHandled = true;
           }
+          logger.log(
+            "[ReactNavigationV5Instrumentation] Routing Instrumentation initial state has not been handled, but dispatch has not been called"
+          );
         }
 
         _global.__sentry_rn_v5_registered = true;
+      } else {
+        logger.log(
+          "[ReactNavigationV5Instrumentation] Invalid Navigation Container Ref"
+        );
       }
+    } else {
+      logger.log("[ReactNavigationV5Instrumentation] Not registered");
     }
   }
 

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -105,10 +105,11 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
             this._onStateChange();
 
             this._initialStateHandled = true;
+          } else {
+            logger.log(
+              "[ReactNavigationV5Instrumentation] Navigation container registered, but integration has not been setup yet."
+            );
           }
-          logger.log(
-            "[ReactNavigationV5Instrumentation] Navigation container registered, but integration has not been setup yet."
-          );
         }
 
         _global.__sentry_rn_v5_registered = true;

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -55,10 +55,20 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
     beforeNavigate: BeforeNavigate
   ): void {
     super.registerRoutingInstrumentation(listener, beforeNavigate);
+
+    logger.log(
+      "[ReactNavigationV5Instrumentation] Routing Instrumentation Registered"
+    );
     // We create an initial state here to ensure a transaction gets created before the first route mounts.
     if (!this._initialStateHandled) {
+      logger.log(
+        "[ReactNavigationV5Instrumentation] Routing Instrumentation Initial Dispatch"
+      );
       this._onDispatch();
       if (this._navigationContainer) {
+        logger.log(
+          "[ReactNavigationV5Instrumentation] Routing Instrumentation Initial State Change due to navigation container set"
+        );
         // Navigation container already registered, just populate with route state
         this._onStateChange();
 
@@ -100,6 +110,9 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
 
         if (!this._initialStateHandled) {
           if (this._latestTransaction) {
+            logger.log(
+              "[ReactNavigationV5Instrumentation] Routing Instrumentation Initial State Change in registerNavigationContainer"
+            );
             // If registerRoutingInstrumentation was called first _onDispatch has already been called
             this._onStateChange();
 

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Transaction } from "@sentry/tracing";
+import { getGlobalObject } from "@sentry/utils";
 
 import {
   AppContainerInstance,
@@ -20,7 +21,8 @@ const initialRoute = {
 const getMockTransaction = () => {
   const transaction = new Transaction(INITIAL_TRANSACTION_CONTEXT_V4);
 
-  transaction.sampled = false;
+  // Assume it's sampled
+  transaction.sampled = true;
 
   return transaction;
 };
@@ -79,6 +81,16 @@ class MockAppContainer implements AppContainerInstance {
   }
 }
 
+const _global = getGlobalObject<{
+  __sentry_rn_v4_registered?: boolean;
+}>();
+
+afterEach(() => {
+  _global.__sentry_rn_v4_registered = false;
+
+  jest.resetAllMocks();
+});
+
 describe("ReactNavigationV4Instrumentation", () => {
   test("transaction set on initialize", () => {
     const instrumentation = new ReactNavigationV4Instrumentation();
@@ -124,6 +136,7 @@ describe("ReactNavigationV4Instrumentation", () => {
       },
       previousRoute: null,
     });
+    expect(mockTransaction.sampled).toBe(true);
   });
 
   test("transaction sent on navigation", () => {
@@ -181,6 +194,8 @@ describe("ReactNavigationV4Instrumentation", () => {
         },
       },
     });
+
+    expect(mockTransaction.sampled).toBe(true);
   });
 
   test("transaction context changed with beforeNavigate", () => {
@@ -241,6 +256,8 @@ describe("ReactNavigationV4Instrumentation", () => {
       },
       sampled: false,
     });
+
+    expect(mockTransaction.sampled).toBe(false);
   });
 
   test("transaction not attached on a cancelled navigation", () => {
@@ -268,5 +285,100 @@ describe("ReactNavigationV4Instrumentation", () => {
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(instrumentation.onRouteWillChange).toHaveBeenCalledTimes(1);
+  });
+
+  describe("navigation container registration", () => {
+    test("registers navigation container object ref", () => {
+      const instrumentation = new ReactNavigationV4Instrumentation();
+      const mockTransaction = getMockTransaction();
+      instrumentation.onRouteWillChange = jest.fn(() => mockTransaction);
+
+      const tracingListener = jest.fn();
+      instrumentation.registerRoutingInstrumentation(
+        tracingListener as any,
+        (context) => context
+      );
+
+      const mockAppContainer = new MockAppContainer();
+      instrumentation.registerAppContainer({
+        current: mockAppContainer,
+      });
+
+      expect(_global.__sentry_rn_v4_registered).toBe(true);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(instrumentation.onRouteWillChange).toHaveBeenCalledTimes(1);
+      expect(mockTransaction.name).toBe(initialRoute.routeName);
+      expect(mockTransaction.sampled).toBe(true);
+    });
+
+    test("registers navigation container direct ref", () => {
+      const instrumentation = new ReactNavigationV4Instrumentation();
+      const mockTransaction = getMockTransaction();
+      instrumentation.onRouteWillChange = jest.fn(() => mockTransaction);
+
+      const tracingListener = jest.fn();
+      instrumentation.registerRoutingInstrumentation(
+        tracingListener as any,
+        (context) => context
+      );
+
+      const mockAppContainer = new MockAppContainer();
+      instrumentation.registerAppContainer(mockAppContainer);
+
+      expect(_global.__sentry_rn_v4_registered).toBe(true);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(instrumentation.onRouteWillChange).toHaveBeenCalledTimes(1);
+      expect(mockTransaction.name).toBe(initialRoute.routeName);
+      expect(mockTransaction.sampled).toBe(true);
+    });
+
+    test("does not register navigation container if there is an existing one", async () => {
+      _global.__sentry_rn_v4_registered = true;
+
+      const instrumentation = new ReactNavigationV4Instrumentation();
+      const mockTransaction = getMockTransaction();
+      instrumentation.onRouteWillChange = jest.fn(() => mockTransaction);
+
+      const tracingListener = jest.fn();
+      instrumentation.registerRoutingInstrumentation(
+        tracingListener as any,
+        (context) => context
+      );
+
+      const mockAppContainer = new MockAppContainer();
+      instrumentation.registerAppContainer(mockAppContainer);
+
+      expect(_global.__sentry_rn_v4_registered).toBe(true);
+
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(mockTransaction.sampled).toBe(false);
+          resolve();
+        }, 500);
+      });
+    });
+
+    test("works if routing instrumentation registration is after navigation registration", async () => {
+      const instrumentation = new ReactNavigationV4Instrumentation();
+
+      const mockNavigationContainer = new MockAppContainer();
+      instrumentation.registerAppContainer(mockNavigationContainer);
+
+      const mockTransaction = getMockTransaction();
+      const tracingListener = jest.fn(() => mockTransaction);
+      instrumentation.registerRoutingInstrumentation(
+        tracingListener as any,
+        (context) => context
+      );
+
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          expect(mockTransaction.sampled).toBe(true);
+          resolve();
+        }, 500);
+      });
+    });
   });
 });

--- a/test/tracing/reactnavigationv5.test.ts
+++ b/test/tracing/reactnavigationv5.test.ts
@@ -303,11 +303,8 @@ describe("ReactNavigationV5Instrumentation", () => {
       const mockNavigationContainer = new MockNavigationContainer();
       instrumentation.registerNavigationContainer(mockNavigationContainer);
 
-      const mockTransactionDummy = getMockTransaction();
-      const transactionRef = {
-        current: mockTransactionDummy,
-      };
-      const tracingListener = jest.fn(() => transactionRef.current);
+      const mockTransaction = getMockTransaction();
+      const tracingListener = jest.fn(() => mockTransaction);
       instrumentation.registerRoutingInstrumentation(
         tracingListener as any,
         (context) => context
@@ -315,7 +312,7 @@ describe("ReactNavigationV5Instrumentation", () => {
 
       await new Promise<void>((resolve) => {
         setTimeout(() => {
-          expect(mockTransactionDummy.sampled).not.toBe(false);
+          expect(mockTransaction.sampled).not.toBe(false);
           resolve();
         }, 500);
       });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
In an attempt to find causes of routing transactions not being sampled. I ended up finding multiple edge cases for routing transactions to not be sent. Below are the list and explanations for what I found. Sorry in advance that this description is especially long:

1. If the Instrumentation gets the navigation container registered before the integration’s `setupOnce` is called. So it tries to update the state of the initial route’s transaction which does not yet exist. When the integration is setup and it registers the routing instrumentation, which triggers the `_onDispatch` to be called and creates the initial blank transaction, the state is never set and the timeout to not sample is never cancelled, so the transaction ends up not being sampled.
    - **Status**: Done
    - Fix:
      - Add a `_initialStateHandled` boolean.
        - On routing instrumentation register, if the flag is false, will start a blank transaction. If an app/navigation container has already been registered, it populates with the state right away and sets it to true.
        - On app/navigation container register, if it is false and a routing instrumentation has been registered, it will populate the latest transaction and sets it to true.
2. If the fast reload feature on RN is used, and the file that the instrumentation+sdk is initialized in is reloaded, it creates a new instance of the instrumentation, so now you have multiple trying to create transactions on the same scope. As only one routing instrumentation can be registered to the `ReactNativeTracing` integration, this means the subsequent ones don't get registered. The initial one also loses the original reference to the navigation container given the method that we set it.
    - **Status**: Done
    - Fix:
        - Set a global (`__sentry_rn_v4_registered`, `__sentry_rn_v5_registered`) to ensure only one is registered at a time.
        - Don't use the passed React.useRef reference object, instead just use a direct reference to the navigator. This will not be un-set when the component containing the ref unmounts.

3. If they re-register the navigation container multiple times (such as forgetting to pass the `[]` as the second parameter to `React.useEffect` like in this [code snippet we have on the docs](https://docs.sentry.io/platforms/react-native/performance/included-instrumentation/#react-navigation-v5))
   - **Status**: Fixed by case 2's fix.
 
4. (V5) React Navigation V5 does not actually set the ref on mount if linking is enabled, will need to move the `registerNavigationContainer` call to `onReady` as per https://github.com/react-navigation/react-navigation/issues/8445#issuecomment-789126307.
   -  **Status**:  This has been done in the sample, and will need to be done in the docs as well: https://github.com/getsentry/sentry-docs/issues/3183

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1361 along with others who have reported issues to me.

## :green_heart: How did you test it?
New unit tests for both V4 and V5 that test:
1. Accepts a app/navigation container ref **object** (`{ current: NavigationContainer }`)
2. Accepts a app/navigation container direct reference.
3. Does not register a navigation container if there already exists one (`__sentry_rn_v4_registered` or `__sentry_rn_v5_registered` is true).
4. Works if the app/navigation container is registered before the tracing integration is setup.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
