### PR TITLE
Prevent native crash by choosing release info from Sentry.init before…

### DIFF
--- a/src/js/integrations/release.ts
+++ b/src/js/integrations/release.ts
@@ -24,16 +24,6 @@ export class Release implements Integration {
         return event;
       }
 
-      try {
-        const release = await NATIVE.fetchRelease();
-        if (release) {
-          event.release = `${release.id}@${release.version}+${release.build}`;
-          event.dist = `${release.build}`;
-        }
-      } catch (_Oo) {
-        // Something went wrong, we just continue
-      }
-
       const options = getCurrentHub().getClient()?.getOptions();
 
       /*
@@ -50,6 +40,20 @@ export class Release implements Integration {
         event.dist = `${event.extra.__sentry_dist}`;
       } else if (typeof options?.dist === "string") {
         event.dist = options.dist;
+      }
+
+      if (event.release && event.dist) {
+        return event;
+      }
+
+      try {
+        const release = await NATIVE.fetchRelease();
+        if (release) {
+          event.release = `${release.id}@${release.version}+${release.build}`;
+          event.dist = `${release.build}`;
+        }
+      } catch (_Oo) {
+        // Something went wrong, we just continue
       }
 
       return event;


### PR DESCRIPTION
… native build settings (plist/gradle)

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ X] Refactoring


## :scroll: Description
Reverse order of preference for selection of build version and build number. Prefer the values passed into Sentry.init() over those set in Info.plist and/or build.gradle.


## :bulb: Motivation and Context
When using environment variables in Info.plist and build.gradle Sentry attempts to use the env variable placeholder text before it checks to see if Sentry.init() sets `release` and `dist`. Using the placeholder text raises a native exception resulting in a hard app crash. The native module for iOS is not rejecting when the when it fails to read from a dict. This change allows the "stronger" binding (via source) to be preferred over the externally defined values in build settings files.


## :green_heart: How did you test it?
Execution in a production app.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ X] All tests passing
- [ X] No breaking changes

## :crystal_ball: Next steps
