### PR TITLE
feat: Close method to fully disable the SDK on all layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - build(ios): Bump sentry-cocoa to 7.0.0 and remove setLogLevel #1459
+- feat: Close method to fully disable the SDK on all layers #1457
 
 ## 2.4.2
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:4.3.0'
+    api 'io.sentry:sentry-android:4.4.0-alpha.2'
 }

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -331,4 +331,10 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             scope.setTag(key, value);
         });
     }
+
+    @ReactMethod
+    public void closeNativeSdk(Promise promise) {
+      Sentry.close();
+      promise.resolve(true);
+    }
 }

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -17,102 +17,91 @@
 @end
 
 @implementation RNSentry {
-  bool sentHybridSdkDidBecomeActive;
+   bool sentHybridSdkDidBecomeActive;
 }
 
-- (dispatch_queue_t)methodQueue {
-  return dispatch_get_main_queue();
+
+
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
 }
 
 + (BOOL)requiresMainQueueSetup {
-  return YES;
+    return YES;
 }
 
 RCT_EXPORT_MODULE()
 
-- (NSDictionary<NSString *, id> *)constantsToExport {
-  return @{@"nativeClientAvailable" : @YES, @"nativeTransport" : @YES};
+- (NSDictionary<NSString *, id> *)constantsToExport
+{
+    return @{@"nativeClientAvailable": @YES, @"nativeTransport": @YES};
 }
 
-RCT_EXPORT_METHOD(startWithOptions
-                  : (NSDictionary *_Nonnull)options resolve
-                  : (RCTPromiseResolveBlock)resolve rejecter
-                  : (RCTPromiseRejectBlock)reject) {
-  NSError *error = nil;
+RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *_Nonnull)options
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSError *error = nil;
 
-  SentryBeforeSendEventCallback beforeSend =
-      ^SentryEvent *(SentryEvent *event) {
-    // We don't want to send an event after startup that came from a Unhandled
-    // JS Exception of react native Because we sent it already before the app
-    // crashed.
-    if (nil != event.exceptions.firstObject.type &&
-        [event.exceptions.firstObject.type
-            rangeOfString:@"Unhandled JS Exception"]
-                .location != NSNotFound) {
-      NSLog(@"Unhandled JS Exception");
-      return nil;
+    SentryBeforeSendEventCallback beforeSend = ^SentryEvent*(SentryEvent *event) {
+        // We don't want to send an event after startup that came from a Unhandled JS Exception of react native
+        // Because we sent it already before the app crashed.
+        if (nil != event.exceptions.firstObject.type &&
+            [event.exceptions.firstObject.type rangeOfString:@"Unhandled JS Exception"].location != NSNotFound) {
+            NSLog(@"Unhandled JS Exception");
+            return nil;
+        }
+
+        // set the event.origin tag to be ios if the event originated from the sentry-cocoa sdk.
+        if (event.sdk && [event.sdk[@"name"] isEqualToString:@"sentry.cocoa"]) {
+            NSMutableDictionary *newTags = [NSMutableDictionary new];
+            [newTags addEntriesFromDictionary:event.tags];
+            [newTags setValue:@"ios" forKey:@"event.origin"];
+            event.tags = newTags;
+        }
+
+        return event;
+    };
+
+    [options setValue:beforeSend forKey:@"beforeSend"];
+
+    SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:options didFailWithError:&error];
+    if (error) {
+        reject(@"SentryReactNative", error.localizedDescription, error);
+        return;
+    }
+    [SentrySDK startWithOptionsObject:sentryOptions];
+
+    // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.
+    if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
+        [[NSNotificationCenter defaultCenter]
+            postNotificationName:@"SentryHybridSdkDidBecomeActive"
+            object:nil];
+
+        sentHybridSdkDidBecomeActive = true;
     }
 
-    // set the event.origin tag to be ios if the event originated from the
-    // sentry-cocoa sdk.
-    if (event.sdk && [event.sdk[@"name"] isEqualToString:@"sentry.cocoa"]) {
-      NSMutableDictionary *newTags = [NSMutableDictionary new];
-      [newTags addEntriesFromDictionary:event.tags];
-      [newTags setValue:@"ios" forKey:@"event.origin"];
-      event.tags = newTags;
-    }
-
-    return event;
-  };
-
-  [options setValue:beforeSend forKey:@"beforeSend"];
-
-  SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:options
-                                                    didFailWithError:&error];
-  if (error) {
-    reject(@"SentryReactNative", error.localizedDescription, error);
-    return;
-  }
-  [SentrySDK startWithOptionsObject:sentryOptions];
-
-  // If the app is active/in foreground, and we have not sent the
-  // SentryHybridSdkDidBecomeActive notification, send it.
-  if ([[UIApplication sharedApplication] applicationState] ==
-          UIApplicationStateActive &&
-      !sentHybridSdkDidBecomeActive &&
-      sentryOptions.enableAutoSessionTracking) {
-    [[NSNotificationCenter defaultCenter]
-        postNotificationName:@"SentryHybridSdkDidBecomeActive"
-                      object:nil];
-
-    sentHybridSdkDidBecomeActive = true;
-  }
-
-  resolve(@YES);
+    resolve(@YES);
 }
 
