### PR TITLE
fix: Bump to sentry-cocoa@7.2.0-beta.7 but disable auto perf tracking

### DIFF
--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'Sentry', '7.0.0'
+  s.dependency 'Sentry', '7.2.0-beta.7'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -71,6 +71,10 @@ RCT_EXPORT_METHOD(startWithOptions:(NSDictionary *_Nonnull)options
         reject(@"SentryReactNative", error.localizedDescription, error);
         return;
     }
+    
+    // TEMPORARY FOR 2.7.0-beta.2 HOTFIX
+    sentryOptions.enableAutoPerformanceTracking = NO;
+
     [SentrySDK startWithOptionsObject:sentryOptions];
 
     // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Bumps to sentry cocoa `7.2.0-beta.7`. We disable auto performance tracking for now as this will be handled in a follow-up PR. We want to quickly release this fix.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-cocoa/issues/1248 by including  https://github.com/getsentry/sentry-cocoa/pull/1224

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
