### PR TITLE
feat: Sentry.flush to flush events to disk and returns a promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - build(android): Bump Android SDK to 5.0.0-beta.3. #1508
 - fix: Use the latest outbox path from hub options instead of private options #1529
 - build(android): Bump Android SDK to 5.0.0-beta.4. #1545
+- feat: Sentry.flush to flush events to disk and returns a promise #1547
 
 ## 2.5.0-beta.1
 

--- a/sample/src/screens/HomeScreen.tsx
+++ b/sample/src/screens/HomeScreen.tsx
@@ -196,6 +196,13 @@ const HomeScreen = (props: Props) => {
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
+                Sentry.flush();
+              }}>
+              <Text style={styles.buttonText}>Flush</Text>
+            </TouchableOpacity>
+            <View style={styles.spacer} />
+            <TouchableOpacity
+              onPress={() => {
                 Sentry.close();
               }}>
               <Text style={styles.buttonText}>Close</Text>

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -56,7 +56,7 @@ export { ReactNativeBackend } from "./backend";
 export { ReactNativeOptions } from "./options";
 export { ReactNativeClient } from "./client";
 // eslint-disable-next-line deprecation/deprecation
-export { init, setDist, setRelease, nativeCrash, close } from "./sdk";
+export { init, setDist, setRelease, nativeCrash, flush, close } from "./sdk";
 export { TouchEventBoundary, withTouchEventBoundary } from "./touchevents";
 
 export {

--- a/src/js/sdk.ts
+++ b/src/js/sdk.ts
@@ -120,6 +120,27 @@ export function nativeCrash(): void {
 }
 
 /**
+ * Flushes all pending events in the queue to disk.
+ * Use this before applying any realtime updates such as code-push or expo updates.
+ */
+export async function flush(): Promise<boolean> {
+  try {
+    const client = getCurrentHub().getClient<ReactNativeClient>();
+
+    if (client) {
+      const result = await client.flush();
+
+      return result;
+    }
+    // eslint-disable-next-line no-empty
+  } catch (_) {}
+
+  logger.error("Failed to flush the event queue.");
+
+  return false;
+}
+
+/**
  * Closes the SDK, stops sending events.
  */
 export async function close(): Promise<void> {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -1,0 +1,52 @@
+import { logger } from "@sentry/utils";
+
+import { flush } from "../src/js/sdk";
+
+jest.mock("@sentry/react", () => {
+  const mockClient = {
+    flush: jest.fn(() => Promise.resolve(true)),
+  };
+
+  return {
+    getCurrentHub: jest.fn(() => ({
+      getClient: jest.fn(() => mockClient),
+    })),
+  };
+});
+
+jest.spyOn(logger, "error");
+
+import { getCurrentHub } from "@sentry/react";
+
+describe("flush", () => {
+  it("Calls flush on the client", async () => {
+    const mockClient = getCurrentHub().getClient();
+
+    expect(mockClient).toBeTruthy();
+
+    if (mockClient) {
+      const flushResult = await flush();
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockClient.flush).toBeCalled();
+      expect(flushResult).toBe(true);
+    }
+  });
+
+  it("Returns false if flush failed and logs error", async () => {
+    const mockClient = getCurrentHub().getClient();
+
+    expect(mockClient).toBeTruthy();
+    if (mockClient) {
+      mockClient.flush = jest.fn(() => Promise.reject());
+
+      const flushResult = await flush();
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mockClient.flush).toBeCalled();
+      expect(flushResult).toBe(false);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(logger.error).toBeCalledWith("Failed to flush the event queue.");
+    }
+  });
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Exports a new public `Sentry.flush` method to flush all pending events in the queue to disk and return a promise that can be awaited.

This method should be used and awaited before live-reloading the JS bundle to ensure any events in the queue are properly stored on disk.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
User contacted support with an issue regarding missing events when reloading the JS bundle using expo-updates, this would also be applicable to code-push updates.

## :green_heart: How did you test it?
On sample app and with new tests for `sdk.ts`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
