### PR TITLE
fix: Fix native frames not being added to transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feat: Align `event.origin`, `event.environment` with other hybrid sdks #1749
 - feat: Add native sdk package info onto events #1749
+- fix: Fix native frames not being added to transactions #1752
 
 ## 3.0.0-beta.3
 

--- a/src/js/tracing/nativeframes.ts
+++ b/src/js/tracing/nativeframes.ts
@@ -42,9 +42,7 @@ export class NativeFramesInstrumentation {
       "[ReactNativeTracing] Native frames instrumentation initialized."
     );
 
-    if (doesExist()) {
-      addGlobalEventProcessor(this._processEvent.bind(this));
-    }
+    addGlobalEventProcessor((event) => this._processEvent(event, doesExist));
   }
 
   /**
@@ -208,7 +206,14 @@ export class NativeFramesInstrumentation {
    * Adds frames measurements to an event. Called from a valid event processor.
    * Awaits for finish frames if needed.
    */
-  private async _processEvent(event: Event): Promise<Event> {
+  private async _processEvent(
+    event: Event,
+    doesExist: () => boolean
+  ): Promise<Event> {
+    if (!doesExist()) {
+      return event;
+    }
+
     if (
       event.type === "transaction" &&
       event.transaction &&


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Native frames were "timing out" due to when we moved the integration's self exist check out of the event processor and into the constructor. The instrumentation did not exist yet at that time so the check should be done in the event processor.

## :green_heart: How did you test it?
Tested on both iOS and Android sample apps

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes