### PR TITLE
feat: Add onReady callback that gets called after Native SDK initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: Add onReady callback that gets called after Native SDK initialization #1406
+
 ## 2.3.0
 
 - feat: Re-export Profiler and useProfiler from @sentry/react #1372

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: Add onReady callback that gets called after Native SDK initialization #1406
+- feat: Add onReady callback that gets called after Native SDK init is called #1406
 
 ## 2.3.0
 

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -34,6 +34,13 @@ Sentry.init({
     console.log('Event beforeSend:', e);
     return e;
   },
+  // This will be called with a boolean `nativeDidInitialize` when the native SDK has been contacted.
+  onNativeReady: ({nativeDidInitialize}) => {
+    console.log(
+      'onReady called with nativeDidInitialize:',
+      nativeDidInitialize,
+    );
+  },
   maxBreadcrumbs: 150, // Extend from the default 100 breadcrumbs.
   integrations: [
     new Sentry.ReactNativeTracing({

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -35,7 +35,7 @@ Sentry.init({
     return e;
   },
   // This will be called with a boolean `nativeDidInitialize` when the native SDK has been contacted.
-  onNativeReady: ({nativeDidInitialize}) => {
+  onReady: ({nativeDidInitialize}) => {
     console.log(
       'onReady called with nativeDidInitialize:',
       nativeDidInitialize,

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -34,12 +34,9 @@ Sentry.init({
     console.log('Event beforeSend:', e);
     return e;
   },
-  // This will be called with a boolean `nativeDidInitialize` when the native SDK has been contacted.
-  onReady: ({nativeDidInitialize}) => {
-    console.log(
-      'onReady called with nativeDidInitialize:',
-      nativeDidInitialize,
-    );
+  // This will be called with a boolean `didCallNativeInit` when the native SDK has been contacted.
+  onReady: ({didCallNativeInit}) => {
+    console.log('onReady called with didCallNativeInit:', didCallNativeInit);
   },
   maxBreadcrumbs: 150, // Extend from the default 100 breadcrumbs.
   integrations: [

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -102,16 +102,20 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
    * Starts native client with dsn and options
    */
   private async _startWithOptions(): Promise<void> {
-    try {
-      const nativeDidInitialize = await NATIVE.startWithOptions(this._options);
-      NATIVE.setLogLevel(this._options.debug ? 2 : 1);
+    let nativeDidInitialize = false;
 
-      this._options.onReady?.({ nativeDidInitialize });
+    try {
+      nativeDidInitialize = await NATIVE.startWithOptions(this._options);
+      NATIVE.setLogLevel(this._options.debug ? 2 : 1);
     } catch (_) {
       this._showCannotConnectDialog();
 
       this._options.onReady?.({ nativeDidInitialize: false });
+
+      return;
     }
+
+    this._options.onReady?.({ nativeDidInitialize });
   }
 
   /**

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -106,11 +106,11 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
       const nativeDidInitialize = await NATIVE.startWithOptions(this._options);
       NATIVE.setLogLevel(this._options.debug ? 2 : 1);
 
-      this._options.onNativeReady?.({ nativeDidInitialize });
+      this._options.onReady?.({ nativeDidInitialize });
     } catch (_) {
       this._showCannotConnectDialog();
 
-      this._options.onNativeReady?.({ nativeDidInitialize: false });
+      this._options.onReady?.({ nativeDidInitialize: false });
     }
   }
 

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -102,20 +102,20 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
    * Starts native client with dsn and options
    */
   private async _startWithOptions(): Promise<void> {
-    let nativeDidInitialize = false;
+    let didCallNativeInit = false;
 
     try {
-      nativeDidInitialize = await NATIVE.startWithOptions(this._options);
+      didCallNativeInit = await NATIVE.startWithOptions(this._options);
       NATIVE.setLogLevel(this._options.debug ? 2 : 1);
     } catch (_) {
       this._showCannotConnectDialog();
 
-      this._options.onReady?.({ nativeDidInitialize: false });
+      this._options.onReady?.({ didCallNativeInit: false });
 
       return;
     }
 
-    this._options.onReady?.({ nativeDidInitialize });
+    this._options.onReady?.({ didCallNativeInit });
   }
 
   /**

--- a/src/js/backend.ts
+++ b/src/js/backend.ts
@@ -103,10 +103,14 @@ export class ReactNativeBackend extends BaseBackend<BrowserOptions> {
    */
   private async _startWithOptions(): Promise<void> {
     try {
-      await NATIVE.startWithOptions(this._options);
+      const nativeDidInitialize = await NATIVE.startWithOptions(this._options);
       NATIVE.setLogLevel(this._options.debug ? 2 : 1);
+
+      this._options.onNativeReady?.({ nativeDidInitialize });
     } catch (_) {
       this._showCannotConnectDialog();
+
+      this._options.onNativeReady?.({ nativeDidInitialize: false });
     }
   }
 

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -56,6 +56,6 @@ export interface ReactNativeOptions extends BrowserOptions {
    */
   onReady?: (response: {
     /** `true` if the native SDK has been initialized, `false` otherwise.  */
-    nativeDidInitialize: boolean;
+    didCallNativeInit: boolean;
   }) => void;
 }

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -50,4 +50,12 @@ export interface ReactNativeOptions extends BrowserOptions {
 
   /** When enabled, all the threads are automatically attached to all logged events on Android */
   attachThreads?: boolean;
+
+  /**
+   * Callback that is called after the RN SDK on the JS Layer has made contact with the Native Layer.
+   */
+  onNativeReady?: (response: {
+    /** `true` if the native SDK has been initialized, `false` otherwise.  */
+    nativeDidInitialize: boolean;
+  }) => void;
 }

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -54,7 +54,7 @@ export interface ReactNativeOptions extends BrowserOptions {
   /**
    * Callback that is called after the RN SDK on the JS Layer has made contact with the Native Layer.
    */
-  onNativeReady?: (response: {
+  onReady?: (response: {
     /** `true` if the native SDK has been initialized, `false` otherwise.  */
     nativeDidInitialize: boolean;
   }) => void;

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -29,12 +29,7 @@ const DEFAULT_OPTIONS: ReactNativeOptions = {
 /**
  * Inits the SDK
  */
-export function init(
-  passedOptions: ReactNativeOptions = {
-    enableNative: true,
-    enableNativeCrashHandling: true,
-  }
-): void {
+export function init(passedOptions: ReactNativeOptions): void {
   const reactNativeHub = new Hub(undefined, new ReactNativeScope());
   makeMain(reactNativeHub);
 

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -93,22 +93,22 @@ describe("Tests ReactNativeBackend", () => {
     });
   });
 
-  describe("onNativeReady", () => {
-    test("calls onNativeReady callback with true if Native SDK is initialized", () => {
+  describe("onReady", () => {
+    test("calls onReady callback with true if Native SDK is initialized", () => {
       new ReactNativeBackend({
         dsn: EXAMPLE_DSN,
         enableNative: true,
-        onNativeReady: ({ nativeDidInitialize }) => {
+        onReady: ({ nativeDidInitialize }) => {
           expect(nativeDidInitialize).toBe(true);
         },
       });
     });
 
-    test("calls onNativeReady callback with false if Native SDK was not initialized", () => {
+    test("calls onReady callback with false if Native SDK was not initialized", () => {
       new ReactNativeBackend({
         dsn: EXAMPLE_DSN,
         enableNative: false,
-        onNativeReady: ({ nativeDidInitialize }) => {
+        onReady: ({ nativeDidInitialize }) => {
           expect(nativeDidInitialize).toBe(true);
         },
       });

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -100,8 +100,8 @@ describe("Tests ReactNativeBackend", () => {
       new ReactNativeBackend({
         dsn: EXAMPLE_DSN,
         enableNative: true,
-        onReady: ({ nativeDidInitialize }) => {
-          expect(nativeDidInitialize).toBe(true);
+        onReady: ({ didCallNativeInit }) => {
+          expect(didCallNativeInit).toBe(true);
 
           done();
         },
@@ -112,8 +112,8 @@ describe("Tests ReactNativeBackend", () => {
       new ReactNativeBackend({
         dsn: EXAMPLE_DSN,
         enableNative: false,
-        onReady: ({ nativeDidInitialize }) => {
-          expect(nativeDidInitialize).toBe(false);
+        onReady: ({ didCallNativeInit }) => {
+          expect(didCallNativeInit).toBe(false);
 
           done();
         },
@@ -130,8 +130,8 @@ describe("Tests ReactNativeBackend", () => {
       new ReactNativeBackend({
         dsn: EXAMPLE_DSN,
         enableNative: true,
-        onReady: ({ nativeDidInitialize }) => {
-          expect(nativeDidInitialize).toBe(false);
+        onReady: ({ didCallNativeInit }) => {
+          expect(didCallNativeInit).toBe(false);
 
           done();
         },

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -119,6 +119,24 @@ describe("Tests ReactNativeBackend", () => {
         },
       });
     });
+
+    test("calls onReady callback with false if Native SDK failed to initialize", (done) => {
+      const RN = require("react-native");
+
+      RN.NativeModules.RNSentry.startWithOptions = async () => {
+        throw new Error();
+      };
+
+      new ReactNativeBackend({
+        dsn: EXAMPLE_DSN,
+        enableNative: true,
+        onReady: ({ nativeDidInitialize }) => {
+          expect(nativeDidInitialize).toBe(false);
+
+          done();
+        },
+      });
+    });
   });
 
   describe("nativeCrash", () => {

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -1,6 +1,7 @@
 import * as RN from "react-native";
 
 import { ReactNativeBackend } from "../src/js/backend";
+import { NATIVE } from "../src/js/wrapper";
 
 const EXAMPLE_DSN =
   "https://6890c2f6677340daa4804f8194804ea2@o19635.ingest.sentry.io/148053";
@@ -14,7 +15,7 @@ jest.mock(
         nativeClientAvailable: true,
         nativeTransport: true,
         setLogLevel: jest.fn(),
-        startWithDsnString: jest.fn((dsn) => {
+        startWithOptions: jest.fn((dsn) => {
           if (typeof dsn !== "string") {
             throw new Error();
           }
@@ -35,6 +36,11 @@ jest.mock(
   /* virtual allows us to mock modules that aren't in package.json */
   { virtual: true }
 );
+
+afterEach(() => {
+  jest.resetAllMocks();
+  NATIVE.enableNative = true;
+});
 
 describe("Tests ReactNativeBackend", () => {
   describe("initializing the backend", () => {
@@ -84,6 +90,28 @@ describe("Tests ReactNativeBackend", () => {
       await expect(backend.eventFromMessage("test")).resolves.toBeDefined();
       // eslint-disable-next-line deprecation/deprecation
       await expect(RN.YellowBox.ignoreWarnings).toBeCalled();
+    });
+  });
+
+  describe("onNativeReady", () => {
+    test("calls onNativeReady callback with true if Native SDK is initialized", () => {
+      new ReactNativeBackend({
+        dsn: EXAMPLE_DSN,
+        enableNative: true,
+        onNativeReady: ({ nativeDidInitialize }) => {
+          expect(nativeDidInitialize).toBe(true);
+        },
+      });
+    });
+
+    test("calls onNativeReady callback with false if Native SDK was not initialized", () => {
+      new ReactNativeBackend({
+        dsn: EXAMPLE_DSN,
+        enableNative: false,
+        onNativeReady: ({ nativeDidInitialize }) => {
+          expect(nativeDidInitialize).toBe(true);
+        },
+      });
     });
   });
 

--- a/test/backend.test.ts
+++ b/test/backend.test.ts
@@ -15,12 +15,14 @@ jest.mock(
         nativeClientAvailable: true,
         nativeTransport: true,
         setLogLevel: jest.fn(),
-        startWithOptions: jest.fn((dsn) => {
-          if (typeof dsn !== "string") {
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        startWithOptions: async (options: any): Promise<boolean> => {
+          if (typeof options.dsn !== "string") {
             throw new Error();
           }
-          return Promise.resolve();
-        }),
+          return true;
+        },
       },
     },
     Platform: {
@@ -94,22 +96,26 @@ describe("Tests ReactNativeBackend", () => {
   });
 
   describe("onReady", () => {
-    test("calls onReady callback with true if Native SDK is initialized", () => {
+    test("calls onReady callback with true if Native SDK is initialized", (done) => {
       new ReactNativeBackend({
         dsn: EXAMPLE_DSN,
         enableNative: true,
         onReady: ({ nativeDidInitialize }) => {
           expect(nativeDidInitialize).toBe(true);
+
+          done();
         },
       });
     });
 
-    test("calls onReady callback with false if Native SDK was not initialized", () => {
+    test("calls onReady callback with false if Native SDK was not initialized", (done) => {
       new ReactNativeBackend({
         dsn: EXAMPLE_DSN,
         enableNative: false,
         onReady: ({ nativeDidInitialize }) => {
-          expect(nativeDidInitialize).toBe(true);
+          expect(nativeDidInitialize).toBe(false);
+
+          done();
         },
       });
     });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds a callback `onReady` to be passed as an option to `Sentry.init`. After the native SDK initialization step is finished, this callback is called with an object with property `nativeDidInitialize`. This value is `true` when the native SDK was initialized by the SDK, `false` otherwise.

In these cases:
- `enableNative: false` = onReady called with `{ nativeDidInitialize: false }`.
- `autoInitializeNativeSdk: false` = onReady called with `{ nativeDidInitialize: false }`.
- Error happens when initializing native SDK but JS layer is fine = onReady called with `{ nativeDidInitialize: false }`.
- Error happens when initializing JS layer SDK = onReady **not** called.

### How I got here
Originally was just going to be a callback after the native SDK initialized. But I figured having it still be called with `false` so you know it was not initialized is way more useful.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1234

## :green_heart: How did you test it?
Added tests and tested with sample app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Document this option