-RCT_EXPORT_METHOD(deviceContexts
-                  : (RCTPromiseResolveBlock)resolve rejecter
-                  : (RCTPromiseRejectBlock)reject) {
-  NSLog(@"Bridge call to: deviceContexts");
-  // Temp work around until sorted out this API in sentry-cocoa.
-  // TODO: If the callback isnt' executed the promise wouldn't be resolved.
-  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    NSDictionary<NSString *, id> *serializedScope = [scope serialize];
-    // Scope serializes as 'context' instead of 'contexts' as it does for the
-    // event.
-    NSDictionary<NSString *, id> *contexts =
-        [serializedScope valueForKey:@"context"];
+RCT_EXPORT_METHOD(deviceContexts:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSLog(@"Bridge call to: deviceContexts");
+    // Temp work around until sorted out this API in sentry-cocoa.
+    // TODO: If the callback isnt' executed the promise wouldn't be resolved.
+    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+        NSDictionary<NSString *, id> *serializedScope = [scope serialize];
+        // Scope serializes as 'context' instead of 'contexts' as it does for the event.
+        NSDictionary<NSString *, id> *contexts = [serializedScope valueForKey:@"context"];
 #if DEBUG
-    NSData *data = [NSJSONSerialization dataWithJSONObject:contexts
-                                                   options:0
-                                                     error:nil];
-    NSString *debugContext =
-        [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-    NSLog(@"Contexts: %@", debugContext);
+        NSData *data = [NSJSONSerialization dataWithJSONObject:contexts options:0 error:nil];
+        NSString *debugContext = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        NSLog(@"Contexts: %@", debugContext);
 #endif
-    resolve(contexts);
-  }];
+        resolve(contexts);
+    }];
 }
 
 RCT_EXPORT_METHOD(fetchRelease:(RCTPromiseResolveBlock)resolve
@@ -164,97 +153,104 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSDictionary * _Nonnull)envelopeDict
         #endif
         resolve(@YES);
     } else {
-      [[SentrySDK currentHub] captureEnvelope:envelope];
+        reject(@"SentryReactNative", @"Cannot serialize event", nil);
     }
-#endif
-    resolve(@YES);
-  } else {
-    reject(@"SentryReactNative", @"Cannot serialize event", nil);
-  }
 }
 
-RCT_EXPORT_METHOD(setUser
-                  : (NSDictionary *)user otherUserKeys
-                  : (NSDictionary *)otherUserKeys) {
-  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    if (nil == user && nil == otherUserKeys) {
-      [scope setUser:nil];
-    } else {
-      SentryUser *userInstance = [[SentryUser alloc] init];
+RCT_EXPORT_METHOD(setUser:(NSDictionary *)user
+                  otherUserKeys:(NSDictionary *)otherUserKeys
+)
+{
+    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+        if (nil == user && nil == otherUserKeys) {
+            [scope setUser:nil];
+        } else {
+            SentryUser* userInstance = [[SentryUser alloc] init];
 
-      if (nil != user) {
-        [userInstance setUserId:user[@"id"]];
-        [userInstance setEmail:user[@"email"]];
-        [userInstance setUsername:user[@"username"]];
-      }
+            if (nil != user) {
+                [userInstance setUserId:user[@"id"]];
+                [userInstance setEmail:user[@"email"]];
+                [userInstance setUsername:user[@"username"]];
+            }
 
-      if (nil != otherUserKeys) {
-        [userInstance setData:otherUserKeys];
-      }
+            if (nil != otherUserKeys) {
+                [userInstance setData:otherUserKeys];
+            }
 
-      [scope setUser:userInstance];
-    }
-  }];
+            [scope setUser:userInstance];
+        }
+    }];
 }
 
