### PR TITLE
fix: Fix dynamic require for promise options ignoring try catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Fix dynamic require for promise options bypassing try catch block and crashing apps #1923
+
 ## 3.2.4
 
 - fix: Warn when promise rejections won't be caught #1886

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -95,11 +95,12 @@ export class ReactNativeErrorHandlers implements Integration {
    * Gets the promise rejection handlers, tries to get React Native's default one but otherwise will default to console.logging unhandled rejections.
    */
   private _getPromiseRejectionTrackingOptions(): PromiseRejectionTrackingOptions {
+    const moduleName = "react-native/Libraries/promiseRejectionTrackingOptions";
     try {
       // Here we try to use React Native's original promise rejection handler.
+      // NOTE: We also need to define the module name as a variable and use .call instead of just calling require() like usual otherwise metro will try to fetch the dependency and ignore the try catch.
       // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-unsafe-member-access
-      return require("react-native/Libraries/promiseRejectionTrackingOptions")
-        .default;
+      return require.call(null, moduleName).default;
     } catch (e) {
       //  Default behavior if the React Native promise rejection handlers are not available such as an older RN version
       return {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a fatal bug caused by the SDK trying to make an inline dynamic require to a file that does not exist on older RN versions. Although the require is inside a try-catch block, the metro bundler's dependency magic, in trying to optimize dependencies, ignores the try catch statement.

Metro added the optional dependency feature in version 0.59, so having a dynamic require statement inside a try catch is not feasible for users on prior versions, **however** we can get around metro's dependency magic by defining the name of the dependency as a string variable, and instead, we pass it into `require.call`.

Fixes #1922 

## :green_heart: How did you test it?
Tested on an RN app running `react-native: 0.63.1` and `metro: 0.58.0` (before the optional dependency feature was added in 0.59).

E2E tests passing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
