### PR TITLE
fix: Fix unhandled promise rejections not being tracked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Fix unhandle promise rejections not being tracked #1367
 
 ## 2.2.1
 

--- a/sample/src/screens/EndToEndTestsScreen.tsx
+++ b/sample/src/screens/EndToEndTestsScreen.tsx
@@ -54,6 +54,15 @@ const EndToEndTestsScreen = () => {
       </Text>
       <Text
         onPress={() => {
+          new Promise(() => {
+            throw new Error('Unhandled Promise Rejection');
+          });
+        }}
+        {...getTestProps('unhandledPromiseRejection')}>
+        Unhandled Promise Rejection
+      </Text>
+      <Text
+        onPress={() => {
           Sentry.nativeCrash();
         }}>
         nativeCrash

--- a/sample/src/screens/HomeScreen.tsx
+++ b/sample/src/screens/HomeScreen.tsx
@@ -173,6 +173,15 @@ const HomeScreen = (props: Props) => {
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
+                new Promise(() => {
+                  throw new Error('Unhandled Promise Rejection');
+                });
+              }}>
+              <Text style={styles.buttonText}>Unhandled Promise Rejection</Text>
+            </TouchableOpacity>
+            <View style={styles.spacer} />
+            <TouchableOpacity
+              onPress={() => {
                 Sentry.nativeCrash();
               }}>
               <Text style={styles.buttonText}>Native Crash</Text>

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -58,7 +58,7 @@ describe('End to end tests for common events', () => {
     const element = await driver.elementByAccessibilityId('captureMessage');
     await element.click();
 
-    await driver.sleep(100);
+    await driver.sleep(300);
 
     expect(await driver.hasElementByAccessibilityId('eventId')).toBe(true);
 
@@ -81,6 +81,31 @@ describe('End to end tests for common events', () => {
     await element.click();
 
     await driver.sleep(100);
+
+    expect(await driver.hasElementByAccessibilityId('eventId')).toBe(true);
+
+    const eventIdElement = await driver.elementByAccessibilityId('eventId');
+    const eventId = await eventIdElement.text();
+
+    await driver.sleep(10000);
+
+    const sentryEvent = await fetchEvent(eventId);
+
+    expect(sentryEvent.eventID).toMatch(eventId);
+  });
+
+  test('unhandledPromiseRejection', async () => {
+    expect(
+      await driver.hasElementByAccessibilityId('unhandledPromiseRejection'),
+    ).toBe(true);
+
+    const element = await driver.elementByAccessibilityId(
+      'unhandledPromiseRejection',
+    );
+    await element.click();
+
+    // Promises needs a while to fail
+    await driver.sleep(5000);
 
     expect(await driver.hasElementByAccessibilityId('eventId')).toBe(true);
 

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -58,7 +58,7 @@ describe('End to end tests for common events', () => {
     const element = await driver.elementByAccessibilityId('captureMessage');
     await element.click();
 
-    await driver.sleep(300);
+    await driver.sleep(100);
 
     expect(await driver.hasElementByAccessibilityId('eventId')).toBe(true);
 

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -87,13 +87,21 @@ export class ReactNativeErrorHandlers implements Integration {
 
         If the global promise is the same as the imported promise (expected in RN <0.63), we do nothing.
       */
+      const _onHandle = Promise._onHandle ?? Promise._Y;
+      const _onReject = Promise._onReject ?? Promise._Z;
+
       if (
         Promise !== _global.Promise &&
-        "_Y" in _global.Promise &&
-        "_Z" in _global.Promise
+        typeof _onHandle !== "undefined" &&
+        typeof _onReject !== "undefined"
       ) {
-        _global.Promise._Y = Promise._Y;
-        _global.Promise._Z = Promise._Z;
+        if ("_onHandle" in _global.Promise && "_onReject" in _global.Promise) {
+          _global.Promise._onHandle = _onHandle;
+          _global.Promise._onReject = _onReject;
+        } else if ("_Y" in _global.Promise && "_Z" in _global.Promise) {
+          _global.Promise._Y = _onHandle;
+          _global.Promise._Z = _onReject;
+        }
       }
       /* eslint-enable
         @typescript-eslint/no-var-requires,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Because of a [version mismatch in the Promise version](https://github.com/facebook/fbjs/pull/413) used in `react-native` and `fbjs` the promise patching we perform is patching the incorrect one, so the hacky fix is to overwrite global promise's methods (if they exist).
https://github.com/getsentry/sentry-react-native/blob/b1de06bbb0d8f45e98340d3cdae02692ba63879f/src/js/integrations/reactnativeerrorhandlers.ts#L90-L105

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1077 

## :green_heart: How did you test it?
Added a new e2e test for unhandled promise rejections. Ran iOS locally but please wait for it to run CI on this PR to confirm.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
We should add a matrix to our e2e CI to test on multiple react native versions as although the code block shown in the description is very defensive to prevent issues, we should still have a way to make sure.