### PR TITLE
ref: Remove v5 prefix from react navigation instrumentation to support v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ref: Remove v5 prefix from react navigation instrumentation to support v6 #1768
+
 ## 3.0.3
 
 - Fix: Set Java 8 for source and target compatibility if not using AGP >= 4.2.x (#1763)

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -75,7 +75,9 @@ export { TouchEventBoundary, withTouchEventBoundary } from "./touchevents";
 export {
   ReactNativeTracing,
   ReactNavigationV4Instrumentation,
+  // eslint-disable-next-line deprecation/deprecation
   ReactNavigationV5Instrumentation,
+  ReactNavigationInstrumentation,
   RoutingInstrumentation,
   ReactNavigationTransactionContext,
 } from "./tracing";

--- a/src/js/tracing/index.ts
+++ b/src/js/tracing/index.ts
@@ -5,7 +5,11 @@ export {
   RoutingInstrumentationInstance,
 } from "./routingInstrumentation";
 
-export { ReactNavigationV5Instrumentation } from "./reactnavigationv5";
+export {
+  ReactNavigationInstrumentation,
+  // eslint-disable-next-line deprecation/deprecation
+  ReactNavigationV5Instrumentation,
+} from "./reactnavigation";
 export { ReactNavigationV4Instrumentation } from "./reactnavigationv4";
 export {
   ReactNavigationCurrentRoute,

--- a/test/tracing/reactnavigation.test.ts
+++ b/test/tracing/reactnavigation.test.ts
@@ -3,10 +3,10 @@ import { Transaction } from "@sentry/tracing";
 import { getGlobalObject } from "@sentry/utils";
 
 import {
-  BLANK_TRANSACTION_CONTEXT_V5,
-  NavigationRouteV5,
-  ReactNavigationV5Instrumentation,
-} from "../../src/js/tracing/reactnavigationv5";
+  BLANK_TRANSACTION_CONTEXT,
+  NavigationRoute,
+  ReactNavigationInstrumentation,
+} from "../../src/js/tracing/reactnavigation";
 
 const dummyRoute = {
   name: "Route",
@@ -14,20 +14,20 @@ const dummyRoute = {
 };
 
 class MockNavigationContainer {
-  currentRoute: NavigationRouteV5 = dummyRoute;
+  currentRoute: NavigationRoute = dummyRoute;
   listeners: Record<string, (e: any) => void> = {};
   addListener: any = jest.fn(
     (eventType: string, listener: (e: any) => void): void => {
       this.listeners[eventType] = listener;
     }
   );
-  getCurrentRoute(): NavigationRouteV5 {
+  getCurrentRoute(): NavigationRoute {
     return this.currentRoute;
   }
 }
 
 const getMockTransaction = () => {
-  const transaction = new Transaction(BLANK_TRANSACTION_CONTEXT_V5);
+  const transaction = new Transaction(BLANK_TRANSACTION_CONTEXT);
 
   // Assume it's sampled
   transaction.sampled = true;
@@ -45,9 +45,9 @@ afterEach(() => {
   jest.resetAllMocks();
 });
 
-describe("ReactNavigationV5Instrumentation", () => {
+describe("ReactNavigationInstrumentation", () => {
   test("transaction set on initialize", () => {
-    const instrumentation = new ReactNavigationV5Instrumentation();
+    const instrumentation = new ReactNavigationInstrumentation();
 
     const mockTransaction = getMockTransaction();
     const tracingListener = jest.fn(() => mockTransaction);
@@ -66,7 +66,7 @@ describe("ReactNavigationV5Instrumentation", () => {
 
     expect(mockTransaction.name).toBe(dummyRoute.name);
     expect(mockTransaction.tags).toStrictEqual({
-      ...BLANK_TRANSACTION_CONTEXT_V5.tags,
+      ...BLANK_TRANSACTION_CONTEXT.tags,
       "routing.route.name": dummyRoute.name,
     });
     expect(mockTransaction.data).toStrictEqual({
@@ -81,7 +81,7 @@ describe("ReactNavigationV5Instrumentation", () => {
   });
 
   test("transaction sent on navigation", async () => {
-    const instrumentation = new ReactNavigationV5Instrumentation();
+    const instrumentation = new ReactNavigationInstrumentation();
 
     // Need a dummy transaction as the instrumentation will start a transaction right away when the first navigation container is attached.
     const mockTransactionDummy = getMockTransaction();
@@ -121,7 +121,7 @@ describe("ReactNavigationV5Instrumentation", () => {
 
         expect(mockTransaction.name).toBe(route.name);
         expect(mockTransaction.tags).toStrictEqual({
-          ...BLANK_TRANSACTION_CONTEXT_V5.tags,
+          ...BLANK_TRANSACTION_CONTEXT.tags,
           "routing.route.name": route.name,
         });
         expect(mockTransaction.data).toStrictEqual({
@@ -144,7 +144,7 @@ describe("ReactNavigationV5Instrumentation", () => {
   });
 
   test("transaction context changed with beforeNavigate", async () => {
-    const instrumentation = new ReactNavigationV5Instrumentation();
+    const instrumentation = new ReactNavigationInstrumentation();
 
     // Need a dummy transaction as the instrumentation will start a transaction right away when the first navigation container is attached.
     const mockTransactionDummy = getMockTransaction();
@@ -194,7 +194,7 @@ describe("ReactNavigationV5Instrumentation", () => {
   });
 
   test("transaction not sent on a cancelled navigation", async () => {
-    const instrumentation = new ReactNavigationV5Instrumentation();
+    const instrumentation = new ReactNavigationInstrumentation();
 
     // Need a dummy transaction as the instrumentation will start a transaction right away when the first navigation container is attached.
     const mockTransactionDummy = getMockTransaction();
@@ -224,10 +224,10 @@ describe("ReactNavigationV5Instrumentation", () => {
       setTimeout(() => {
         expect(mockTransaction.sampled).toBe(false);
         expect(mockTransaction.name).toStrictEqual(
-          BLANK_TRANSACTION_CONTEXT_V5.name
+          BLANK_TRANSACTION_CONTEXT.name
         );
         expect(mockTransaction.tags).toStrictEqual(
-          BLANK_TRANSACTION_CONTEXT_V5.tags
+          BLANK_TRANSACTION_CONTEXT.tags
         );
         expect(mockTransaction.data).toStrictEqual({});
         resolve();
@@ -237,7 +237,7 @@ describe("ReactNavigationV5Instrumentation", () => {
 
   describe("navigation container registration", () => {
     test("registers navigation container object ref", () => {
-      const instrumentation = new ReactNavigationV5Instrumentation();
+      const instrumentation = new ReactNavigationInstrumentation();
       const mockNavigationContainer = new MockNavigationContainer();
       instrumentation.registerNavigationContainer({
         current: mockNavigationContainer,
@@ -260,7 +260,7 @@ describe("ReactNavigationV5Instrumentation", () => {
     });
 
     test("registers navigation container direct ref", () => {
-      const instrumentation = new ReactNavigationV5Instrumentation();
+      const instrumentation = new ReactNavigationInstrumentation();
       const mockNavigationContainer = new MockNavigationContainer();
       instrumentation.registerNavigationContainer(mockNavigationContainer);
 
@@ -283,7 +283,7 @@ describe("ReactNavigationV5Instrumentation", () => {
     test("does not register navigation container if there is an existing one", () => {
       _global.__sentry_rn_v5_registered = true;
 
-      const instrumentation = new ReactNavigationV5Instrumentation();
+      const instrumentation = new ReactNavigationInstrumentation();
       const mockNavigationContainer = new MockNavigationContainer();
       instrumentation.registerNavigationContainer({
         current: mockNavigationContainer,
@@ -298,7 +298,7 @@ describe("ReactNavigationV5Instrumentation", () => {
     });
 
     test("works if routing instrumentation registration is after navigation registration", async () => {
-      const instrumentation = new ReactNavigationV5Instrumentation();
+      const instrumentation = new ReactNavigationInstrumentation();
 
       const mockNavigationContainer = new MockNavigationContainer();
       instrumentation.registerNavigationContainer(mockNavigationContainer);
@@ -321,7 +321,7 @@ describe("ReactNavigationV5Instrumentation", () => {
 
   describe("options", () => {
     test("waits until routeChangeTimeoutMs", async () => {
-      const instrumentation = new ReactNavigationV5Instrumentation({
+      const instrumentation = new ReactNavigationInstrumentation({
         routeChangeTimeoutMs: 200,
       });
 
@@ -351,7 +351,7 @@ describe("ReactNavigationV5Instrumentation", () => {
     });
 
     test("discards if after routeChangeTimeoutMs", async () => {
-      const instrumentation = new ReactNavigationV5Instrumentation({
+      const instrumentation = new ReactNavigationInstrumentation({
         routeChangeTimeoutMs: 200,
       });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Rename the React Navigation V5 instrumentation by removing the V5 prefix as the same instrumentation supports both V5 and V6. We still export the `reactNavigationV5Instrumentation` for backwards compatibility purposes with a `@deprecated` tag.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1756 

## :green_heart: How did you test it?
Tested on an example app with React Navigation 6.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- Update docs: https://github.com/getsentry/sentry-docs/pull/4134

- Add the React Navigation V6 example to the [examples](https://github.com/getsentry/examples) repo. Waiting for a release to be made with this PR so the example can have the correct imports.