### PR TITLE
test(e2e): Fix ios e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,7 +118,7 @@ jobs:
         run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload > appium.log &
       - name: Build and run iOS emulator
         working-directory: ./sample
-        run: react-native run-ios --configuration Release --simulator "iPhone 12"
+        run: react-native run-ios --configuration Release --simulator "iPhone 13"
 
         # Ping the Appium server to make sure its running, this way if it does fail it'll be easy to tell that this step failed and not the tests
       - name: Ping Appium Server

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,7 +121,7 @@ jobs:
         run: react-native run-ios --configuration Release --simulator "iPhone 13"
       - name: Build WDA
         working-directory: ./sample
-        run: xcodebuild -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath /Users/runner/work/sentry-react-native/sentry-react-native/sample/xc-build -destination id=846E82B7-C95A-4C73-A4AB-4A99FC7F1E09 IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
+        run: xcodebuild -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath /Users/runner/work/sentry-react-native/sentry-react-native/sample/xc-build -destination name="iPhone 13" IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
       - name: Install WDA
         working-directory: ./sample
         run: xcrun simctl install "iPhone 13" './xc-build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Start Appium Server
         working-directory: ./sample
-        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload |& tee appium.log &
+        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload | tee appium.log &
       - name: Run Android Emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -115,7 +115,7 @@ jobs:
         run: pod install
       - name: Start Appium Server
         working-directory: ./sample
-        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload |& tee appium.log &
+        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload | tee appium.log &
       - name: Build and run iOS emulator
         working-directory: ./sample
         run: react-native run-ios --configuration Release --simulator "iPhone 13"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Start Appium Server
         working-directory: ./sample
-        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload | tee appium.log &
+        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload > appium.log &
       - name: Run Android Emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -69,6 +69,8 @@ jobs:
     env:
       PLATFORM: ios
       TEST: true
+      DEVICE: "iPhone 13"
+      IOS_DEPLOYMENT_TARGET: 15.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -108,29 +110,32 @@ jobs:
         if: steps.deps-cache.outputs['cache-hit'] != 'true'
         working-directory: ./sample
         run: yarn install
-
       - name: Install iOS pods
         # Even though we cache the pods, we call it regardless
         working-directory: ./sample/ios
         run: pod install
+
       - name: Start Appium Server
         working-directory: ./sample
-        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload | tee appium.log &
+        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload > appium.log &
       - name: Build and run iOS emulator
         working-directory: ./sample
-        run: react-native run-ios --configuration Release --simulator "iPhone 13"
+        run: react-native run-ios --configuration Release --simulator $DEVICE
+
       - name: Build WDA
         working-directory: ./sample
-        run: xcodebuild -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath /Users/runner/work/sentry-react-native/sentry-react-native/sample/xc-build -destination name="iPhone 13" IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
+        run: xcodebuild -project ./node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath ./xc-build -destination name=$DEVICE IPHONEOS_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
       - name: Install WDA
         working-directory: ./sample
-        run: xcrun simctl install "iPhone 13" './xc-build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app'
+        run: xcrun simctl install $DEVICE './xc-build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app'
+
         # Ping the Appium server to make sure its running, this way if it does fail it'll be easy to tell that this step failed and not the tests
       - name: Ping Appium Server
         run: curl --output /dev/null --silent --head --fail http://127.0.0.1:4723/wd/hub/sessions
       - name: Run Tests
         working-directory: ./sample
         run: yarn test
+
       - name: Upload Appium logs
         # This condition is so it uploads the logs always regardless of whether the previous step succeeded or not
         # otherwise it would not run if the previous step failed

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,16 +119,18 @@ jobs:
       - name: Build and run iOS emulator
         working-directory: ./sample
         run: react-native run-ios --configuration Release --simulator "iPhone 13"
