### PR TITLE
Fix passing mutable options to iOS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Passing correct mutableOptions to iOS SDK (#2037)
+
 ## 3.2.13
 
 - fix(deps): Add `@sentry/wizard` back in as a dependency to avoid missing dependency when running react-native link. #2015

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -68,10 +68,11 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
     // remove performance traces sample rate and traces sampler since we don't want to synchronize these configurations
     // to the Native SDKs.
     // The user could tho initialize the SDK manually and set themselves.
-    [mutableOptions removeObjectForKey:@"tracesSampleRate"];
+    // Remove comment below once https://github.com/getsentry/sentry-cocoa/issues/1657 gets fixed.
+    // [mutableOptions removeObjectForKey:@"tracesSampleRate"];
     [mutableOptions removeObjectForKey:@"tracesSampler"];
 
-    sentryOptions = [[SentryOptions alloc] initWithDict:options didFailWithError:&error];
+    sentryOptions = [[SentryOptions alloc] initWithDict:mutableOptions didFailWithError:&error];
     if (error) {
         reject(@"SentryReactNative", error.localizedDescription, error);
         return;

--- a/sample/ios/sample.xcodeproj/project.pbxproj
+++ b/sample/ios/sample.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-sample/Pods-sample-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/hermes.framework/hermes",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/sample/ios/sample.xcodeproj/project.pbxproj
+++ b/sample/ios/sample.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-sample-sampleTests/Pods-sample-sampleTests-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/hermes.framework/hermes",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/sample/ios/sample.xcodeproj/project.pbxproj
+++ b/sample/ios/sample.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-sample-sampleTests/Pods-sample-sampleTests-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes/hermes.framework/hermes",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -495,7 +495,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-sample/Pods-sample-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes/hermes.framework/hermes",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fix passing mutable options to iOS SDK


## :bulb: Motivation and Context
Not passing `tracesSampleRate` leads to https://github.com/getsentry/sentry-cocoa/issues/1657
Passing a JS `tracesSampler` leads to a crash.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
https://github.com/getsentry/sentry-cocoa/issues/1657