### PR TITLE
Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x (#)
+- Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x (#1764)
 
 ## 3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x (#)
+
 ## 3.0.2
 
 - Bump: Android tooling API 30 (#1761)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,11 @@ android {
             abiFilters "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Fix #1762 if not using latest AGPs


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
