### PR TITLE
fix(ios): tracesSampler becomes NSNull in iOS and the app cannot be started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Unreleased
 
-- fix(ios): tracesSampler becomes NSNull in iOS and the app cannot be started #
+- fix(ios): tracesSampler becomes NSNull in iOS and the app cannot be started #1872
 
 ## 3.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+- fix(ios): tracesSampler becomes NSNull in iOS and the app cannot be started #
+
 ## 3.2.2
 
 - Bump Sentry Android SDK to 5.3.0 #1860

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'Sentry', '7.4.8'
+  s.dependency 'Sentry', '7.5.1'
 
   s.source_files = 'ios/RNSentry.{h,m}'
   s.public_header_files = 'ios/RNSentry.h'

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -65,7 +65,7 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
     NSMutableDictionary * mutableOptions =[options mutableCopy];
     [mutableOptions setValue:beforeSend forKey:@"beforeSend"];
 
-    // remove performance traces sample rate and traces sampler since we don't want to syncronize these configuration
+    // remove performance traces sample rate and traces sampler since we don't want to synchronize these configurations
     // to the Native SDKs.
     // The user could tho initialize the SDK manually and set themselves.
     [mutableOptions removeObjectForKey:@"tracesSampleRate"];

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -64,6 +64,12 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
 
     [options setValue:beforeSend forKey:@"beforeSend"];
 
+    // remove performance traces sample rate and traces sampler since we don't want to syncronize these configuration
+    // to the Native SDKs.
+    // The user could tho initialize the SDK manually and set themselves.
+    [options removeObjectForKey:@"tracesSampleRate"];
+    [options removeObjectForKey:@"tracesSampler"];
+
     sentryOptions = [[SentryOptions alloc] initWithDict:options didFailWithError:&error];
     if (error) {
         reject(@"SentryReactNative", error.localizedDescription, error);

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -62,13 +62,14 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
         return event;
     };
 
-    [options setValue:beforeSend forKey:@"beforeSend"];
+    NSMutableDictionary * mutableOptions =[options mutableCopy];
+    [mutableOptions setValue:beforeSend forKey:@"beforeSend"];
 
     // remove performance traces sample rate and traces sampler since we don't want to syncronize these configuration
     // to the Native SDKs.
     // The user could tho initialize the SDK manually and set themselves.
-    [options removeObjectForKey:@"tracesSampleRate"];
-    [options removeObjectForKey:@"tracesSampler"];
+    [mutableOptions removeObjectForKey:@"tracesSampleRate"];
+    [mutableOptions removeObjectForKey:@"tracesSampler"];
 
     sentryOptions = [[SentryOptions alloc] initWithDict:options didFailWithError:&error];
     if (error) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-react-native/issues/1864


## :green_heart: How did you test it?
running with sampler

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
