### PR TITLE
fix: Fatal uncaught events should be tagged handled:false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Fatal uncaught events should be tagged handled:false #1597
+
 ## 2.5.0
 
 ### Dependencies
@@ -16,8 +18,8 @@
 - feat: `Sentry.close()` method to fully disable the SDK on all layers and returns a promise #1457
 
 ### Fixes
-- fix: Process "log" levels in breadcrumbs before sending to native #1565
 
+- fix: Process "log" levels in breadcrumbs before sending to native #1565
 
 ## 2.5.0-beta.1
 

--- a/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/test/integrations/reactnativeerrorhandlers.test.ts
@@ -1,0 +1,89 @@
+import { ReactNativeErrorHandlers } from "../../src/js/integrations/reactnativeerrorhandlers";
+
+jest.mock("@sentry/core", () => {
+  const core = jest.requireActual("@sentry/core");
+
+  const client = {
+    getOptions: () => ({}),
+  };
+
+  const hub = {
+    getClient: () => client,
+    captureEvent: jest.fn(),
+  };
+
+  return {
+    ...core,
+    addGlobalEventProcessor: jest.fn(),
+    getCurrentHub: () => hub,
+  };
+});
+
+import { getCurrentHub } from "@sentry/core";
+import { Severity } from "@sentry/types";
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("ReactNativeErrorHandlers", () => {
+  describe("onError", () => {
+    test("Sets handled:false on a fatal error", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      let callback: (error: Error, isFatal: boolean) => Promise<void> = () =>
+        Promise.resolve();
+
+      ErrorUtils.setGlobalHandler = jest.fn((_callback) => {
+        callback = _callback as typeof callback;
+      });
+
+      const integration = new ReactNativeErrorHandlers();
+
+      integration.setupOnce();
+
+      expect(ErrorUtils.setGlobalHandler).toHaveBeenCalledWith(callback);
+
+      await callback(new Error("Test Error"), true);
+
+      const hub = getCurrentHub();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockCall = (hub.captureEvent as jest.MockedFunction<
+        typeof hub.captureEvent
+      >).mock.calls[0];
+      const event = mockCall[0];
+
+      expect(event.level).toBe(Severity.Fatal);
+      expect(event.exception?.values?.[0].mechanism?.handled).toBe(false);
+      expect(event.exception?.values?.[0].mechanism?.type).toBe("onerror");
+    });
+
+    test("Does not set handled:false on a non-fatal error", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      let callback: (error: Error, isFatal: boolean) => Promise<void> = () =>
+        Promise.resolve();
+
+      ErrorUtils.setGlobalHandler = jest.fn((_callback) => {
+        callback = _callback as typeof callback;
+      });
+
+      const integration = new ReactNativeErrorHandlers();
+
+      integration.setupOnce();
+
+      expect(ErrorUtils.setGlobalHandler).toHaveBeenCalledWith(callback);
+
+      await callback(new Error("Test Error"), false);
+
+      const hub = getCurrentHub();
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const mockCall = (hub.captureEvent as jest.MockedFunction<
+        typeof hub.captureEvent
+      >).mock.calls[0];
+      const event = mockCall[0];
+
+      expect(event.level).toBe(Severity.Error);
+      expect(event.exception?.values?.[0].mechanism?.handled).toBe(true);
+      expect(event.exception?.values?.[0].mechanism?.type).toBe("generic");
+    });
+  });
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fatal uncaught errors sent from the React Native global error handler are now marked `handled: false` alongside `level: "fatal"` with the mechanism type `onerror`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Uncaught errors that crash the app should be marked `handled: false`. Not doing so meant our sessions might have not correctly been marked as crashed.

This fix is needed before we can tackle #1409.

## :green_heart: How did you test it?
Tested on Android sample app on both debug and release builds. Written new unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Land the PR to handle #1409.