### PR TITLE
fix: fetchNativeDeviceContexts returns an empty Array if no Device Context available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: fetchNativeDeviceContexts returns an empty Array if no Device Context available
+
 ## 3.2.11
 
 - fix: Polyfill the promise library to permanently fix unhandled rejections #1984

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: fetchNativeDeviceContexts returns an empty Array if no Device Context available
+- fix: fetchNativeDeviceContexts returns an empty Array if no Device Context available #2002
 
 ## 3.2.11
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -140,19 +140,23 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSLog(@"Bridge call to: deviceContexts");
+    NSMutableDictionary<NSString *, id> *contexts = [NSMutableDictionary new];
     // Temp work around until sorted out this API in sentry-cocoa.
     // TODO: If the callback isnt' executed the promise wouldn't be resolved.
     [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
         NSDictionary<NSString *, id> *serializedScope = [scope serialize];
         // Scope serializes as 'context' instead of 'contexts' as it does for the event.
-        NSDictionary<NSString *, id> *contexts = [serializedScope valueForKey:@"context"];
+        NSDictionary<NSString *, id> *tempContexts = [serializedScope valueForKey:@"context"];
+        if (tempContexts != nil) {
+            [contexts addEntriesFromDictionary:tempContexts];
+        }
 #if DEBUG
         NSData *data = [NSJSONSerialization dataWithJSONObject:contexts options:0 error:nil];
         NSString *debugContext = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         NSLog(@"Contexts: %@", debugContext);
 #endif
-        resolve(contexts);
     }];
+    resolve(contexts);
 }
 
 RCT_EXPORT_METHOD(fetchNativeAppStart:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fix: fetchNativeDeviceContexts returns an empty Array if no Device Context available


## :bulb: Motivation and Context
Avoid crash https://github.com/getsentry/sentry-react-native/issues/1999


## :green_heart: How did you test it?
Running it without initing the SDK

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
Investigate why `fetchNativeDeviceContexts` returned null in the first place.