### PR TITLE
Support sendDefaultPii on React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: Support the `sendDefaultPii` option. #1634
+
 ## 2.5.2
 
 - fix: Fix `Sentry.close()` not correctly resolving the promise on iOS. #1617

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -113,6 +113,9 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                 // by default we hide.
                 options.setAttachThreads(rnOptions.getBoolean("attachThreads"));
             }
+            if (rnOptions.hasKey("sendDefaultPii")) {
+                options.setSendDefaultPii(rnOptions.getBoolean("sendDefaultPii"));
+            }
 
             options.setBeforeSend((event, hint) -> {
                 // React native internally throws a JavascriptException

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -52,6 +52,13 @@ export interface ReactNativeOptions extends BrowserOptions {
   attachThreads?: boolean;
 
   /**
+   *  When enabled, certain personally identifiable information (PII) is added by active integrations.
+   *
+   * @default false
+   * */
+  sendDefaultPii?: boolean;
+
+  /**
    * Callback that is called after the RN SDK on the JS Layer has made contact with the Native Layer.
    */
   onReady?: (response: {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description
<!--- Describe your changes in detail -->
Adds support for `sendDefaultPii` in React Native.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The RN docs stated `sendDefaultPii` was supported but it wasn't in the TypeScript types. I queried this on the Sentry Community Discord[[1](https://discord.com/channels/621778831602221064/750735628932612096/857554081244512267)]. It was a documentation bug[[2](https://discord.com/channels/621778831602221064/750735628932612096/857554424929714198)] but @jennmueng & @bruno-garcia suggested I raise a PR so Sentry could officially support it on RN[[3](https://discord.com/channels/621778831602221064/750735628932612096/857591080367554560)].
 

## :green_heart: How did you test it?
There didn't appear to be any unit tests around the areas changed so I manually tested. I couldn't see a debug statement from the iOS/Java SDKs stating whether `sendDefaultPII` was enabled or disabled so I attached a debugger and ensured the native SDK `sendDefaultPii` option was correctly being set when specified in the RN options.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
