### PR TITLE
build: Bump sentry-cocoa to 7.2.6 and sentry-android to 5.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - feat: Add native sdk package info onto events #1749
 - build(js): Bump sentry-javascript dependencies to 6.12.0 #1750
 - fix: Fix native frames not being added to transactions #1752
+- build(android): Bump sentry-android to 5.1.2 #1753
+- build(ios): Bump sentry-cocoa to 7.2.6 #1753
 
 ## 3.0.0-beta.3
 

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'Sentry', '7.2.0-beta.9'
+  s.dependency 'Sentry', '7.2.6'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,5 +26,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:5.1.0-beta.9'
+    api 'io.sentry:sentry-android:5.1.2'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Bumps sentry-cocoa to 7.2.6 and sentry-android to 5.1.2

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We should use the latest GA'd versions of the native sdks for the RN SDK's GA.


## :green_heart: How did you test it?
Sample app on both emulators + see e2e tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes