### PR TITLE
Native + JS Startup Time Measurement (Do Not Merge)

### DIFF
--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -51,9 +51,13 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     private static PackageInfo packageInfo;
     private SentryOptions sentryOptions;
 
+  private long nativeStartedTime;
+
     public RNSentryModule(ReactApplicationContext reactContext) {
         super(reactContext);
         RNSentryModule.packageInfo = getPackageInfo(reactContext);
+
+    nativeStartedTime = System.currentTimeMillis();
     }
 
     @Override
@@ -166,6 +170,16 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
 
         promise.resolve(true);
     }
+
+  @ReactMethod
+  public void getNativeStartupTimestamps(Promise promise) {
+    WritableMap response = Arguments.createMap();
+
+    response.putDouble("nativeStartedTime", (double)nativeStartedTime);
+    response.putDouble("nativeStartTime", (double)(nativeStartedTime - 2000));
+
+    promise.resolve(response);
+  }
 
     @ReactMethod
     public void crash() {

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -343,6 +343,14 @@ export const NATIVE = {
     });
   },
 
+  async getNativeStartupTimestamps(): Promise<{
+    nativeStartTime: number;
+    nativeStartedTime: number;
+  }> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return RNSentry.getNativeStartupTimestamps();
+  },
+
   /**
    * Serializes all values of root-level keys into strings.
    * @param data key-value map.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This is just a quick proof of concept on which points RN would use to measure startup time...**The first two timestamp points will need to be retrieved from the Native SDK and not like what is here currently**

Measures the startup time in a transaction. Creates a parent transaction that contains the app's full startup time, with two child spans, the first being the native layer startup time, and the second the js layer startup time.

<img width="1121" alt="Screen Shot 2021-05-12 at 8 19 07 PM" src="https://user-images.githubusercontent.com/30991498/117981561-538dd080-b35f-11eb-9659-9e8bb35a2325.png">


The timestamp points used are the constructor of the RNSentry module as the native layer started point, and the global closure of the JS code as the js layer started point. The first pre-start timestamp is currently a temporary native layer started - 2000ms.

This proof of concept code temporarily lies in the backend class, where it shouldn't be and will be moved somewhere more suitable. It also does not handle the case of a refreshed js bundle causing a new js "startup" 



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
