### PR TITLE
fix: Polyfill the promise library to permanently fix unhandled rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Polyfill the promise library to permanently fix unhandled rejections #1984
+
 ## 3.2.10
 
 - fix: Do not crash if androidx.core isn't available on Android #1981
@@ -10,7 +14,6 @@
 
 - Deprecate initialScope in favor of configureScope #1963
 - Bump: Sentry Android to 5.5.1 and Sentry Cocoa to 7.7.0 #1965
-- fix: Polyfill the promise library to permanently fix unhandled rejections #1984
 
 ## 3.2.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Deprecate initialScope in favor of configureScope #1963
 - Bump: Sentry Android to 5.5.1 and Sentry Cocoa to 7.7.0 #1965
+- fix: Polyfill the promise library to permanently fix unhandled rejections #1984
 
 ## 3.2.8
 

--- a/sample/package.json
+++ b/sample/package.json
@@ -29,9 +29,6 @@
   },
   "name": "sample",
   "private": true,
-  "resolutions": {
-    "promise": "^8.1.0"
-  },
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -1,7 +1,7 @@
 import { eventFromException } from "@sentry/browser";
 import { getCurrentHub } from "@sentry/core";
 import { Integration, Severity } from "@sentry/types";
-import { addExceptionMechanism, getGlobalObject, logger } from "@sentry/utils";
+import { addExceptionMechanism, logger } from "@sentry/utils";
 
 import { ReactNativeClient } from "../client";
 

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -62,7 +62,7 @@ export class ReactNativeErrorHandlers implements Integration {
         this._polyfillPromise();
       }
 
-      // this._attachUnhandledRejectionHandler();
+      this._attachUnhandledRejectionHandler();
       this._checkPromiseAndWarn();
     }
   }
@@ -92,9 +92,8 @@ export class ReactNativeErrorHandlers implements Integration {
     /* eslint-enable import/no-extraneous-dependencies,@typescript-eslint/no-var-requires */
   }
   /**
-   *
+   * Attach the unhandled rejection handler
    */
-  // @ts-ignore temp
   private _attachUnhandledRejectionHandler(): void {
     const tracking: {
       disable: () => void;

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -101,9 +101,23 @@ export class ReactNativeErrorHandlers implements Integration {
       // eslint-disable-next-line import/no-extraneous-dependencies,@typescript-eslint/no-var-requires
     } = require("promise/setimmediate/rejection-tracking");
 
-    const promiseRejectionTrackingOptions = this._getPromiseRejectionTrackingOptions();
+    const promiseRejectionTrackingOptions: PromiseRejectionTrackingOptions = {
+      onUnhandled: (id, rejection = {}) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Possible Unhandled Promise Rejection (id: ${id}):\n${rejection}`
+        );
+      },
+      onHandled: (id) => {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Promise Rejection Handled (id: ${id})\n` +
+            "This means you can ignore any previous messages of the form " +
+            `"Possible Unhandled Promise Rejection (id: ${id}):"`
+        );
+      },
+    };
 
