### PR TITLE
feat(performance): Option to set route change timeout in routing instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix(performance): Handle edge cases in React Navigation routing instrumentation. #1365
 - build(android): Bump sentry-android to 4.3.0 #1373
+- feat(performance): Option to set route change timeout in routing instrumentation #1370
 
 ## 2.2.2
 

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -20,7 +20,11 @@ import {store} from './reduxApp';
 import {version as packageVersion} from '../../package.json';
 import {SENTRY_INTERNAL_DSN} from './dsn';
 
-const reactNavigationV5Instrumentation = new Sentry.ReactNavigationV5Instrumentation();
+const reactNavigationV5Instrumentation = new Sentry.ReactNavigationV5Instrumentation(
+  {
+    routeChangeTimeoutMs: 500, // How long it will wait for the route change to complete. Default is 1000ms
+  },
+);
 
 Sentry.init({
   // Replace the example DSN below with your own DSN:

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -41,7 +41,16 @@ interface AppContainerRef {
   current: AppContainerInstance | null;
 }
 
-const STATE_CHANGE_TIMEOUT_DURATION = 200;
+interface ReactNavigationV4Options {
+  /**
+   * The time the transaction will wait for route to mount before it is discarded.
+   */
+  routeChangeTimeoutMs: number;
+}
+
+const defaultOptions: ReactNavigationV4Options = {
+  routeChangeTimeoutMs: 1000,
+};
 
 /**
  * Instrumentation for React-Navigation V4.
@@ -60,6 +69,17 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
   private _latestTransaction?: Transaction;
   private _initialStateHandled: boolean = false;
   private _stateChangeTimeout?: number | undefined;
+
+  private _options: ReactNavigationV4Options;
+
+  constructor(options: Partial<ReactNavigationV4Options> = {}) {
+    super();
+
+    this._options = {
+      ...defaultOptions,
+      ...options,
+    };
+  }
 
   /**
    * Extends by calling _handleInitialState at the end.
@@ -82,7 +102,7 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
       } else {
         this._stateChangeTimeout = setTimeout(
           this._discardLatestTransaction.bind(this),
-          STATE_CHANGE_TIMEOUT_DURATION
+          this._options.routeChangeTimeoutMs
         );
       }
     }

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -24,7 +24,16 @@ type NavigationContainerV5Ref = {
   current: NavigationContainerV5 | null;
 };
 
-const STATE_CHANGE_TIMEOUT_DURATION = 200;
+interface ReactNavigationV5Options {
+  /**
+   * The time the transaction will wait for route to mount before it is discarded.
+   */
+  routeChangeTimeoutMs: number;
+}
+
+const defaultOptions: ReactNavigationV5Options = {
+  routeChangeTimeoutMs: 1000,
+};
 
 /**
  * Instrumentation for React-Navigation V5. See docs or sample app for usage.
@@ -46,6 +55,17 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
   private _initialStateHandled: boolean = false;
   private _stateChangeTimeout?: number | undefined;
   private _recentRouteKeys: string[] = [];
+
+  private _options: ReactNavigationV5Options;
+
+  constructor(options: Partial<ReactNavigationV5Options> = {}) {
+    super();
+
+    this._options = {
+      ...defaultOptions,
+      ...options,
+    };
+  }
 
   /**
    * Extends by calling _handleInitialState at the end.
@@ -137,7 +157,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
 
     this._stateChangeTimeout = setTimeout(
       this._discardLatestTransaction.bind(this),
-      STATE_CHANGE_TIMEOUT_DURATION
+      this._options.routeChangeTimeoutMs
     );
   }
 

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -356,7 +356,7 @@ describe("ReactNavigationV4Instrumentation", () => {
         setTimeout(() => {
           expect(mockTransaction.sampled).toBe(false);
           resolve();
-        }, 500);
+        }, 1100);
       });
     });
 
@@ -378,6 +378,66 @@ describe("ReactNavigationV4Instrumentation", () => {
           expect(mockTransaction.sampled).toBe(true);
           resolve();
         }, 500);
+      });
+    });
+  });
+
+  describe("options", () => {
+    test("waits until routeChangeTimeoutMs", async () => {
+      const instrumentation = new ReactNavigationV4Instrumentation({
+        routeChangeTimeoutMs: 200,
+      });
+
+      const mockTransaction = getMockTransaction();
+      const tracingListener = jest.fn(() => mockTransaction);
+      instrumentation.registerRoutingInstrumentation(
+        tracingListener as any,
+        (context) => context
+      );
+
+      const mockNavigationContainerRef = {
+        current: new MockAppContainer(),
+      };
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          instrumentation.registerAppContainer(
+            mockNavigationContainerRef as any
+          );
+
+          expect(mockTransaction.sampled).toBe(true);
+          expect(mockTransaction.name).toBe(initialRoute.routeName);
+
+          resolve();
+        }, 190);
+      });
+    });
+
+    test("discards if after routeChangeTimeoutMs", async () => {
+      const instrumentation = new ReactNavigationV4Instrumentation({
+        routeChangeTimeoutMs: 200,
+      });
+
+      const mockTransaction = getMockTransaction();
+      const tracingListener = jest.fn(() => mockTransaction);
+      instrumentation.registerRoutingInstrumentation(
+        tracingListener as any,
+        (context) => context
+      );
+
+      const mockNavigationContainerRef = {
+        current: new MockAppContainer(),
+      };
+
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          instrumentation.registerAppContainer(
+            mockNavigationContainerRef as any
+          );
+
+          expect(mockTransaction.sampled).toBe(false);
+          resolve();
+        }, 210);
       });
     });
   });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds the ability to set the timeout duration where a routing transaction is considered "discarded". The default timeout duration is now set to 1000ms.

This stems from an issue of users having unperformant navigation routes that take longer than the old default of 200ms getting their valid navigation transactions discarded. It makes sense as you're supposed to measure the performance of these route changes.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1369 and #1361 

## :green_heart: How did you test it?
Adds test for both V4 and V5.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