-RCT_EXPORT_METHOD(addBreadcrumb : (NSDictionary *)breadcrumb) {
-  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    SentryBreadcrumb *breadcrumbInstance = [[SentryBreadcrumb alloc] init];
+RCT_EXPORT_METHOD(addBreadcrumb:(NSDictionary *)breadcrumb)
+{
+    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+        SentryBreadcrumb* breadcrumbInstance = [[SentryBreadcrumb alloc] init];
 
-    NSString *levelString = breadcrumb[@"level"];
-    SentryLevel sentryLevel;
-    if ([levelString isEqualToString:@"fatal"]) {
-      sentryLevel = kSentryLevelFatal;
-    } else if ([levelString isEqualToString:@"warning"]) {
-      sentryLevel = kSentryLevelWarning;
-    } else if ([levelString isEqualToString:@"info"]) {
-      sentryLevel = kSentryLevelInfo;
-    } else if ([levelString isEqualToString:@"debug"]) {
-      sentryLevel = kSentryLevelDebug;
-    } else {
-      sentryLevel = kSentryLevelError;
-    }
-    [breadcrumbInstance setLevel:sentryLevel];
+        NSString * levelString = breadcrumb[@"level"];
+        SentryLevel sentryLevel;
+        if ([levelString isEqualToString:@"fatal"]) {
+            sentryLevel = kSentryLevelFatal;
+        } else if ([levelString isEqualToString:@"warning"]) {
+            sentryLevel = kSentryLevelWarning;
+        } else if ([levelString isEqualToString:@"info"]) {
+            sentryLevel = kSentryLevelInfo;
+        } else if ([levelString isEqualToString:@"debug"]) {
+            sentryLevel = kSentryLevelDebug;
+        } else {
+            sentryLevel = kSentryLevelError;
+        }
+        [breadcrumbInstance setLevel:sentryLevel];
 
-    [breadcrumbInstance setCategory:breadcrumb[@"category"]];
+        [breadcrumbInstance setCategory:breadcrumb[@"category"]];
 
-    [breadcrumbInstance setType:breadcrumb[@"type"]];
+        [breadcrumbInstance setType:breadcrumb[@"type"]];
 
-    [breadcrumbInstance setMessage:breadcrumb[@"message"]];
+        [breadcrumbInstance setMessage:breadcrumb[@"message"]];
 
-    [breadcrumbInstance setData:breadcrumb[@"data"]];
+        [breadcrumbInstance setData:breadcrumb[@"data"]];
 
-    [scope addBreadcrumb:breadcrumbInstance];
-  }];
+        [scope addBreadcrumb:breadcrumbInstance];
+    }];
 }
 
 RCT_EXPORT_METHOD(clearBreadcrumbs) {
-  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    [scope clearBreadcrumbs];
-  }];
+    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+        [scope clearBreadcrumbs];
+    }];
 }
 
-RCT_EXPORT_METHOD(setExtra : (NSString *)key extra : (NSString *)extra) {
-  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    [scope setExtraValue:extra forKey:key];
-  }];
+RCT_EXPORT_METHOD(setExtra:(NSString *)key
+                  extra:(NSString *)extra
+)
+{
+    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+        [scope setExtraValue:extra forKey:key];
+    }];
 }
 
-RCT_EXPORT_METHOD(setContext
-                  : (NSString *)key context
-                  : (NSDictionary *)context) {
-  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    [scope setContextValue:context forKey:key];
-  }];
+RCT_EXPORT_METHOD(setContext:(NSString *)key
+                  context:(NSDictionary *)context
+)
+{
+    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+        [scope setContextValue:context forKey:key];
+    }];
 }
 
-RCT_EXPORT_METHOD(setTag : (NSString *)key value : (NSString *)value) {
-  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
-    [scope setTagValue:value forKey:key];
-  }];
+RCT_EXPORT_METHOD(setTag:(NSString *)key
+                  value:(NSString *)value
+)
+{
+    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
+        [scope setTagValue:value forKey:key];
+    }];
 }
 
