### PR TITLE
Example Android event processor for Device ID (Do not merge)

### DIFF
--- a/sample/package.json
+++ b/sample/package.json
@@ -7,6 +7,7 @@
     "appium-doctor": "^1.15.4",
     "react": "17.0.1",
     "react-native": "0.64.0",
+    "react-native-device-info": "^8.1.3",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-reanimated": "^1.13.0",
     "react-native-safe-area-context": "^3.1.4",

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -67,15 +67,15 @@ Sentry.init({
   dist: `${packageVersion}.0`,
 });
 
-Sentry.addGlobalEventProcessor((event) => {
-  if (Platform.OS === 'android') {
+if (Platform.OS === 'android') {
+  Sentry.addGlobalEventProcessor((event) => {
     const id = DeviceInfo.getUniqueId();
 
     event.user = event.user ?? {id};
-  }
 
-  return event;
-});
+    return event;
+  });
+}
 
 const Stack = createStackNavigator();
 

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import {Platform} from 'react-native';
 import {Provider} from 'react-redux';
 import {
   NavigationContainer,
   NavigationContainerRef,
 } from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
+import DeviceInfo from 'react-native-device-info';
 
 // Import the Sentry React Native SDK
 import * as Sentry from '@sentry/react-native';
@@ -63,6 +65,16 @@ Sentry.init({
   // otherwise they will not work.
   release: packageVersion,
   dist: `${packageVersion}.0`,
+});
+
+Sentry.addGlobalEventProcessor((event) => {
+  if (Platform.OS === 'android') {
+    const id = DeviceInfo.getUniqueId();
+
+    event.user = event.user ?? {id};
+  }
+
+  return event;
 });
 
 const Stack = createStackNavigator();

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -9707,6 +9707,11 @@ react-native-codegen@^0.0.6:
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
 
+react-native-device-info@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.1.3.tgz#022fc01372632bf80c0a6d201aab53344efc715f"
+  integrity sha512-73e3wiGFL8DvIXEd8x4Aq+mO8mZvHARwfYorIEu+X0trLHY92bP5Ict8DJHDjCQ0+HtAvpA4Wda2VoUVN1zh6Q==
+
 react-native-gesture-handler@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"


### PR DESCRIPTION
Working example to reflect the solution we used on Flutter: https://github.com/getsentry/sentry-dart/issues/449

Fixes #1489

Will put this code into a migration guide on docs