### PR TITLE
Support monorepo in gradle android plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat(android): Support monorepo in gradle plugin #1917
+
 ## 3.2.4
 
 - fix: Warn when promise rejections won't be caught #1886

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -93,7 +93,10 @@ gradle.projectsEvaluated {
                   project.logger.info("file not found '$propertiesFile' for '$variant'")
               }
 
-              def resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
+              def resolvedCliPackage = null;
+              try {
+              resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
+              } catch (Throwable ignored) {}
               def cliPackage = resolvedCliPackage != null ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
               def cliExecutable = sentryProps.get("cli.executable", "$cliPackage/bin/sentry-cli")
 

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -97,7 +97,7 @@ gradle.projectsEvaluated {
               try {
               resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
               } catch (Throwable ignored) {}
-              def cliPackage = resolvedCliPackage != null ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
+              def cliPackage = resolvedCliPackage != null && resolvedCliPackage.exists() ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
               def cliExecutable = sentryProps.get("cli.executable", "$cliPackage/bin/sentry-cli")
 
               // fix path separator for Windows

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -93,9 +93,9 @@ gradle.projectsEvaluated {
                   project.logger.info("file not found '$propertiesFile' for '$variant'")
               }
 
-              def resolvedCliPackage = null;
+              def resolvedCliPackage = null
               try {
-                resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
+                  resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
               } catch (Throwable ignored) {}
               def cliPackage = resolvedCliPackage != null && resolvedCliPackage.exists() ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
               def cliExecutable = sentryProps.get("cli.executable", "$cliPackage/bin/sentry-cli")

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -95,7 +95,7 @@ gradle.projectsEvaluated {
 
               def resolvedCliPackage = null;
               try {
-              resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
+                resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
               } catch (Throwable ignored) {}
               def cliPackage = resolvedCliPackage != null && resolvedCliPackage.exists() ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
               def cliExecutable = sentryProps.get("cli.executable", "$cliPackage/bin/sentry-cli")

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -92,7 +92,10 @@ gradle.projectsEvaluated {
               } catch (FileNotFoundException e) {
                   project.logger.info("file not found '$propertiesFile' for '$variant'")
               }
-              def cliExecutable = sentryProps.get("cli.executable", "$reactRoot/node_modules/@sentry/cli/bin/sentry-cli")
+
+              def resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
+              def cliPackage = resolvedCliPackage != null ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
+              def cliExecutable = sentryProps.get("cli.executable", "$cliPackage/bin/sentry-cli")
 
               // fix path separator for Windows
               if (Os.isFamily(Os.FAMILY_WINDOWS)) {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Instead of hardcoding the path to @sentry/cli when an executable path is not provided we can use node to get the path instead.

## :bulb: Motivation and Context

This is the technique used by expo libraries to get the path to where js deps are installed.

## :green_heart: How did you test it?

Tested locally in an app inside a monorepo

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
