### PR TITLE
feat: Align event.origin, event.environment and sdk info with other hybrid sdks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- feat: Align `event.origin`, `event.environment` with other hybrid sdks #1749
+- feat: Add native sdk package info onto events #1749
+
 ## 3.0.0-beta.3
 
 - feat: Add `wrap` wrapper method with profiler and touch event boundary #1728

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import io.sentry.SentryEvent;
 import io.sentry.android.core.AnrIntegration;
 import io.sentry.android.core.AppStartState;
 import io.sentry.android.core.NdkIntegration;
@@ -43,6 +44,7 @@ import io.sentry.SentryLevel;
 import io.sentry.UncaughtExceptionHandlerIntegration;
 import io.sentry.protocol.SdkVersion;
 import io.sentry.protocol.SentryException;
+import io.sentry.protocol.SentryPackage;
 import io.sentry.protocol.User;
 
 @ReactModule(name = RNSentryModule.NAME)
@@ -150,25 +152,8 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                     // We do nothing
                 }
 
-                // Add on the correct event.origin tag.
-                // it needs to be here so we can determine where it originated from.
-                SdkVersion sdkVersion = event.getSdk();
-                if (sdkVersion != null) {
-                    String sdkName = sdkVersion.getName();
-                    if (sdkName != null) {
-                        if (sdkName.equals("sentry.javascript.react-native")) {
-                            event.setTag("event.origin", "javascript");
-                        } else if (sdkName.equals("sentry.java.android") || sdkName.equals("sentry.native")) {
-                            event.setTag("event.origin", "android");
-
-                            if (sdkName.equals("sentry.native")) {
-                                event.setTag("event.environment", "native");
-                            } else {
-                                event.setTag("event.environment", "java");
-                            }
-                        }
-                    }
-                }
+                setEventOriginTag(event);
+                addPackages(event, options.getSdkVersion());
 
                 return event;
             });
