### PR TITLE
fix: Type navigation container ref arguments as any to avoid Typescript errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Type navigation container ref arguments as any to avoid Typescript errors #1453
+
 ## 2.4.0
 
 - fix: Don't call `NATIVE.fetchRelease` if release and dist already exists on the event #1388

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: Type navigation container ref arguments as any to avoid Typescript errors #1453
+- fix: Type navigation container ref arguments as any to avoid TypeScript errors #1453
 
 ## 2.4.0
 

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -112,9 +112,7 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
    * Pass the ref to the app container to register it to the instrumentation
    * @param appContainerRef Ref to an `AppContainer`
    */
-  public registerAppContainer(
-    appContainerRef: AppContainerRef | AppContainerInstance
-  ): void {
+  public registerAppContainer(appContainerRef: any): void {
     const _global = getGlobalObject<{ __sentry_rn_v4_registered?: boolean }>();
 
     /* We prevent duplicate routing instrumentation to be initialized on fast refreshes
@@ -145,7 +143,7 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
 
         _global.__sentry_rn_v4_registered = true;
       } else {
-        logger.log(
+        logger.warn(
           "[ReactNavigationV4Instrumentation] Received invalid app container ref!"
         );
       }

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -37,10 +37,6 @@ export interface AppContainerInstance {
   };
 }
 
-interface AppContainerRef {
-  current: AppContainerInstance | null;
-}
-
 interface ReactNavigationV4Options {
   /**
    * The time the transaction will wait for route to mount before it is discarded.
@@ -112,6 +108,7 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
    * Pass the ref to the app container to register it to the instrumentation
    * @param appContainerRef Ref to an `AppContainer`
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public registerAppContainer(appContainerRef: any): void {
     const _global = getGlobalObject<{ __sentry_rn_v4_registered?: boolean }>();
 
@@ -122,6 +119,7 @@ class ReactNavigationV4Instrumentation extends RoutingInstrumentation {
      */
     if (!_global.__sentry_rn_v4_registered) {
       if ("current" in appContainerRef) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this._appContainer = appContainerRef.current;
       } else {
         this._appContainer = appContainerRef;

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -92,9 +92,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
    * Pass the ref to the navigation container to register it to the instrumentation
    * @param navigationContainerRef Ref to a `NavigationContainer`
    */
-  public registerNavigationContainer(
-    navigationContainerRef: NavigationContainerV5Ref | NavigationContainerV5
-  ): void {
+  public registerNavigationContainer(navigationContainerRef: any): void {
     const _global = getGlobalObject<{ __sentry_rn_v5_registered?: boolean }>();
 
     /* We prevent duplicate routing instrumentation to be initialized on fast refreshes
@@ -134,7 +132,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
 
         _global.__sentry_rn_v5_registered = true;
       } else {
-        logger.log(
+        logger.warn(
           "[ReactNavigationV5Instrumentation] Received invalid navigation container ref!"
         );
       }

--- a/src/js/tracing/reactnavigationv5.ts
+++ b/src/js/tracing/reactnavigationv5.ts
@@ -20,10 +20,6 @@ interface NavigationContainerV5 {
   getCurrentRoute: () => NavigationRouteV5;
 }
 
-type NavigationContainerV5Ref = {
-  current: NavigationContainerV5 | null;
-};
-
 interface ReactNavigationV5Options {
   /**
    * The time the transaction will wait for route to mount before it is discarded.
@@ -92,6 +88,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
    * Pass the ref to the navigation container to register it to the instrumentation
    * @param navigationContainerRef Ref to a `NavigationContainer`
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public registerNavigationContainer(navigationContainerRef: any): void {
     const _global = getGlobalObject<{ __sentry_rn_v5_registered?: boolean }>();
 
@@ -102,6 +99,7 @@ export class ReactNavigationV5Instrumentation extends RoutingInstrumentation {
      */
     if (!_global.__sentry_rn_v5_registered) {
       if ("current" in navigationContainerRef) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         this._navigationContainer = navigationContainerRef.current;
       } else {
         this._navigationContainer = navigationContainerRef;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
When making integrations for other libraries, to avoid a dependency of the library we usually just define the types inline, however doing so means we have to manually keep them up to date otherwise a new update on the other library could cause new type errors, so I decided to just allow `any` types for the React Navigation container. We check the passed ref and warn the user if it is invalid, so it should be OK to accept an `any` type.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves #1445

## :green_heart: How did you test it?
Eslint on CI to make sure the types work, and e2e tests to make sure nothing is broken.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes