### PR TITLE
Respect sentryOption.debug setting instead of #DEBUG build flag for outputting logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Respect sentryOption.debug setting instead of #DEBUG build flag for outputting logs #2039
+
 ## 3.2.14-beta.1
 
 - fix: Discard prior transactions on react navigation dispatch #2053

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -150,7 +150,7 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts:(RCTPromiseResolveBlock)resolve
         if (tempContexts != nil) {
             [contexts addEntriesFromDictionary:tempContexts];
         }
-        if (sentryOptions.debug == YES) {
+        if (sentryOptions != nil && sentryOptions.debug) {
             NSData *data = [NSJSONSerialization dataWithJSONObject:contexts options:0 error:nil];
             NSString *debugContext = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
             NSLog(@"Contexts: %@", debugContext);

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -150,11 +150,11 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts:(RCTPromiseResolveBlock)resolve
         if (tempContexts != nil) {
             [contexts addEntriesFromDictionary:tempContexts];
         }
-#if DEBUG
-        NSData *data = [NSJSONSerialization dataWithJSONObject:contexts options:0 error:nil];
-        NSString *debugContext = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-        NSLog(@"Contexts: %@", debugContext);
-#endif
+        if (sentryOptions.debug == YES) {
+            NSData *data = [NSJSONSerialization dataWithJSONObject:contexts options:0 error:nil];
+            NSString *debugContext = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+            NSLog(@"Contexts: %@", debugContext);
+        }
     }];
     resolve(contexts);
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Instead of using a build flag of #DEBUG the code should respect the variable set by user in the sentryOptions.debug.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We have are putting a pretty large payload into our context, it is filling up our logs and we have to go comment out the` NSLog("Contexts: %")` in our code to get around this. 


## :green_heart: How did you test it?

I didnt 🤷 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Decide if you want it or not. This is a Take it or leave it PR, I won't be doing followup changes. 