-RCT_EXPORT_METHOD(crash) { [SentrySDK crash]; }
+RCT_EXPORT_METHOD(crash)
+{
+    [SentrySDK crash];
+}
 
 RCT_EXPORT_METHOD(closeNativeSdk
                   : (RCTPromiseResolveBlock)resolve rejecter

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -255,7 +255,7 @@ RCT_EXPORT_METHOD(crash)
 RCT_EXPORT_METHOD(closeNativeSdk
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-  [[SentrySDK currentHub] getClient].options.enabled = NO;
+  [SentrySDK close];
 }
 
 @end

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -17,91 +17,102 @@
 @end
 
 @implementation RNSentry {
-   bool sentHybridSdkDidBecomeActive;
+  bool sentHybridSdkDidBecomeActive;
 }
 
-
-
-- (dispatch_queue_t)methodQueue
-{
-    return dispatch_get_main_queue();
+- (dispatch_queue_t)methodQueue {
+  return dispatch_get_main_queue();
 }
 
 + (BOOL)requiresMainQueueSetup {
-    return YES;
+  return YES;
 }
 
 RCT_EXPORT_MODULE()
 
-- (NSDictionary<NSString *, id> *)constantsToExport
-{
-    return @{@"nativeClientAvailable": @YES, @"nativeTransport": @YES};
+- (NSDictionary<NSString *, id> *)constantsToExport {
+  return @{@"nativeClientAvailable" : @YES, @"nativeTransport" : @YES};
 }
 
-RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *_Nonnull)options
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
-{
-    NSError *error = nil;
+RCT_EXPORT_METHOD(startWithOptions
+                  : (NSDictionary *_Nonnull)options resolve
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject) {
+  NSError *error = nil;
 
-    SentryBeforeSendEventCallback beforeSend = ^SentryEvent*(SentryEvent *event) {
-        // We don't want to send an event after startup that came from a Unhandled JS Exception of react native
-        // Because we sent it already before the app crashed.
-        if (nil != event.exceptions.firstObject.type &&
-            [event.exceptions.firstObject.type rangeOfString:@"Unhandled JS Exception"].location != NSNotFound) {
-            NSLog(@"Unhandled JS Exception");
-            return nil;
-        }
-
-        // set the event.origin tag to be ios if the event originated from the sentry-cocoa sdk.
-        if (event.sdk && [event.sdk[@"name"] isEqualToString:@"sentry.cocoa"]) {
-            NSMutableDictionary *newTags = [NSMutableDictionary new];
-            [newTags addEntriesFromDictionary:event.tags];
-            [newTags setValue:@"ios" forKey:@"event.origin"];
-            event.tags = newTags;
-        }
-
-        return event;
-    };
-
-    [options setValue:beforeSend forKey:@"beforeSend"];
-
-    SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:options didFailWithError:&error];
-    if (error) {
-        reject(@"SentryReactNative", error.localizedDescription, error);
-        return;
-    }
-    [SentrySDK startWithOptionsObject:sentryOptions];
-
-    // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.
-    if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
-        [[NSNotificationCenter defaultCenter]
-            postNotificationName:@"SentryHybridSdkDidBecomeActive"
-            object:nil];
-
-        sentHybridSdkDidBecomeActive = true;
+  SentryBeforeSendEventCallback beforeSend =
+      ^SentryEvent *(SentryEvent *event) {
+    // We don't want to send an event after startup that came from a Unhandled
+    // JS Exception of react native Because we sent it already before the app
+    // crashed.
+    if (nil != event.exceptions.firstObject.type &&
+        [event.exceptions.firstObject.type
+            rangeOfString:@"Unhandled JS Exception"]
+                .location != NSNotFound) {
+      NSLog(@"Unhandled JS Exception");
+      return nil;
     }
 
-    resolve(@YES);
+    // set the event.origin tag to be ios if the event originated from the
+    // sentry-cocoa sdk.
+    if (event.sdk && [event.sdk[@"name"] isEqualToString:@"sentry.cocoa"]) {
+      NSMutableDictionary *newTags = [NSMutableDictionary new];
+      [newTags addEntriesFromDictionary:event.tags];
+      [newTags setValue:@"ios" forKey:@"event.origin"];
+      event.tags = newTags;
+    }
+
+    return event;
+  };
+
+  [options setValue:beforeSend forKey:@"beforeSend"];
+
+  SentryOptions *sentryOptions = [[SentryOptions alloc] initWithDict:options
+                                                    didFailWithError:&error];
+  if (error) {
+    reject(@"SentryReactNative", error.localizedDescription, error);
+    return;
+  }
+  [SentrySDK startWithOptionsObject:sentryOptions];
+
+  // If the app is active/in foreground, and we have not sent the
+  // SentryHybridSdkDidBecomeActive notification, send it.
+  if ([[UIApplication sharedApplication] applicationState] ==
+          UIApplicationStateActive &&
+      !sentHybridSdkDidBecomeActive &&
+      sentryOptions.enableAutoSessionTracking) {
+    [[NSNotificationCenter defaultCenter]
+        postNotificationName:@"SentryHybridSdkDidBecomeActive"
+                      object:nil];
+
+    sentHybridSdkDidBecomeActive = true;
+  }
+
+  resolve(@YES);
 }
 
-RCT_EXPORT_METHOD(deviceContexts:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
-{
-    NSLog(@"Bridge call to: deviceContexts");
-    // Temp work around until sorted out this API in sentry-cocoa.
-    // TODO: If the callback isnt' executed the promise wouldn't be resolved.
-    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        NSDictionary<NSString *, id> *serializedScope = [scope serialize];
-        // Scope serializes as 'context' instead of 'contexts' as it does for the event.
-        NSDictionary<NSString *, id> *contexts = [serializedScope valueForKey:@"context"];
+RCT_EXPORT_METHOD(deviceContexts
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject) {
+  NSLog(@"Bridge call to: deviceContexts");
+  // Temp work around until sorted out this API in sentry-cocoa.
+  // TODO: If the callback isnt' executed the promise wouldn't be resolved.
+  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
+    NSDictionary<NSString *, id> *serializedScope = [scope serialize];
+    // Scope serializes as 'context' instead of 'contexts' as it does for the
+    // event.
+    NSDictionary<NSString *, id> *contexts =
+        [serializedScope valueForKey:@"context"];
 #if DEBUG
-        NSData *data = [NSJSONSerialization dataWithJSONObject:contexts options:0 error:nil];
-        NSString *debugContext = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-        NSLog(@"Contexts: %@", debugContext);
+    NSData *data = [NSJSONSerialization dataWithJSONObject:contexts
+                                                   options:0
+                                                     error:nil];
+    NSString *debugContext =
+        [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    NSLog(@"Contexts: %@", debugContext);
 #endif
-        resolve(contexts);
-    }];
+    resolve(contexts);
+  }];
 }
 
 RCT_EXPORT_METHOD(fetchRelease:(RCTPromiseResolveBlock)resolve
@@ -153,103 +164,102 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSDictionary * _Nonnull)envelopeDict
         #endif
         resolve(@YES);
     } else {
-        reject(@"SentryReactNative", @"Cannot serialize event", nil);
+      [[SentrySDK currentHub] captureEnvelope:envelope];
     }
