### PR TITLE
meta(gha): Deploy action stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+name: 'close stale issues/PRs'
+on:
+  schedule:
+    - cron: '* */3 * * *'
+  workflow_dispatch:
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@87c2b794b9b47a9bec68ae03c01aeb572ffebdb1
+        with:
+          repo-token: ${{ github.token }}
+          days-before-stale: 21
+          days-before-close: 7
+          only-labels: ""
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          debug-only: false
+          ascending: false
+
+          exempt-issue-labels: "Status: Backlog,Status: In Progress"
+          stale-issue-label: "Status: Stale"
+          stale-issue-message: |-
+            This issue has gone three weeks without activity. In another week, I will close it.
+
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Backlog` or `Status: In Progress`, I will leave it alone ... forever!
+
+            ----
+
+            "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
+          skip-stale-issue-message: false
+          close-issue-label: ""
+          close-issue-message: ""
+
+          exempt-pr-labels: "Status: Backlog,Status: In Progress"
+          stale-pr-label: "Status: Stale"
+          stale-pr-message: |-
+            This pull request has gone three weeks without activity. In another week, I will close it.
+
+            But! If you comment or otherwise update it, I will reset the clock, and if you label it `Status: Backlog` or `Status: In Progress`, I will leave it alone ... forever!
+
+            ----
+
+            "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
+          skip-stale-pr-message: false
+          close-pr-label:
+          close-pr-message: ""


### PR DESCRIPTION
I are a bot, here to deploy [stale.yml](https://github.com/getsentry/.github/blob/6792a4b7673b043db114a3ff3d828522671606ce/.github/workflows/stale.yml). 🤖

#skip-changelog