### PR TITLE
fix: Fix the error handler (error dialog) not called in dev

### DIFF
--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -170,12 +170,14 @@ export class ReactNativeErrorHandlers implements Integration {
 
         currentHub.captureEvent(event);
 
-        // If in dev, we call the default handler anyway and hope the error will be sent
-        // Just for a better dev experience
         if (!__DEV__) {
           void client.flush(options.shutdownTimeout || 2000).then(() => {
             defaultHandler(error, isFatal);
           });
+        } else {
+          // If in dev, we call the default handler anyway and hope the error will be sent
+          // Just for a better dev experience
+          defaultHandler(error, isFatal);
         }
       });
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes a regression caused by #1597 that caused the default error handler (the red box dialog) not to be shown in dev mode.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Customer issue raised in slack.

## :green_heart: How did you test it?
iOS simulator.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
