### PR TITLE
fix: Use the latest outbox path from hub options instead of private options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - build(android): Bump Android SDK to 5.0.0-beta.3. #1508
+- fix: Use the latest outbox path from hub options instead of private options #1529
 
 ## 2.5.0-beta.1
 

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -33,6 +33,7 @@ import io.sentry.android.core.NdkIntegration;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.Sentry;
 import io.sentry.Breadcrumb;
+import io.sentry.HubAdapter;
 import io.sentry.Integration;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
@@ -49,7 +50,6 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     final static Logger logger = Logger.getLogger("react-native-sentry");
 
     private static PackageInfo packageInfo;
-    private SentryOptions sentryOptions;
 
     public RNSentryModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -161,7 +161,6 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             }
 
             logger.info(String.format("Native Integrations '%s'", options.getIntegrations().toString()));
-            sentryOptions = options;
         });
 
         promise.resolve(true);
@@ -184,7 +183,8 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void captureEnvelope(String envelope, Promise promise) {
         try {
-            File installation = new File(sentryOptions.getOutboxPath(), UUID.randomUUID().toString());
+      String outboxPath = HubAdapter.getInstance().getOptions().getOutboxPath();
+      File installation = new File(outboxPath, UUID.randomUUID().toString());
             try (FileOutputStream out = new FileOutputStream(installation)) {
                 out.write(envelope.getBytes(Charset.forName("UTF-8")));
             }

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -183,10 +183,15 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void captureEnvelope(String envelope, Promise promise) {
         try {
-      String outboxPath = HubAdapter.getInstance().getOptions().getOutboxPath();
-      File installation = new File(outboxPath, UUID.randomUUID().toString());
-            try (FileOutputStream out = new FileOutputStream(installation)) {
-                out.write(envelope.getBytes(Charset.forName("UTF-8")));
+            final String outboxPath = HubAdapter.getInstance().getOptions().getOutboxPath();
+
+            if (outboxPath == null) {
+                logger.severe("Error retrieving outboxPath. Envelope will not be sent. Is the Android SDK initialized?");
+            } else {
+                File installation = new File(outboxPath, UUID.randomUUID().toString());
+                try (FileOutputStream out = new FileOutputStream(installation)) {
+                    out.write(envelope.getBytes(Charset.forName("UTF-8")));
+                }
             }
         } catch (Exception e) {
             logger.severe("Error reading envelope");


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Gets the latest outbox path from the hub through `HubAdapter` instead of a private variable like before. This fixes the issue of not having the correct outbox path or not having it entirely if the user decides to init the SDK elsewhere and disabling auto init using `autoInitNativeSdk: false`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1516 

## :green_heart: How did you test it?
Android Sample + e2e tests (waiting)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Maybe release this fix before the beta as `2.4.3`.