@@ -444,6 +429,49 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
         if (RNSentryModule.frameMetricsAggregator != null) {
             RNSentryModule.frameMetricsAggregator.stop();
             RNSentryModule.frameMetricsAggregator = null;
+        }
+    }
+
+    private void setEventOriginTag(SentryEvent event) {
+        SdkVersion sdk = event.getSdk();
+        if (sdk != null) {
+          switch (sdk.getName()) {
+          // If the event is from capacitor js, it gets set there and we do not handle it here.
+          case "sentry.native":
+            setEventEnvironmentTag(event, "android", "native");
+            break;
+          case "sentry.java.android":
+            setEventEnvironmentTag(event, "android", "java");
+            break;
+          default:
+            break;
+          }
+        }
+    }
+
+    private void setEventEnvironmentTag(SentryEvent event, String origin, String environment) {
+        event.setTag("event.origin", origin);
+        event.setTag("event.environment", environment);
+    }
+
+    private void addPackages(SentryEvent event, SdkVersion sdk) {
+        SdkVersion eventSdk = event.getSdk();
+        if (eventSdk != null && eventSdk.getName().equals("sentry.javascript.react-native") && sdk != null) {
+            List<SentryPackage> sentryPackages = sdk.getPackages();
+            if (sentryPackages != null) {
+                for (SentryPackage sentryPackage : sentryPackages) {
+                    eventSdk.addPackage(sentryPackage.getName(), sentryPackage.getVersion());
+                }
+            }
+
+            List<String> integrations = sdk.getIntegrations();
+            if (integrations != null) {
+                for (String integration : integrations) {
+                    eventSdk.addIntegration(integration);
+                }
+            }
+
+            event.setSdk(eventSdk);
         }
     }
 }

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -102,11 +102,17 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
                         origin:(NSString *)origin
                    environment:(NSString *)environment {
   NSMutableDictionary *newTags = [NSMutableDictionary new];
-  if (nil != event.tags) {
+
+  if (nil != event.tags && [event.tags count] > 0) {
     [newTags addEntriesFromDictionary:event.tags];
   }
-  [newTags setValue:origin forKey:@"event.origin"];
-  [newTags setValue:environment forKey:@"event.environment"];
+  if (nil != origin) {
+    [newTags setValue:origin forKey:@"event.origin"];
+  }
+  if (nil != environment) {
+    [newTags setValue:environment forKey:@"event.environment"];
+  }
+
   event.tags = newTags;
 }
 
@@ -116,7 +122,7 @@ RCT_EXPORT_METHOD(fetchNativeSdkInfo:(RCTPromiseResolveBlock)resolve
     if (sentryOptions == nil) {
         return reject(@"SentryReactNative",@"Called fetchNativeSdkInfo without initializing the SDK first.", nil);
     }
-    
+
     resolve(@{
         @"name": sentryOptions.sdkInfo.name,
         @"version": sentryOptions.sdkInfo.version

--- a/src/js/definitions.ts
+++ b/src/js/definitions.ts
@@ -1,4 +1,4 @@
-import { Breadcrumb } from "@sentry/types";
+import { Breadcrumb, Package } from "@sentry/types";
 
 import { ReactNativeOptions } from "./options";
 
@@ -49,6 +49,7 @@ export interface SentryNativeBridgeModule {
     id: string;
     version: string;
   }>;
+  fetchNativeSdkInfo(): PromiseLike<Package>;
   fetchNativeDeviceContexts(): PromiseLike<NativeDeviceContextsResponse>;
   fetchNativeAppStart(): PromiseLike<NativeAppStartResponse | null>;
   fetchNativeFrames(): PromiseLike<NativeFramesResponse | null>;

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -81,31 +81,4 @@ export {
   ReactNavigationTransactionContext,
 } from "./tracing";
 
-/**
- * Adds the sdk info. Make sure this is called after @sentry/react's so this is the top-level SDK.
- */
-function createReactNativeEventProcessor(): void {
-  if (addGlobalEventProcessor) {
-    addGlobalEventProcessor((event) => {
-      event.platform = event.platform || "javascript";
-      event.sdk = {
-        ...event.sdk,
-        name: SDK_NAME,
-        packages: [
-          ...((event.sdk && event.sdk.packages) || []),
-          {
-            name: "npm:@sentry/react-native",
-            version: SDK_VERSION,
-          },
-        ],
-        version: SDK_VERSION,
-      };
-
-      return event;
-    });
-  }
-}
-
-createReactNativeEventProcessor();
-
 export { Integrations, SDK_NAME, SDK_VERSION };

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -13,7 +13,6 @@ export {
   User,
 } from "@sentry/types";
 
-import { addGlobalEventProcessor } from "@sentry/core";
 export {
   addGlobalEventProcessor,
   addBreadcrumb,

--- a/src/js/integrations/eventorigin.ts
+++ b/src/js/integrations/eventorigin.ts
@@ -1,0 +1,28 @@
+import { EventProcessor, Integration } from "@sentry/types";
+
+/** Default EventOrigin instrumentation */
+export class EventOrigin implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = "EventOrigin";
+
+  /**
+   * @inheritDoc
+   */
+  public name: string = EventOrigin.id;
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(addGlobalEventProcessor: (e: EventProcessor) => void): void {
+    addGlobalEventProcessor((event) => {
+      event.tags = event.tags ?? {};
+
+      event.tags["event.origin"] = "javascript";
+      event.tags["event.environment"] = "javascript";
+
+      return event;
+    });
+  }
+}

--- a/src/js/integrations/index.ts
+++ b/src/js/integrations/index.ts
@@ -2,3 +2,5 @@ export { DebugSymbolicator } from "./debugsymbolicator";
 export { DeviceContext } from "./devicecontext";
 export { ReactNativeErrorHandlers } from "./reactnativeerrorhandlers";
 export { Release } from "./release";
+export { EventOrigin } from "./eventorigin";
+export { SdkInfo } from "./sdkinfo";

--- a/src/js/integrations/sdkinfo.ts
+++ b/src/js/integrations/sdkinfo.ts
@@ -38,7 +38,7 @@ export class SdkInfo implements Integration {
 
       event.platform = event.platform || "javascript";
       event.sdk = {
-        ...event.sdk,
+        ...(event.sdk ?? {}),
         name: SDK_NAME,
         packages: [
           ...((event.sdk && event.sdk.packages) || []),

--- a/src/js/integrations/sdkinfo.ts
+++ b/src/js/integrations/sdkinfo.ts
@@ -1,0 +1,57 @@
+import { EventProcessor, Integration, Package } from "@sentry/types";
+import { logger } from "@sentry/utils";
+
+import { SDK_NAME, SDK_VERSION } from "../version";
+import { NATIVE } from "../wrapper";
+
+/** Default SdkInfo instrumentation */
+export class SdkInfo implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = "SdkInfo";
+
+  /**
+   * @inheritDoc
+   */
+  public name: string = SdkInfo.id;
+
+  private _nativeSdkInfo: Package | null = null;
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(addGlobalEventProcessor: (e: EventProcessor) => void): void {
+    addGlobalEventProcessor(async (event) => {
+      // The native SDK info package here is only used on iOS as `beforeSend` is not called on `captureEnvelope`.
+      // this._nativeSdkInfo should be defined a following time so this call won't always be awaited.
+      if (NATIVE.platform === "ios" && this._nativeSdkInfo === null) {
+        try {
+          this._nativeSdkInfo = await NATIVE.fetchNativeSdkInfo();
+        } catch (_) {
+          // If this fails, go ahead as usual as we would rather have the event be sent with a package missing.
+          logger.warn(
+            "[SdkInfo] Native SDK Info retrieval failed...something could be wrong with your Sentry installation."
+          );
+        }
+      }
+
+      event.platform = event.platform || "javascript";
+      event.sdk = {
+        ...event.sdk,
+        name: SDK_NAME,
+        packages: [
+          ...((event.sdk && event.sdk.packages) || []),
+          ...((this._nativeSdkInfo && [this._nativeSdkInfo]) || []),
+          {
+            name: "npm:@sentry/react-native",
+            version: SDK_VERSION,
+          },
+        ],
+        version: SDK_VERSION,
+      };
+
+      return event;
+    });
+  }
+}

--- a/src/js/integrations/sdkinfo.ts
+++ b/src/js/integrations/sdkinfo.ts
@@ -28,11 +28,12 @@ export class SdkInfo implements Integration {
       if (NATIVE.platform === "ios" && this._nativeSdkInfo === null) {
         try {
           this._nativeSdkInfo = await NATIVE.fetchNativeSdkInfo();
-        } catch (_) {
+        } catch (e) {
           // If this fails, go ahead as usual as we would rather have the event be sent with a package missing.
           logger.warn(
-            "[SdkInfo] Native SDK Info retrieval failed...something could be wrong with your Sentry installation."
+            "[SdkInfo] Native SDK Info retrieval failed...something could be wrong with your Sentry installation:"
           );
+          logger.warn(e);
         }
       }
 

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -10,8 +10,10 @@ import { ReactNativeClient } from "./client";
 import {
   DebugSymbolicator,
   DeviceContext,
+  EventOrigin,
   ReactNativeErrorHandlers,
   Release,
+  SdkInfo,
 } from "./integrations";
 import { ReactNativeOptions, ReactNativeWrapperOptions } from "./options";
 import { ReactNativeScope } from "./scope";
@@ -54,10 +56,14 @@ export function init(passedOptions: ReactNativeOptions): void {
       ...defaultIntegrations.filter(
         (i) => !IGNORED_DEFAULT_INTEGRATIONS.includes(i.name)
       ),
+      new EventOrigin(),
+      new SdkInfo(),
     ];
+
     if (__DEV__) {
       options.defaultIntegrations.push(new DebugSymbolicator());
     }
+
     options.defaultIntegrations.push(
       new RewriteFrames({
         iteratee: (frame: StackFrame) => {
@@ -94,9 +100,6 @@ export function init(passedOptions: ReactNativeOptions): void {
   }
 
   initAndBind(ReactNativeClient, options);
-
-  // set the event.origin tag.
-  getCurrentHub().setTag("event.origin", "javascript");
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
   if (getGlobalObject<any>().HermesInternal) {

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -2,6 +2,7 @@
 import {
   Breadcrumb,
   Event,
+  Package,
   Response,
   Severity,
   Status,
@@ -47,6 +48,7 @@ interface SentryNativeWrapper {
   fetchNativeDeviceContexts(): PromiseLike<NativeDeviceContextsResponse>;
   fetchNativeAppStart(): PromiseLike<NativeAppStartResponse | null>;
   fetchNativeFrames(): PromiseLike<NativeFramesResponse | null>;
+  fetchNativeSdkInfo(): PromiseLike<Package | null>;
 
   disableNativeFramesTracking(): void;
 
@@ -232,6 +234,25 @@ export const NATIVE: SentryNativeWrapper = {
     }
 
     return RNSentry.fetchNativeRelease();
+  },
+
+  /**
+   * Fetches the Sdk info for the native sdk.
+   * NOTE: Only available on iOS.
+   */
+  async fetchNativeSdkInfo(): Promise<Package | null> {
+    if (!this.enableNative) {
+      throw this._DisabledNativeError;
+    }
+    if (!this._isModuleLoaded(RNSentry)) {
+      throw this._NativeClientError;
+    }
+
+    if (this.platform !== "ios") {
+      return null;
+    }
+
+    return RNSentry.fetchNativeSdkInfo();
   },
 
   /**

--- a/test/integrations/eventorigin.test.ts
+++ b/test/integrations/eventorigin.test.ts
@@ -1,0 +1,26 @@
+import { Event } from "@sentry/types";
+
+import { EventOrigin } from "../../src/js/integrations";
+
+describe("Event Origin", () => {
+  it("Adds event.origin and event.environment javascript tags to events", (done) => {
+    const integration = new EventOrigin();
+
+    const mockEvent: Event = {};
+
+    integration.setupOnce(async (eventProcessor) => {
+      const processedEvent = await eventProcessor(mockEvent);
+
+      expect(processedEvent).toBeDefined();
+      if (processedEvent) {
+        expect(processedEvent.tags).toBeDefined();
+        if (processedEvent.tags) {
+          expect(processedEvent.tags["event.origin"]).toBe("javascript");
+          expect(processedEvent.tags["event.environment"]).toBe("javascript");
+        }
+      }
+
+      done();
+    });
+  });
+});

--- a/test/integrations/eventorigin.test.ts
+++ b/test/integrations/eventorigin.test.ts
@@ -9,18 +9,22 @@ describe("Event Origin", () => {
     const mockEvent: Event = {};
 
     integration.setupOnce(async (eventProcessor) => {
-      const processedEvent = await eventProcessor(mockEvent);
+      try {
+        const processedEvent = await eventProcessor(mockEvent);
 
-      expect(processedEvent).toBeDefined();
-      if (processedEvent) {
-        expect(processedEvent.tags).toBeDefined();
-        if (processedEvent.tags) {
-          expect(processedEvent.tags["event.origin"]).toBe("javascript");
-          expect(processedEvent.tags["event.environment"]).toBe("javascript");
+        expect(processedEvent).toBeDefined();
+        if (processedEvent) {
+          expect(processedEvent.tags).toBeDefined();
+          if (processedEvent.tags) {
+            expect(processedEvent.tags["event.origin"]).toBe("javascript");
+            expect(processedEvent.tags["event.environment"]).toBe("javascript");
+          }
         }
-      }
 
-      done();
+        done();
+      } catch (e) {
+        done(e);
+      }
     });
   });
 });

--- a/test/integrations/sdkinfo.test.ts
+++ b/test/integrations/sdkinfo.test.ts
@@ -1,0 +1,96 @@
+import { Event } from "@sentry/types";
+
+import { SdkInfo } from "../../src/js/integrations";
+import { NATIVE } from "../../src/js/wrapper";
+
+const mockPackage = {
+  name: "sentry-cocoa",
+  version: "0.0.1",
+};
+
+jest.mock("../../src/js/wrapper", () => {
+  const actual = jest.requireActual("../../src/js/wrapper");
+
+  return {
+    NATIVE: {
+      ...actual.NATIVE,
+      platform: "ios",
+      fetchNativeSdkInfo: jest.fn(() => Promise.resolve(mockPackage)),
+    },
+  };
+});
+
+afterEach(() => {
+  NATIVE.platform = "ios";
+});
+
+describe("Sdk Info", () => {
+  it("Adds native package and javascript platform to event on iOS", (done) => {
+    const integration = new SdkInfo();
+
+    const mockEvent: Event = {};
+
+    integration.setupOnce(async (eventProcessor) => {
+      try {
+        const processedEvent = await eventProcessor(mockEvent);
+
+        expect(processedEvent).toBeDefined();
+        if (processedEvent) {
+          expect(processedEvent.sdk).toBeDefined();
+          if (processedEvent.sdk) {
+            expect(processedEvent.sdk.packages).toBeDefined();
+            if (processedEvent.sdk.packages) {
+              expect(
+                processedEvent.sdk.packages.some(
+                  (pkg) =>
+                    pkg.name === mockPackage.name &&
+                    pkg.version === mockPackage.version
+                )
+              ).toBe(true);
+            }
+          }
+          expect(processedEvent.platform === "javascript");
+        }
+
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+
+  it("Adds javascript platform but not native package on Android", (done) => {
+    NATIVE.platform = "android";
+    const integration = new SdkInfo();
+
+    const mockEvent: Event = {};
+
+    integration.setupOnce(async (eventProcessor) => {
+      try {
+        const processedEvent = await eventProcessor(mockEvent);
+
+        expect(processedEvent).toBeDefined();
+        if (processedEvent) {
+          expect(processedEvent.sdk).toBeDefined();
+          if (processedEvent.sdk) {
+            expect(processedEvent.sdk.packages).toBeDefined();
+            if (processedEvent.sdk.packages) {
+              expect(
+                processedEvent.sdk.packages.some(
+                  (pkg) =>
+                    pkg.name === mockPackage.name &&
+                    pkg.version === mockPackage.version
+                )
+              ).toBe(false);
+            }
+          }
+          expect(processedEvent.platform === "javascript");
+        }
+
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Aligns the values for `event.origin` and `event.environment` with what we have on other Hybrid SDKs such as capacitor, cordova, and flutter.

Possible values:
- **event.origin**: `android`, `javascript`, `ios`,
- **event.environment**: `java`, `native`, `javascript`

Adds the `SdkInfo` integration so we now add the sdk package info of the native sdks to the event.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of #1701 

## :green_heart: How did you test it?
Wrote unit tests for each of the integrations + tested them on both ios and android sample apps.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes (As we changed the values for the tags, will break users.)
