### PR TITLE
Deprecate initialScope in favor of configureScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Deprecate initialScope in favor of configureScope #1963
+
 ## 3.2.8
 
 ### Various fixes & improvements

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -1,5 +1,6 @@
 import { BrowserOptions } from "@sentry/react";
 import { ProfilerProps } from "@sentry/react/dist/profiler";
+import { CaptureContext } from "@sentry/types/dist/scope";
 
 import { TouchEventBoundaryProps } from "./touchevents";
 
@@ -79,7 +80,13 @@ export interface ReactNativeOptions extends BrowserOptions {
    *
    * @default true
    * */
-   enableOutOfMemoryTracking?: boolean;
+  enableOutOfMemoryTracking?: boolean;
+
+  /**
+   * Set data to the inital scope
+   * @deprecated Use `Sentry.configureScope(...)`
+   */
+  initialScope?: CaptureContext;
 }
 
 export interface ReactNativeWrapperOptions {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
Deprecate initialScope in favor of configureScope


## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-react-native/issues/1925


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
Remove in the next major version