### PR TITLE
Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x (#1763)
 
 ## 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 - Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x (#1763)
 
 ## 3.0.2

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,10 @@ android {
         ndk {
             abiFilters "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
         }
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
     }
 }
 


### PR DESCRIPTION
fixed #1762
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
after updating new version,  android is build is crashing with this error
```
project1/node_modules/@sentry/react-native/android/src/main/java/io/sentry/react/RNSentryModule.java:86: error: lambda expressions are not supported in -source 7
        SentryAndroid.init(this.getReactApplicationContext(), options -> {
                                                                      ^
  (use -source 8 or higher to enable lambda expressions)
1 error

FAILURE: Build failed with an exception.
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
by running build on android

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
