### PR TITLE
fix: enableNative: false should take precedence over autoInitializeNativeSdk: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: enableNative: false should take precedence over autoInitializeNativeSdk: false #1462
+
 ## 2.4.1
 
 - fix: Type navigation container ref arguments as any to avoid TypeScript errors #1453

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -85,23 +85,26 @@ export const NATIVE = {
       ..._options,
     };
 
-    if (!options.autoInitializeNativeSdk) {
-      if (options.enableNativeNagger) {
-        logger.warn("Note: Native Sentry SDK was not initialized.");
-      }
-      return false;
-    }
-    if (!options.dsn) {
-      logger.warn(
-        "Warning: No DSN was provided. The Sentry SDK will be disabled. Native SDK will also not be initalized."
-      );
-      return false;
-    }
     if (!options.enableNative) {
       if (options.enableNativeNagger) {
         logger.warn("Note: Native Sentry SDK is disabled.");
       }
       this.enableNative = false;
+      return false;
+    }
+    if (!options.autoInitializeNativeSdk) {
+      if (options.enableNativeNagger) {
+        logger.warn(
+          "Note: Native Sentry SDK was not initialized automatically, you will need to initialize it manually. If you wish to disable the native SDK, pass enableNative: false"
+        );
+      }
+      return false;
+    }
+
+    if (!options.dsn) {
+      logger.warn(
+        "Warning: No DSN was provided. The Sentry SDK will be disabled. Native SDK will also not be initalized."
+      );
       return false;
     }
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -95,7 +95,7 @@ export const NATIVE = {
     if (!options.autoInitializeNativeSdk) {
       if (options.enableNativeNagger) {
         logger.warn(
-          "Note: Native Sentry SDK was not initialized automatically, you will need to initialize it manually. If you wish to disable the native SDK, pass enableNative: false"
+          "Note: Native Sentry SDK was not initialized automatically, you will need to initialize it manually. If you wish to disable the native SDK and get rid of this warning, pass enableNative: false"
         );
       }
       return false;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Setting both `enableNative: false` and `autoInitializeNativeSdk: false` will now prioritize `enableNative: false`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setting both `enableNative: false` and `autoInitializeNativeSdk: false` ignores `enableNative: false` and only considers `autoInitializeNativeSdk` thus it would not initialize the native SDK but not set `NATIVE.enableNative: false`, allowing calls to still be made to the bridge.

Fixes #1461

## :green_heart: How did you test it?
Added a test for this precedence, also added tests for each of the scope sync methods as well.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
