### PR TITLE
fix: Move @sentry/wizard dependency to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,13 @@
     "@sentry/react": "6.12.0-beta.2",
     "@sentry/tracing": "6.12.0-beta.2",
     "@sentry/types": "6.12.0-beta.2",
-    "@sentry/utils": "6.12.0-beta.2",
-    "@sentry/wizard": "^1.2.2"
+    "@sentry/utils": "6.12.0-beta.2"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "6.12.0-beta.2",
     "@sentry-internal/eslint-plugin-sdk": "6.12.0-beta.2",
     "@sentry/typescript": "^5.20.0",
+    "@sentry/wizard": "^1.2.2",
     "@types/jest": "^26.0.15",
     "@types/react": "^16.9.49",
     "@types/react-native": "^0.64.2",


### PR DESCRIPTION
## :loudspeaker: Type of change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description

This moves the dependency `@sentry/wizard` to a `devDependency` of `sentry-react-native`.

## :bulb: Motivation and Context

We noticed that `@sentry/wizard` was bringing in `lodash` as a dependency to our React Native project. Since the wizard is only intended to be a development tool, it seemed appropriate to make it a `devDependency` instead.

## :green_heart: How did you test it?

I didn't test it, given the nature of the PR. If you want me to spin up the sample app I can, but it doesn't really make a lot of sense to do that.

## :pencil: Checklist

- [x] I reviewed submitted code
- [ ] I added tests to verify changes (n/a)
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Discuss ... and merge if cool!