+#endif
+    resolve(@YES);
+  } else {
+    reject(@"SentryReactNative", @"Cannot serialize event", nil);
+  }
 }
 
-RCT_EXPORT_METHOD(setUser:(NSDictionary *)user
-                  otherUserKeys:(NSDictionary *)otherUserKeys
-)
-{
-    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        if (nil == user && nil == otherUserKeys) {
-            [scope setUser:nil];
-        } else {
-            SentryUser* userInstance = [[SentryUser alloc] init];
+RCT_EXPORT_METHOD(setUser
+                  : (NSDictionary *)user otherUserKeys
+                  : (NSDictionary *)otherUserKeys) {
+  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
+    if (nil == user && nil == otherUserKeys) {
+      [scope setUser:nil];
+    } else {
+      SentryUser *userInstance = [[SentryUser alloc] init];
 
-            if (nil != user) {
-                [userInstance setUserId:user[@"id"]];
-                [userInstance setEmail:user[@"email"]];
-                [userInstance setUsername:user[@"username"]];
-            }
+      if (nil != user) {
+        [userInstance setUserId:user[@"id"]];
+        [userInstance setEmail:user[@"email"]];
+        [userInstance setUsername:user[@"username"]];
+      }
 
-            if (nil != otherUserKeys) {
-                [userInstance setData:otherUserKeys];
-            }
+      if (nil != otherUserKeys) {
+        [userInstance setData:otherUserKeys];
+      }
 
-            [scope setUser:userInstance];
-        }
-    }];
+      [scope setUser:userInstance];
+    }
+  }];
 }
 
