### PR TITLE
fix: Clear transaction on route change for React Native Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - feat: Support setting maxCacheItems #2102
+- fix: Clear transaction on route change for React Native Navigation #2119
 
 ## 3.3.0
 

--- a/src/js/tracing/reactnativenavigation.ts
+++ b/src/js/tracing/reactnativenavigation.ts
@@ -135,69 +135,72 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
    */
   private _onComponentWillAppear(event: ComponentWillAppearEvent): void {
     // If the route is a different key, this is so we ignore actions that pertain to the same screen.
-    if (
-      this._latestTransaction &&
-      (!this._prevComponentEvent ||
-        event.componentId != this._prevComponentEvent.componentId)
-    ) {
-      this._clearStateChangeTimeout();
+    if (this._latestTransaction) {
+      if (
+        !this._prevComponentEvent ||
+        event.componentId != this._prevComponentEvent.componentId
+      ) {
+        this._clearStateChangeTimeout();
 
-      const originalContext = this._latestTransaction.toContext();
-      const routeHasBeenSeen = this._recentComponentIds.includes(
-        event.componentId
-      );
-
-      const data: RouteChangeContextData = {
-        ...originalContext.data,
-        route: {
-          ...event,
-          name: event.componentName,
-          hasBeenSeen: routeHasBeenSeen,
-        },
-        previousRoute: this._prevComponentEvent
-          ? {
-              ...this._prevComponentEvent,
-              name: this._prevComponentEvent?.componentName,
-            }
-          : null,
-      };
-
-      const updatedContext = {
-        ...originalContext,
-        name: event.componentName,
-        tags: {
-          ...originalContext.tags,
-          "routing.route.name": event.componentName,
-        },
-        data,
-      };
-
-      let finalContext = this._beforeNavigate?.(updatedContext);
-
-      // This block is to catch users not returning a transaction context
-      if (!finalContext) {
-        logger.error(
-          `[${ReactNativeNavigationInstrumentation.name}] beforeNavigate returned ${finalContext}, return context.sampled = false to not send transaction.`
+        const originalContext = this._latestTransaction.toContext();
+        const routeHasBeenSeen = this._recentComponentIds.includes(
+          event.componentId
         );
 
-        finalContext = {
-          ...updatedContext,
-          sampled: false,
+        const data: RouteChangeContextData = {
+          ...originalContext.data,
+          route: {
+            ...event,
+            name: event.componentName,
+            hasBeenSeen: routeHasBeenSeen,
+          },
+          previousRoute: this._prevComponentEvent
+            ? {
+                ...this._prevComponentEvent,
+                name: this._prevComponentEvent?.componentName,
+              }
+            : null,
         };
+
+        const updatedContext = {
+          ...originalContext,
+          name: event.componentName,
+          tags: {
+            ...originalContext.tags,
+            "routing.route.name": event.componentName,
+          },
+          data,
+        };
+
+        let finalContext = this._beforeNavigate?.(updatedContext);
+
+        // This block is to catch users not returning a transaction context
+        if (!finalContext) {
+          logger.error(
+            `[${ReactNativeNavigationInstrumentation.name}] beforeNavigate returned ${finalContext}, return context.sampled = false to not send transaction.`
+          );
+
+          finalContext = {
+            ...updatedContext,
+            sampled: false,
+          };
+        }
+
+        if (finalContext.sampled === false) {
+          logger.log(
+            `[${ReactNativeNavigationInstrumentation.name}] Will not send transaction "${finalContext.name}" due to beforeNavigate.`
+          );
+        }
+
+        this._latestTransaction.updateWithContext(finalContext);
+        this._onConfirmRoute?.(finalContext);
+
+        this._prevComponentEvent = event;
+      } else {
+        this._discardLatestTransaction();
       }
 
-      if (finalContext.sampled === false) {
-        logger.log(
-          `[${ReactNativeNavigationInstrumentation.name}] Will not send transaction "${finalContext.name}" due to beforeNavigate.`
-        );
-      }
-
-      this._latestTransaction.updateWithContext(finalContext);
-      this._onConfirmRoute?.(finalContext);
-
-      this._prevComponentEvent = event;
-    } else {
-      this._discardLatestTransaction();
+      this._latestTransaction = undefined;
     }
   }
 

--- a/test/tracing/reactnativenavigation.test.ts
+++ b/test/tracing/reactnativenavigation.test.ts
@@ -272,5 +272,49 @@ describe("React Native Navigation Instrumentation", () => {
         }
       }
     });
+
+    test("onRouteConfirmed clears transaction", () => {
+      const instrumentation = new ReactNativeNavigationInstrumentation(
+        mockNavigationDelegate
+      );
+
+      const mockTransaction = getMockTransaction(
+        ReactNativeNavigationInstrumentation.instrumentationName
+      );
+      const tracingListener = jest.fn(() => mockTransaction);
+      let confirmedContext: TransactionContext | undefined;
+      instrumentation.registerRoutingInstrumentation(
+        tracingListener,
+        (context) => context,
+        (context) => {
+          confirmedContext = context;
+        }
+      );
+
+      mockEventsRegistry.onCommand("root", {});
+
+      expect(mockTransaction.name).toBe("Route Change");
+
+      const mockEvent1: ComponentWillAppearEvent = {
+        componentId: "1",
+        componentName: "Test 1",
+        componentType: "Component",
+        passProps: {},
+      };
+      mockEventsRegistry.onComponentWillAppear(mockEvent1);
+
+      const mockEvent2: ComponentWillAppearEvent = {
+        componentId: "2",
+        componentName: "Test 2",
+        componentType: "Component",
+        passProps: {},
+      };
+      mockEventsRegistry.onComponentWillAppear(mockEvent2);
+
+      expect(confirmedContext).toBeDefined();
+      if (confirmedContext) {
+        expect(confirmedContext.name).toBe(mockEvent1.componentName);
+      }
+    });
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The transaction is not cleared on a route change confirm in the React Native Navigation instrumentation so a subsequent call to `onComponentWillAppear` will overwrite the existing transaction context. Potentially fixes #2066, however I was not able to reproduce the exact behavior. 

## :green_heart: How did you test it?
Add a unit test and test with React Native Navigation example app.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Check with customers if this fixes the issue.