-    tracking.disable();
     tracking.enable({
       allRejections: true,
       onUnhandled: (id: string, error: Error) => {
@@ -144,27 +158,6 @@ export class ReactNativeErrorHandlers implements Integration {
         "Unhandled promise rejections will not be caught by Sentry. Read about how to fix this on our troubleshooting page."
       );
     }
-  }
-  /**
-   * Gets the promise rejection handlers, tries to get React Native's default one but otherwise will default to console.logging unhandled rejections.
-   */
-  private _getPromiseRejectionTrackingOptions(): PromiseRejectionTrackingOptions {
-    return {
-      onUnhandled: (id, rejection = {}) => {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Possible Unhandled Promise Rejection (id: ${id}):\n${rejection}`
-        );
-      },
-      onHandled: (id) => {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `Promise Rejection Handled (id: ${id})\n` +
-            "This means you can ignore any previous messages of the form " +
-            `"Possible Unhandled Promise Rejection (id: ${id}):"`
-        );
-      },
-    };
   }
   /**
    * Handle errors

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -36,7 +36,7 @@ export class ReactNativeErrorHandlers implements Integration {
   private readonly _options: ReactNativeErrorHandlersOptions;
 
   /** Constructor */
-  public constructor(options?: ReactNativeErrorHandlersOptions) {
+  public constructor(options?: Partial<ReactNativeErrorHandlersOptions>) {
     this._options = {
       onerror: true,
       onunhandledrejection: true,
@@ -89,12 +89,12 @@ export class ReactNativeErrorHandlers implements Integration {
     require("promise/setimmediate/finally");
 
     polyfillGlobal("Promise", () => Promise);
-
     /* eslint-enable import/no-extraneous-dependencies,@typescript-eslint/no-var-requires */
   }
   /**
    *
    */
+  // @ts-ignore temp
   private _attachUnhandledRejectionHandler(): void {
     const tracking: {
       disable: () => void;

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -61,8 +61,26 @@ export class ReactNativeErrorHandlers implements Integration {
         This is due to a version mismatch between promise versions. The version will need to be fixed with a package resolution.
         We first run a check and show a warning if needed.
       */
+      this._polyfillPromise();
       this._checkPromiseVersion();
+    }
+  }
+  /**
+   *
+   */
+  private _polyfillPromise(): void {
+    const {
+      polyfillGlobal,
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+    } = require("react-native/Libraries/Utilities/PolyfillFunctions");
+    // eslint-disable-next-line import/no-extraneous-dependencies,@typescript-eslint/no-var-requires
+    const Promise = require("promise/setimmediate/es6-extensions");
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    require("promise/setimmediate/done");
+    // eslint-disable-next-line import/no-extraneous-dependencies
+    require("promise/setimmediate/finally");
 
+    polyfillGlobal("Promise", () => {
       const tracking: {
         disable: () => void;
         enable: (arg: unknown) => void;
@@ -88,7 +106,9 @@ export class ReactNativeErrorHandlers implements Integration {
           promiseRejectionTrackingOptions.onHandled(id);
         },
       });
-    }
+
+      return Promise;
+    });
   }
   /**
    * Gets the promise rejection handlers, tries to get React Native's default one but otherwise will default to console.logging unhandled rejections.

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -88,6 +88,14 @@ export interface ReactNativeOptions extends BrowserOptions {
    */
   initialScope?: CaptureContext;
 
+  /**
+   * When enabled, Sentry will overwrite the global Promise instance to ensure that unhandled rejections are correctly tracked.
+   * If you run into issues with Promise polyfills such as `core-js`, make sure you polyfill after Sentry is initialized.
+   * Read more at https://docs.sentry.io/platforms/react-native/troubleshooting/#unhandled-promise-rejections
+   *
+   * When disabled, this option will not disable unhandled rejection tracking. Set `onunhandledrejection: false` on the `ReactNativeErrorHandlers` integration instead.
+   * @default true
+   */
   patchGlobalPromise?: boolean;
 }
 

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -87,6 +87,8 @@ export interface ReactNativeOptions extends BrowserOptions {
    * @deprecated Use `Sentry.configureScope(...)`
    */
   initialScope?: CaptureContext;
+
+  patchGlobalPromise?: boolean;
 }
 
 export interface ReactNativeWrapperOptions {

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -31,6 +31,7 @@ const DEFAULT_OPTIONS: ReactNativeOptions = {
   autoInitializeNativeSdk: true,
   enableAutoPerformanceTracking: true,
   enableOutOfMemoryTracking: true,
+  patchGlobalPromise: true,
 };
 
 /**
@@ -52,7 +53,9 @@ export function init(passedOptions: ReactNativeOptions): void {
 
   if (options.defaultIntegrations === undefined) {
     options.defaultIntegrations = [
-      new ReactNativeErrorHandlers(),
+      new ReactNativeErrorHandlers({
+        patchGlobalPromise: options.patchGlobalPromise,
+      }),
       new Release(),
       ...defaultIntegrations.filter(
         (i) => !IGNORED_DEFAULT_INTEGRATIONS.includes(i.name)

--- a/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/test/integrations/reactnativeerrorhandlers.test.ts
@@ -29,13 +29,8 @@ jest.mock("@sentry/utils", () => {
   };
 });
 
-jest.mock("promise/setimmediate/core", () => {
-  return {};
-});
-
 import { getCurrentHub } from "@sentry/core";
 import { Severity } from "@sentry/types";
-import { getGlobalObject, logger } from "@sentry/utils";
 
 import { ReactNativeErrorHandlers } from "../../src/js/integrations/reactnativeerrorhandlers";
 
@@ -105,32 +100,6 @@ describe("ReactNativeErrorHandlers", () => {
       expect(event.level).toBe(Severity.Error);
       expect(event.exception?.values?.[0].mechanism?.handled).toBe(true);
       expect(event.exception?.values?.[0].mechanism?.type).toBe("generic");
-    });
-  });
-
-  describe("onUnhandledRejection", () => {
-    it("Warns if promise instances are different", () => {
-      const _global = getGlobalObject<{ Promise: any }>();
-
-      _global.Promise = {};
-
-      const inst = new ReactNativeErrorHandlers();
-      inst.setupOnce();
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(logger.warn).toBeCalled();
-    });
-
-    it("Does not warn if promise instances match", () => {
-      const _global = getGlobalObject<{ Promise: any }>();
-
-      _global.Promise = require("promise/setimmediate/core");
-
-      const inst = new ReactNativeErrorHandlers();
-      inst.setupOnce();
-
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(logger.warn).not.toBeCalled();
     });
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Instead of warning the user and requiring them to set the Promise library resolution, we instead polyfill the global promise library to ensure we can install our handler.

Adds a new option `patchGlobalPromise` that can be passed to either `Sentry.init` or the `ReactNativeErrorHandlers` integration.

There is the expectation that a third party SDK shouldn't have the side effect of polyfilling a commonly used global instance, but as RN has not changed the functionality of its promises for quite a while we should be fine. If you use a polyfill such as core-js for example, such as adding `Promise.allSettled`, they would have to use the polyfill after Sentry init. We can also add back in the Promise warning along with a boolean toggle for people who do not want to polyfill.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Resolves #1942 

**NOTE**
Polyfilling like this also fixes unhandled promise rejections in Hermes, which was what has been blocking #1836.

## :green_heart: How did you test it?
e2e tests test unhandled promise rejections.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## Next Steps:
Rewrite https://docs.sentry.io/platforms/react-native/troubleshooting/#unhandled-promise-rejections

-> https://github.com/getsentry/sentry-docs/pull/4525