-RCT_EXPORT_METHOD(addBreadcrumb:(NSDictionary *)breadcrumb)
-{
-    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        SentryBreadcrumb* breadcrumbInstance = [[SentryBreadcrumb alloc] init];
+RCT_EXPORT_METHOD(addBreadcrumb : (NSDictionary *)breadcrumb) {
+  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
+    SentryBreadcrumb *breadcrumbInstance = [[SentryBreadcrumb alloc] init];
 
-        NSString * levelString = breadcrumb[@"level"];
-        SentryLevel sentryLevel;
-        if ([levelString isEqualToString:@"fatal"]) {
-            sentryLevel = kSentryLevelFatal;
-        } else if ([levelString isEqualToString:@"warning"]) {
-            sentryLevel = kSentryLevelWarning;
-        } else if ([levelString isEqualToString:@"info"]) {
-            sentryLevel = kSentryLevelInfo;
-        } else if ([levelString isEqualToString:@"debug"]) {
-            sentryLevel = kSentryLevelDebug;
-        } else {
-            sentryLevel = kSentryLevelError;
-        }
-        [breadcrumbInstance setLevel:sentryLevel];
+    NSString *levelString = breadcrumb[@"level"];
+    SentryLevel sentryLevel;
+    if ([levelString isEqualToString:@"fatal"]) {
+      sentryLevel = kSentryLevelFatal;
+    } else if ([levelString isEqualToString:@"warning"]) {
+      sentryLevel = kSentryLevelWarning;
+    } else if ([levelString isEqualToString:@"info"]) {
+      sentryLevel = kSentryLevelInfo;
+    } else if ([levelString isEqualToString:@"debug"]) {
+      sentryLevel = kSentryLevelDebug;
+    } else {
+      sentryLevel = kSentryLevelError;
+    }
+    [breadcrumbInstance setLevel:sentryLevel];
 
-        [breadcrumbInstance setCategory:breadcrumb[@"category"]];
+    [breadcrumbInstance setCategory:breadcrumb[@"category"]];
 
-        [breadcrumbInstance setType:breadcrumb[@"type"]];
+    [breadcrumbInstance setType:breadcrumb[@"type"]];
 
-        [breadcrumbInstance setMessage:breadcrumb[@"message"]];
+    [breadcrumbInstance setMessage:breadcrumb[@"message"]];
 
-        [breadcrumbInstance setData:breadcrumb[@"data"]];
+    [breadcrumbInstance setData:breadcrumb[@"data"]];
 
-        [scope addBreadcrumb:breadcrumbInstance];
-    }];
+    [scope addBreadcrumb:breadcrumbInstance];
+  }];
 }
 
 RCT_EXPORT_METHOD(clearBreadcrumbs) {
-    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        [scope clearBreadcrumbs];
-    }];
+  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
+    [scope clearBreadcrumbs];
+  }];
 }
 
-RCT_EXPORT_METHOD(setExtra:(NSString *)key
-                  extra:(NSString *)extra
-)
-{
-    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        [scope setExtraValue:extra forKey:key];
-    }];
+RCT_EXPORT_METHOD(setExtra : (NSString *)key extra : (NSString *)extra) {
+  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
+    [scope setExtraValue:extra forKey:key];
+  }];
 }
 
-RCT_EXPORT_METHOD(setContext:(NSString *)key
-                  context:(NSDictionary *)context
-)
-{
-    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        [scope setContextValue:context forKey:key];
-    }];
+RCT_EXPORT_METHOD(setContext
+                  : (NSString *)key context
+                  : (NSDictionary *)context) {
+  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
+    [scope setContextValue:context forKey:key];
+  }];
 }
 
-RCT_EXPORT_METHOD(setTag:(NSString *)key
-                  value:(NSString *)value
-)
-{
-    [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        [scope setTagValue:value forKey:key];
-    }];
+RCT_EXPORT_METHOD(setTag : (NSString *)key value : (NSString *)value) {
+  [SentrySDK configureScope:^(SentryScope *_Nonnull scope) {
+    [scope setTagValue:value forKey:key];
+  }];
 }
 
