### PR TITLE
fix: Remove dependency on promiseRejectionTrackingOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- fix: Remove dependency on promiseRejectionTrackingOptions #1928
+
+## 3.2.5
+
 - fix: Fix dynamic require for promise options bypassing try catch block and crashing apps #1923
 
 ## 3.2.4

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -73,6 +73,7 @@ export class ReactNativeErrorHandlers implements Integration {
 
       tracking.disable();
       tracking.enable({
+        allRejections: true,
         onUnhandled: (id: string, error: Error) => {
           if (__DEV__) {
             promiseRejectionTrackingOptions.onUnhandled(id, error);

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -12,7 +12,6 @@ interface ReactNativeErrorHandlersOptions {
 }
 
 interface PromiseRejectionTrackingOptions {
-  allRejections: boolean;
   onUnhandled: (id: string, error: unknown) => void;
   onHandled: (id: string) => void;
 }
@@ -95,24 +94,22 @@ export class ReactNativeErrorHandlers implements Integration {
    * Gets the promise rejection handlers, tries to get React Native's default one but otherwise will default to console.logging unhandled rejections.
    */
   private _getPromiseRejectionTrackingOptions(): PromiseRejectionTrackingOptions {
-    const moduleName = "react-native/Libraries/promiseRejectionTrackingOptions";
-    try {
-      // Here we try to use React Native's original promise rejection handler.
-      // NOTE: We also need to define the module name as a variable and use .call instead of just calling require() like usual otherwise metro will try to fetch the dependency and ignore the try catch.
-      // eslint-disable-next-line @typescript-eslint/no-var-requires,@typescript-eslint/no-unsafe-member-access
-      return require.call(null, moduleName).default;
-    } catch (e) {
-      //  Default behavior if the React Native promise rejection handlers are not available such as an older RN version
-      return {
-        allRejections: true,
-        onUnhandled: (_id: string, error: unknown) => {
-          // eslint-disable-next-line no-console
-          console.warn(error);
-        },
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        onHandled: (_id: string) => {},
-      };
-    }
+    return {
+      onUnhandled: (id, rejection = {}) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Possible Unhandled Promise Rejection (id: ${id}):\n${rejection}`
+        );
+      },
+      onHandled: (id) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Promise Rejection Handled (id: ${id})\n` +
+            "This means you can ignore any previous messages of the form " +
+            `"Possible Unhandled Promise Rejection (id: ${id}):"`
+        );
+      },
+    };
   }
   /**
    * Checks if the promise is the same one or not, if not it will warn the user

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -73,7 +73,6 @@ export class ReactNativeErrorHandlers implements Integration {
 
       tracking.disable();
       tracking.enable({
-        allRejections: true,
         onUnhandled: (id: string, error: Error) => {
           if (__DEV__) {
             promiseRejectionTrackingOptions.onUnhandled(id, error);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
by @jennmueng -> the simplest solution is to remove the dependency on react-native/Libraries/promiseRejectionTrackingOptions altogether. All it does is to prettify the promise rejection error message, before my PR we didn't prettify the message. This is causing more issues than it's worth.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1927


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