-
+      - name: Build WDA
+        working-directory: ./sample
+        run: xcodebuild -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath /Users/runner/work/sentry-react-native/sentry-react-native/sample/xc-build -destination id=846E82B7-C95A-4C73-A4AB-4A99FC7F1E09 IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
+      - name: Install WDA
+        working-directory: ./sample
+        run: xcrun simctl install "iPhone 13" './xc-build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app'
         # Ping the Appium server to make sure its running, this way if it does fail it'll be easy to tell that this step failed and not the tests
       - name: Ping Appium Server
         run: curl --output /dev/null --silent --head --fail http://127.0.0.1:4723/wd/hub/sessions
       - name: Run Tests
         working-directory: ./sample
         run: yarn test
-      # - name: See what happens
-      #   working-directory: ./sample
-      #   run: xcodebuild build-for-testing test-without-building -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination id=EC07A4DD-8419-4679-8CC4-B57B229A2121 IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO
       - name: Upload Appium logs
         # This condition is so it uploads the logs always regardless of whether the previous step succeeded or not
         # otherwise it would not run if the previous step failed

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,9 +125,6 @@ jobs:
       - name: Build WDA
         working-directory: ./sample
         run: xcodebuild -project ./node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath ./xc-build -destination name=$DEVICE IPHONEOS_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
-      - name: Install WDA
-        working-directory: ./sample
-        run: xcrun simctl install $DEVICE './xc-build/Build/Products/Debug-iphonesimulator/WebDriverAgentRunner-Runner.app'
 
         # Ping the Appium server to make sure its running, this way if it does fail it'll be easy to tell that this step failed and not the tests
       - name: Ping Appium Server

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -123,9 +123,12 @@ jobs:
         # Ping the Appium server to make sure its running, this way if it does fail it'll be easy to tell that this step failed and not the tests
       - name: Ping Appium Server
         run: curl --output /dev/null --silent --head --fail http://127.0.0.1:4723/wd/hub/sessions
-      - name: Run Tests
+      # - name: Run Tests
+      #   working-directory: ./sample
+      #   run: yarn test
+      - name: See what happens
         working-directory: ./sample
-        run: yarn test
+        run: xcodebuild build-for-testing test-without-building -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination id=EC07A4DD-8419-4679-8CC4-B57B229A2121 IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO
       - name: Upload Appium logs
         # This condition is so it uploads the logs always regardless of whether the previous step succeeded or not
         # otherwise it would not run if the previous step failed

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -123,12 +123,12 @@ jobs:
         # Ping the Appium server to make sure its running, this way if it does fail it'll be easy to tell that this step failed and not the tests
       - name: Ping Appium Server
         run: curl --output /dev/null --silent --head --fail http://127.0.0.1:4723/wd/hub/sessions
-      # - name: Run Tests
-      #   working-directory: ./sample
-      #   run: yarn test
-      - name: See what happens
+      - name: Run Tests
         working-directory: ./sample
-        run: xcodebuild build-for-testing test-without-building -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination id=EC07A4DD-8419-4679-8CC4-B57B229A2121 IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO
+        run: yarn test
+      # - name: See what happens
+      #   working-directory: ./sample
+      #   run: xcodebuild build-for-testing test-without-building -project /Users/runner/work/sentry-react-native/sentry-react-native/sample/node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination id=EC07A4DD-8419-4679-8CC4-B57B229A2121 IPHONEOS_DEPLOYMENT_TARGET=15.0 GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO
       - name: Upload Appium logs
         # This condition is so it uploads the logs always regardless of whether the previous step succeeded or not
         # otherwise it would not run if the previous step failed

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,11 +120,11 @@ jobs:
         run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload > appium.log &
       - name: Build and run iOS emulator
         working-directory: ./sample
-        run: react-native run-ios --configuration Release --simulator $DEVICE
+        run: react-native run-ios --configuration Release --simulator "${DEVICE}"
 
       - name: Build WDA
         working-directory: ./sample