-RCT_EXPORT_METHOD(crash)
-{
-    [SentrySDK crash];
+RCT_EXPORT_METHOD(crash) { [SentrySDK crash]; }
+
+RCT_EXPORT_METHOD(closeNativeSdk
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject) {
+  [[SentrySDK currentHub] getClient].options.enabled = NO;
 }
 
 @end

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -29,7 +29,6 @@ const reactNavigationV5Instrumentation = new Sentry.ReactNavigationV5Instrumenta
 Sentry.init({
   // Replace the example DSN below with your own DSN:
   dsn: SENTRY_INTERNAL_DSN,
-  debug: true,
   beforeSend: (e) => {
     console.log('Event beforeSend:', e);
     return e;

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -29,6 +29,7 @@ const reactNavigationV5Instrumentation = new Sentry.ReactNavigationV5Instrumenta
 Sentry.init({
   // Replace the example DSN below with your own DSN:
   dsn: SENTRY_INTERNAL_DSN,
+  debug: true,
   beforeSend: (e) => {
     console.log('Event beforeSend:', e);
     return e;

--- a/sample/src/screens/EndToEndTestsScreen.tsx
+++ b/sample/src/screens/EndToEndTestsScreen.tsx
@@ -62,6 +62,13 @@ const EndToEndTestsScreen = () => {
         Unhandled Promise Rejection
       </Text>
       <Text
+        {...getTestProps('close')}
+        onPress={() => {
+          Sentry.close();
+        }}>
+        close
+      </Text>
+      <Text
         onPress={() => {
           Sentry.nativeCrash();
         }}>

--- a/sample/src/screens/HomeScreen.tsx
+++ b/sample/src/screens/HomeScreen.tsx
@@ -194,6 +194,13 @@ const HomeScreen = (props: Props) => {
               <Text style={styles.buttonText}>Set Scope Properties</Text>
             </TouchableOpacity>
             <View style={styles.spacer} />
+            <TouchableOpacity
+              onPress={() => {
+                Sentry.close();
+              }}>
+              <Text style={styles.buttonText}>Close</Text>
+            </TouchableOpacity>
+            <View style={styles.spacer} />
             <Sentry.ErrorBoundary
               fallback={({eventId}) => (
                 <Text>Error boundary caught with event id: {eventId}</Text>

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -118,4 +118,17 @@ describe('End to end tests for common events', () => {
 
     expect(sentryEvent.eventID).toMatch(eventId);
   });
+
+  test('close', async () => {
+    expect(await driver.hasElementByAccessibilityId('close')).toBe(true);
+
+    const element = await driver.elementByAccessibilityId('close');
+    await element.click();
+
+    // Wait a while in case
+    await driver.sleep(5000);
+
+    // This time we don't expect an eventId
+    expect(await driver.hasElementByAccessibilityId('eventId')).toBe(false);
+  });
 });

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -129,6 +129,10 @@ describe('End to end tests for common events', () => {
     await driver.sleep(5000);
 
     // This time we don't expect an eventId
-    expect(await driver.hasElementByAccessibilityId('eventId')).toBe(false);
+    expect(await driver.hasElementByAccessibilityId('eventId')).toBe(true);
+    const eventIdElement = await driver.elementByAccessibilityId('eventId');
+    const eventId = await eventIdElement.text();
+
+    expect(eventId).toBe('');
   });
 });

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -2,6 +2,7 @@ import { BaseClient } from "@sentry/core";
 
 import { ReactNativeBackend } from "./backend";
 import { ReactNativeOptions } from "./options";
+import { NATIVE } from "./wrapper";
 
 /**
  * The Sentry React Native SDK Client.
@@ -12,7 +13,7 @@ import { ReactNativeOptions } from "./options";
 export class ReactNativeClient extends BaseClient<
   ReactNativeBackend,
   ReactNativeOptions
-  > {
+> {
   /**
    * Creates a new React Native SDK instance.
    * @param options Configuration options for this SDK.
@@ -27,5 +28,14 @@ export class ReactNativeClient extends BaseClient<
    */
   public nativeCrash(): void {
     this._getBackend().nativeCrash();
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public close(): PromiseLike<boolean> {
+    return super.close().then((result: boolean) => {
+      return NATIVE.closeNativeSdk().then(() => result) as PromiseLike<boolean>;
+    });
   }
 }

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -34,6 +34,7 @@ export class ReactNativeClient extends BaseClient<
    * @inheritDoc
    */
   public close(): PromiseLike<boolean> {
+    // As super.close() flushes queued events, we wait for that to finish before closing the native SDK.
     return super.close().then((result: boolean) => {
       return NATIVE.closeNativeSdk().then(() => result) as PromiseLike<boolean>;
     });

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -56,7 +56,7 @@ export { ReactNativeBackend } from "./backend";
 export { ReactNativeOptions } from "./options";
 export { ReactNativeClient } from "./client";
 // eslint-disable-next-line deprecation/deprecation
-export { init, setDist, setRelease, nativeCrash } from "./sdk";
+export { init, setDist, setRelease, nativeCrash, close } from "./sdk";
 export { TouchEventBoundary, withTouchEventBoundary } from "./touchevents";
 
 export {

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -3,7 +3,7 @@ import { Hub, makeMain } from "@sentry/hub";
 import { RewriteFrames } from "@sentry/integrations";
 import { defaultIntegrations, getCurrentHub } from "@sentry/react";
 import { StackFrame } from "@sentry/types";
-import { getGlobalObject, SentryError } from "@sentry/utils";
+import { getGlobalObject, logger, SentryError } from "@sentry/utils";
 
 import { ReactNativeClient } from "./client";
 import {
@@ -130,6 +130,6 @@ export async function close(): Promise<void> {
       await client.close();
     }
   } catch (e) {
-    throw new SentryError("Failed to close the SDK");
+    logger.error("Failed to close the SDK");
   }
 }

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -3,7 +3,7 @@ import { Hub, makeMain } from "@sentry/hub";
 import { RewriteFrames } from "@sentry/integrations";
 import { defaultIntegrations, getCurrentHub } from "@sentry/react";
 import { StackFrame } from "@sentry/types";
-import { getGlobalObject } from "@sentry/utils";
+import { getGlobalObject, SentryError } from "@sentry/utils";
 
 import { ReactNativeClient } from "./client";
 import {
@@ -116,5 +116,20 @@ export function nativeCrash(): void {
   const client = getCurrentHub().getClient<ReactNativeClient>();
   if (client) {
     client.nativeCrash();
+  }
+}
+
+/**
+ * Closes the SDK, stops sending events.
+ */
+export async function close(): Promise<void> {
+  try {
+    const client = getCurrentHub().getClient<ReactNativeClient>();
+
+    if (client) {
+      await client.close();
+    }
+  } catch (e) {
+    throw new SentryError("Failed to close the SDK");
   }
 }

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -3,7 +3,7 @@ import { Hub, makeMain } from "@sentry/hub";
 import { RewriteFrames } from "@sentry/integrations";
 import { defaultIntegrations, getCurrentHub } from "@sentry/react";
 import { StackFrame } from "@sentry/types";
-import { getGlobalObject, logger, SentryError } from "@sentry/utils";
+import { getGlobalObject, logger } from "@sentry/utils";
 
 import { ReactNativeClient } from "./client";
 import {

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -1,5 +1,12 @@
 /* eslint-disable max-lines */
-import { Breadcrumb, Event, Response, Severity, User } from "@sentry/types";
+import {
+  Breadcrumb,
+  Event,
+  Response,
+  Severity,
+  Status,
+  User,
+} from "@sentry/types";
 import { logger, SentryError } from "@sentry/utils";
 import { NativeModules, Platform } from "react-native";
 
@@ -17,7 +24,10 @@ export const NATIVE = {
    */
   async sendEvent(event: Event): Promise<Response> {
     if (!this.enableNative) {
-      throw this._DisabledNativeError;
+      return {
+        reason: `Event was skipped as native SDK is not enabled.`,
+        status: Status.Skipped,
+      };
     }
     if (!this.isNativeClientAvailable()) {
       throw this._NativeClientError;
@@ -318,6 +328,19 @@ export const NATIVE = {
         context !== null ? this._serializeObject(context) : null
       );
     }
+  },
+
+  /**
+   * Closes the Native Layer SDK
+   */
+  async closeNativeSdk(): Promise<void> {
+    if (!this.enableNative) {
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return RNSentry.closeNativeSdk().then(() => {
+      this.enableNative = false;
+    });
   },
 
   /**

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -460,6 +460,7 @@ describe("Tests Native Wrapper", () => {
       await NATIVE.closeNativeSdk();
 
       expect(RN.NativeModules.RNSentry.closeNativeSdk).toBeCalled();
+      expect(NATIVE.enableNative).toBe(false);
     });
   });
 });

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -35,6 +35,7 @@ jest.mock(
           return;
         }),
         startWithOptions: jest.fn((options) => Promise.resolve(options)),
+        closeNativeSdk: jest.fn(() => Promise.resolve()),
       },
     },
     Platform: {
@@ -449,6 +450,16 @@ describe("Tests Native Wrapper", () => {
   describe("isNativeTransportAvailable", () => {
     test("checks if native transport is available", () => {
       expect(NATIVE.isNativeTransportAvailable()).toBe(true);
+    });
+  });
+
+  describe("closeNativeSdk", () => {
+    test("closeNativeSdk calls native bridge", async () => {
+      const RN = require("react-native");
+
+      await NATIVE.closeNativeSdk();
+
+      expect(RN.NativeModules.RNSentry.closeNativeSdk).toBeCalled();
     });
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Exposes a new `close` method that closes the SDK. This includes the JavaScript layer and calls down to the native SDK layer.

Although this uses the latest Cocoa SDK `7.0.0`, it still uses Android `4.4.0-alpha.2`.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1329 

## :green_heart: How did you test it?
Added a unit test for the wrapper, and a JS-layer integration test on the e2e test. The test only tests that the eventId is not set by beforeSend. Cannot do a full e2e test there is no way to determine how long to wait for an event to not show up on the dashboard.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
