### PR TITLE
fix(deps): Add `@sentry/wizard` back in as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(deps): Add `@sentry/wizard` back in as a dependency to avoid missing dependency when running react-native link.
+
 ## 3.2.12
 
 - fix: fetchNativeDeviceContexts returns an empty Array if no Device Context available #2002

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(deps): Add `@sentry/wizard` back in as a dependency to avoid missing dependency when running react-native link.
+- fix(deps): Add `@sentry/wizard` back in as a dependency to avoid missing dependency when running react-native link. #2015
 
 ## 3.2.12
 

--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
     "@sentry/react": "6.12.0",
     "@sentry/tracing": "6.12.0",
     "@sentry/types": "6.12.0",
-    "@sentry/utils": "6.12.0"
+    "@sentry/utils": "6.12.0",
+    "@sentry/wizard": "^1.2.17"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "6.12.0",
     "@sentry-internal/eslint-plugin-sdk": "6.12.0",
     "@sentry/typescript": "^5.20.0",
-    "@sentry/wizard": "^1.2.15",
     "@types/jest": "^26.0.15",
     "@types/react": "^16.9.49",
     "@types/react-native": "^0.66.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,10 +1269,10 @@
     "@sentry/types" "6.12.0"
     tslib "^1.9.3"
 
-"@sentry/wizard@^1.2.15":
-  version "1.2.15"
-  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-1.2.15.tgz#d12fcdf2193080177dd32d8ca8f7bcfa08479d3e"
-  integrity sha512-xH4An91ZKYix7ug5MEUDg0JdKV8u1dl0TvE2rxXWpHRhmKfGtd/fblNLJCORRHjiyQ4R8wBYmsbklhKpasYShg==
+"@sentry/wizard@^1.2.17":
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-1.2.17.tgz#c3247b47129d002cfa45d7a2048d13dc6513457b"
+  integrity sha512-wXzjOZVDzh+1MhA9tpZXCKNTDusL2Dc298KGQkEkNefbW+OlYbsWwF7GAihLKUjYOSnKKZFzLIwbD+gxwxWxlw==
   dependencies:
     "@sentry/cli" "^1.52.4"
     chalk "^2.4.1"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds `@sentry/wizard` back in as a direct dependency.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sentry wizard is called after running `react-native link @sentry/react-native` in older versions of RN before 0.60. As it is currently not a direct dependency, an error is thrown.

## :green_heart: How did you test it?
Tried in a blank empty project

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes