### PR TITLE
fix: ReactNavigationV4Instrumentation null when evaluating 'state.routes'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: ReactNavigationV4Instrumentation null when evaluating 'state.routes' #
+- fix: ReactNavigationV4Instrumentation null when evaluating 'state.routes' #1940
 
 ## 3.2.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- fix: ReactNavigationV4Instrumentation null when evaluating 'state.routes' #
+
+## 3.2.6
+
 - feat(android): Support monorepo in gradle plugin #1917
 - fix: Remove dependency on promiseRejectionTrackingOptions #1928
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.2.6
+## Unreleased
 
 - fix: ReactNavigationV4Instrumentation null when evaluating 'state.routes' #1940
 

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -203,6 +203,16 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
     state: NavigationStateV4,
     updateLatestTransaction: boolean = false
   ): void {
+    // it's not guaranteed that a state is always produced.
+    // see: https://github.com/react-navigation/react-navigation/blob/45d419be93c34e900e8734ce98321ae875ac4997/packages/core/src/routers/SwitchRouter.js?rgh-link-date=2021-09-25T12%3A43%3A36Z#L301
+    if (!state) {
+      logger.warn(
+        "[ReactNavigationV4Instrumentation] onStateChange called without a valid state."
+      );
+
+      return;
+    }
+
     const currentRoute = this._getCurrentRouteFromState(state);
 
     // If the route is a different key, this is so we ignore actions that pertain to the same screen.

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -200,12 +200,12 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
    * To be called on navigation state changes and creates the transaction.
    */
   private _onStateChange(
-    state: NavigationStateV4,
+    state: NavigationStateV4 | undefined,
     updateLatestTransaction: boolean = false
   ): void {
     // it's not guaranteed that a state is always produced.
     // see: https://github.com/react-navigation/react-navigation/blob/45d419be93c34e900e8734ce98321ae875ac4997/packages/core/src/routers/SwitchRouter.js?rgh-link-date=2021-09-25T12%3A43%3A36Z#L301
-    if (!state) {
+    if (!state || state === undefined) {
       logger.warn(
         "[ReactNavigationV4Instrumentation] onStateChange called without a valid state."
       );


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: ReactNavigationV4Instrumentation null when evaluating 'state.routes'


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-react-native/issues/1454


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