-        run: xcodebuild -project ./node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath ./xc-build -destination name=$DEVICE IPHONEOS_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
+        run: xcodebuild -project ./node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -derivedDataPath ./xc-build -destination name="${DEVICE}" IPHONEOS_DEPLOYMENT_TARGET=$IOS_DEPLOYMENT_TARGET GCC_TREAT_WARNINGS_AS_ERRORS=0 COMPILER_INDEX_STORE_ENABLE=NO build
 
         # Ping the Appium server to make sure its running, this way if it does fail it'll be easy to tell that this step failed and not the tests
       - name: Ping Appium Server

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Start Appium Server
         working-directory: ./sample
-        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload > appium.log &
+        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload |& tee appium.log &
       - name: Run Android Emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -115,7 +115,7 @@ jobs:
         run: pod install
       - name: Start Appium Server
         working-directory: ./sample
-        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload > appium.log &
+        run: yarn run appium --log-timestamp --log-no-colors --allow-insecure chromedriver_autodownload |& tee appium.log &
       - name: Build and run iOS emulator
         working-directory: ./sample
         run: react-native run-ios --configuration Release --simulator "iPhone 13"

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -20,6 +20,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+./xc-build
 
 # Android/IntelliJ
 #
@@ -57,3 +58,4 @@ buck-out/
 
 # CocoaPods
 /ios/Pods/
+

--- a/sample/package.json
+++ b/sample/package.json
@@ -3,7 +3,7 @@
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/native": "^5.7.3",
     "@react-navigation/stack": "^5.9.0",
-    "appium": "^1.23.0-beta.0",
+    "appium": "^1.22.1",
     "appium-doctor": "^1.16.0",
     "react": "17.0.1",
     "react-native": "0.64.2",

--- a/sample/package.json
+++ b/sample/package.json
@@ -3,7 +3,7 @@
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/native": "^5.7.3",
     "@react-navigation/stack": "^5.9.0",
-    "appium": "^1.22.0",
+    "appium": "^1.22.1",
     "appium-doctor": "^1.16.0",
     "react": "17.0.1",
     "react-native": "0.64.2",

--- a/sample/package.json
+++ b/sample/package.json
@@ -3,7 +3,7 @@
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/native": "^5.7.3",
     "@react-navigation/stack": "^5.9.0",
