### PR TITLE
fix(performance): remove @sentry/wizard dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- fix(performance): remove @sentry/wizard dependency
 
 ## 2.3.0
 

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "@sentry/react": "6.2.1",
     "@sentry/tracing": "6.2.1",
     "@sentry/types": "6.2.1",
-    "@sentry/utils": "6.2.1",
-    "@sentry/wizard": "^1.2.2"
+    "@sentry/utils": "6.2.1"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "6.2.1",
@@ -72,8 +71,8 @@
   },
   "rnpm": {
     "commands": {
-      "postlink": "node node_modules/@sentry/wizard/dist/bin.js -i reactNative -p ios android",
-      "postunlink": "node node_modules/@sentry/wizard/dist/bin.js -i reactNative -p ios android --uninstall"
+      "postlink": "npx @sentry/wizard -i reactNative -p ios android",
+      "postunlink": "npx @sentry/wizard -i reactNative -p ios android --uninstall"
     },
     "android": {
       "packageInstance": "new RNSentryPackage()"

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -10,9 +10,9 @@ module.exports = {
     },
     hooks: {
       postlink:
-        "node node_modules/@sentry/wizard/dist/bin.js -i reactNative -p ios android",
+        "npx @sentry/wizard -i reactNative -p ios android",
       postunlink:
-        "node node_modules/@sentry/wizard/dist/bin.js -i reactNative -p ios android --uninstall"
+        "npx @sentry/wizard -i reactNative -p ios android --uninstall"
     }
   }
 };


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x ] Refactoring


## :scroll: Description
fix(performance): remove @sentry/wizard dependencyfix(performance): remove @sentry/wizard dependency
Note: this *could* break projects that required `@sentry/wizard` or `@sentry/cli` and got them via this project (transitive dependency). These projects should add  `@sentry/wizard` or `@sentry/cli` as direct dependencies.

## :bulb: Motivation and Context
@sentry/wizard is redundant and currently brings in @sentri/cli which takes ~37mb (see below)
![image](https://user-images.githubusercontent.com/3373954/110809462-92cf7080-828d-11eb-86f6-60bb1e3a25bf.png)


## :green_heart: How did you test it?
Tested in our (Wix) app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
I recommend to bump up the major as this could be considered as a breaking change (see description)
Merge :) 🙏 