### PR TITLE
fix: Process "log" levels in breadcrumbs before sending to native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fix: Use the latest outbox path from hub options instead of private options #1529
 - build(android): Bump Android SDK to 5.0.0-beta.4. #1545
 - feat: Sentry.flush to flush events to disk and returns a promise #1547
+- fix: Process "log" levels in breadcrumbs before sending to native #1565
 
 ## 2.5.0-beta.1
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -22,7 +22,7 @@ export const NATIVE = {
    * Sending the event over the bridge to native
    * @param event Event
    */
-  async sendEvent(event: Event): Promise<Response> {
+  async sendEvent(_event: Event): Promise<Response> {
     if (!this.enableNative) {
       return {
         reason: `Event was skipped as native SDK is not enabled.`,
@@ -33,8 +33,7 @@ export const NATIVE = {
       throw this._NativeClientError;
     }
 
-    // Process and convert deprecated levels
-    event.level = event.level ? this._processLevel(event.level) : undefined;
+    const event = this._processLevels(_event);
 
     const header = {
       event_id: event.event_id,
@@ -360,6 +359,26 @@ export const NATIVE = {
     });
 
     return serialized;
+  },
+
+  /**
+   * Convert js severity level in event.level and event.breadcrumbs to more widely supported levels.
+   * @param event
+   * @returns Event with more widely supported Severity level strings
+   */
+  _processLevels(event: Event): Event {
+    const processed: Event = {
+      ...event,
+      level: event.level ? this._processLevel(event.level) : undefined,
+      breadcrumbs: event.breadcrumbs?.map((breadcrumb) => ({
+        ...breadcrumb,
+        level: breadcrumb.level
+          ? this._processLevel(breadcrumb.level)
+          : undefined,
+      })),
+    };
+
+    return processed;
   },
 
   /**


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Processes `level` in breadcrumbs as well as the native layers do not support the `"log"` level that is used in JS.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Every time a `log` breadcrumb comes through, an error happens and the breadcrumb could've been dropped. Also could've caused duplication seen in #1409?

Related change made for the Capacitor SDK: https://github.com/getsentry/sentry-capacitor/pull/46

## :green_heart: How did you test it?
Tested on sample app and confirmed through logcat logs. Await for e2e tests on CI.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