-    "appium": "^1.22.1",
+    "appium": "^1.23.0-beta.0",
     "appium-doctor": "^1.16.0",
     "react": "17.0.1",
     "react-native": "0.64.2",

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -30,6 +30,8 @@ beforeAll(async () => {
           newCommandTimeout: 600000,
           automationName: 'XCUITest',
           showXcodeLog: true,
+          iosInstallPause: 8000,
+          wdaStartupRetries: 6,
         };
 
   await driver.init(config);

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -30,8 +30,7 @@ beforeAll(async () => {
           newCommandTimeout: 600000,
           automationName: 'XCUITest',
           showXcodeLog: true,
-          iosInstallPause: 8000,
-          wdaStartupRetries: 6,
+          usePrebuiltWDA: true,
         };
 
   await driver.init(config);

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -25,10 +25,11 @@ beforeAll(async () => {
         }
       : {
           app: 'io.sentry.sample',
-          deviceName: 'iPhone 13',
+          deviceName: 'iPhone 12',
           platformName: 'iOS',
           newCommandTimeout: 600000,
           automationName: 'XCUITest',
+          showXcodeLog: true,
         };
 
   await driver.init(config);

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -25,7 +25,7 @@ beforeAll(async () => {
         }
       : {
           app: 'io.sentry.sample',
-          deviceName: 'iPhone 12',
+          deviceName: 'iPhone 13',
           platformName: 'iOS',
           newCommandTimeout: 600000,
           automationName: 'XCUITest',

--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -1,5 +1,6 @@
 // tslint:disable: no-unsafe-any
 import wd from 'wd';
+import path from 'path';
 
 import {fetchEvent} from '../utils/fetchEvent';
 
@@ -29,6 +30,7 @@ beforeAll(async () => {
           platformName: 'iOS',
           newCommandTimeout: 600000,
           automationName: 'XCUITest',
+          derivedDataPath: path.resolve('./xc-build'),
           showXcodeLog: true,
           usePrebuiltWDA: true,
         };

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -4252,7 +4252,7 @@ appium-xcuitest-driver@^3.27.4, appium-xcuitest-driver@^3.27.6:
     teen_process "^1.14.0"
     ws "^8.0.0"
 
-appium-youiengine-driver@^1.2.9:
+appium-youiengine-driver@^1.2.8:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/appium-youiengine-driver/-/appium-youiengine-driver-1.2.9.tgz#cf1e1282ed411d9d449d3c2d94b4958b1ed49cd4"
   integrity sha512-Xq3sttITAJi+fF42BepuyT82YwMWQCFpH21/fZuNwUv8Ry6jercFoNa0wz6SIXyXOMgmoHsf+uW7sinrcq/9tA==
@@ -4273,10 +4273,10 @@ appium-youiengine-driver@^1.2.9:
     source-map-support "^0.5.19"
     teen_process "^1.15.0"
 
-appium@^1.23.0-beta.0:
-  version "1.23.0-beta.0"
-  resolved "https://registry.yarnpkg.com/appium/-/appium-1.23.0-beta.0.tgz#4ce6c5e6cfc138970e2b2c19af134493398b0774"
-  integrity sha512-U1R5PCZ07Odp/jMGtbdI3xYeRVVdhPn0Q5l1053FGDJRleeHG29RAFskKNmtf2oP6ROLqX13ECcgKs6Dt55JKw==
+appium@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/appium/-/appium-1.22.1.tgz#cc8660d5803c996fa9b5fb7ad59129a4f2c4e72f"
+  integrity sha512-geeoVdqjjcpCrL0dVwAF3LP0yt06iPfJi6MG88MDa7mEGmDColxCnrX3qGrsCESSTR4G3KGKaSaTJMZRojSytg==
   dependencies:
     "@babel/runtime" "^7.6.0"
     appium-android-driver "^4.20.0"
@@ -4294,7 +4294,7 @@ appium@^1.23.0-beta.0:
     appium-uiautomator2-driver "^1.37.1"
     appium-windows-driver "1.x"
     appium-xcuitest-driver "^3.27.6"
-    appium-youiengine-driver "^1.2.9"
+    appium-youiengine-driver "^1.2.8"
     argparse "^2.0.1"
     async-lock "^1.0.0"
     asyncbox "2.x"
@@ -4304,7 +4304,7 @@ appium@^1.23.0-beta.0:
     find-root "^1.1.0"
     lodash "^4.17.11"
     longjohn "^0.2.12"
-    npmlog "5.x"
+    npmlog "4.x"
     semver "^7.0.0"
     source-map-support "^0.x"
     teen_process "1.x"
@@ -9119,17 +9119,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@5.x, npmlog@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
-  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
-  dependencies:
-    are-we-there-yet "^2.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^3.0.0"
-    set-blocking "^2.0.0"
-
-npmlog@^4.1.2:
+npmlog@4.x, npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -9138,6 +9128,16 @@ npmlog@^4.1.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+npmlog@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
+  integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
+  dependencies:
+    are-we-there-yet "^2.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^3.0.0"
+    set-blocking "^2.0.0"
 
 nullthrows@^1.1.1:
   version "1.1.1"

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -4273,10 +4273,10 @@ appium-youiengine-driver@^1.2.8:
     source-map-support "^0.5.19"
     teen_process "^1.15.0"
 
-appium@^1.22.0:
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/appium/-/appium-1.22.0.tgz#aac58877e63d0955df53585e9f5ac68e1bb2a927"
-  integrity sha512-k3SaI+FTRZp+KUO5GL4kJJFLvrEoTmi163/jk01Ms1VScuFkn1TQuGTMzK/ToUQOcSILMtFyHiRJB2c0q3YaVg==
+appium@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/appium/-/appium-1.22.1.tgz#cc8660d5803c996fa9b5fb7ad59129a4f2c4e72f"
+  integrity sha512-geeoVdqjjcpCrL0dVwAF3LP0yt06iPfJi6MG88MDa7mEGmDColxCnrX3qGrsCESSTR4G3KGKaSaTJMZRojSytg==
   dependencies:
     "@babel/runtime" "^7.6.0"
     appium-android-driver "^4.20.0"

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -4252,7 +4252,7 @@ appium-xcuitest-driver@^3.27.4, appium-xcuitest-driver@^3.27.6:
     teen_process "^1.14.0"
     ws "^8.0.0"
 
-appium-youiengine-driver@^1.2.8:
+appium-youiengine-driver@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/appium-youiengine-driver/-/appium-youiengine-driver-1.2.9.tgz#cf1e1282ed411d9d449d3c2d94b4958b1ed49cd4"
   integrity sha512-Xq3sttITAJi+fF42BepuyT82YwMWQCFpH21/fZuNwUv8Ry6jercFoNa0wz6SIXyXOMgmoHsf+uW7sinrcq/9tA==
@@ -4273,10 +4273,10 @@ appium-youiengine-driver@^1.2.8:
     source-map-support "^0.5.19"
     teen_process "^1.15.0"
 
-appium@^1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/appium/-/appium-1.22.1.tgz#cc8660d5803c996fa9b5fb7ad59129a4f2c4e72f"
-  integrity sha512-geeoVdqjjcpCrL0dVwAF3LP0yt06iPfJi6MG88MDa7mEGmDColxCnrX3qGrsCESSTR4G3KGKaSaTJMZRojSytg==
+appium@^1.23.0-beta.0:
+  version "1.23.0-beta.0"
+  resolved "https://registry.yarnpkg.com/appium/-/appium-1.23.0-beta.0.tgz#4ce6c5e6cfc138970e2b2c19af134493398b0774"
+  integrity sha512-U1R5PCZ07Odp/jMGtbdI3xYeRVVdhPn0Q5l1053FGDJRleeHG29RAFskKNmtf2oP6ROLqX13ECcgKs6Dt55JKw==
   dependencies:
     "@babel/runtime" "^7.6.0"
     appium-android-driver "^4.20.0"
@@ -4294,7 +4294,7 @@ appium@^1.22.1:
     appium-uiautomator2-driver "^1.37.1"
     appium-windows-driver "1.x"
     appium-xcuitest-driver "^3.27.6"
-    appium-youiengine-driver "^1.2.8"
+    appium-youiengine-driver "^1.2.9"
     argparse "^2.0.1"
     async-lock "^1.0.0"
     asyncbox "2.x"
@@ -4304,7 +4304,7 @@ appium@^1.22.1:
     find-root "^1.1.0"
     lodash "^4.17.11"
     longjohn "^0.2.12"
-    npmlog "4.x"
+    npmlog "5.x"
     semver "^7.0.0"
     source-map-support "^0.x"
     teen_process "1.x"
@@ -9119,17 +9119,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@4.x, npmlog@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
-  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
-  dependencies:
-    are-we-there-yet "~1.1.2"
-    console-control-strings "~1.1.0"
-    gauge "~2.7.3"
-    set-blocking "~2.0.0"
-
-npmlog@^5.0.0:
+npmlog@5.x, npmlog@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-5.0.1.tgz#f06678e80e29419ad67ab964e0fa69959c1eb8b0"
   integrity sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==
@@ -9138,6 +9128,16 @@ npmlog@^5.0.0:
     console-control-strings "^1.1.0"
     gauge "^3.0.0"
     set-blocking "^2.0.0"
+
+npmlog@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
 
 nullthrows@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The Appium server's build step for the WebDriverAgent (WDA) was either failing without any logs or hanging after the default iOS deployment target was switched from 14.4 to 15.0 on Github Actions. Attempts to obtain logs from the build step with `showXcodeLog` repeatedly failed. 

The solution is to disable the Appium server from building the WDA (`usePrebuiltWDA: true`) and instead build it ourselves as a step of the workflow. Also updates the iOS e2e tests to test on iPhone 13 instead of iPhone 12.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes failing iOS e2e tests.


## :green_heart: How did you test it?
Ran here on CI.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

#skip-changelog