### PR TITLE
fix: Fix types for allowing non-serializeable values

### DIFF
--- a/src/js/scope.ts
+++ b/src/js/scope.ts
@@ -3,6 +3,9 @@ import { Breadcrumb, User } from "@sentry/types";
 
 import { NATIVE } from "./wrapper";
 
+type SerializeableValue = string | number | boolean
+type SerializeableMap = { [key: string]: SerializeableValue }
+
 /**
  * Extends the scope methods to set scope on the Native SDKs
  */
@@ -37,8 +40,7 @@ export class ReactNativeScope extends Scope {
   /**
    * @inheritDoc
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public setExtras(extras: { [key: string]: any }): this {
+  public setExtras(extras: SerializeableMap): this {
     Object.keys(extras).forEach((key) => {
       NATIVE.setExtra(key, extras[key]);
     });
@@ -48,8 +50,7 @@ export class ReactNativeScope extends Scope {
   /**
    * @inheritDoc
    */
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types,@typescript-eslint/no-explicit-any
-  public setExtra(key: string, extra: any): this {
+  public setExtra(key: string, extra: SerializeableValue): this {
     NATIVE.setExtra(key, extra);
     return super.setExtra(key, extra);
   }
@@ -74,7 +75,7 @@ export class ReactNativeScope extends Scope {
    * @inheritDoc
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public setContext(key: string, context: { [key: string]: any } | null): this {
+  public setContext(key: string, context: SerializeableMap | null): this {
     NATIVE.setContext(key, context);
     return super.setContext(key, context);
   }


### PR DESCRIPTION
While this is perfectly valid code:

```ts
    Sentry.setContext('test', {
      values: [{ hi: 'test' }, { test: 'hi' }]
    })
```

it doesn't serialize the values in the dashboard:

![Screenshot 2021-12-20 at 13 41 28](https://user-images.githubusercontent.com/15199031/146768725-0cdbaf61-ec73-4bed-bbc2-6329588ecd41.png)

This PR fixes this by marking the types to only be serializeable values (string, number, boolean) to forbid Arrays and Objects. The user then has to serialize them himself.
