### PR TITLE
Missing userId on iOS when the user is not set in the Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - fix: Do not report empty measurements #1983
 - fix(iOS): Bump Sentry Cocoa to 7.10.1 and report slow and frozen measurements (#2132)
-- fix(iOS): Missing userId on iOS when userId is not set (#2133)
+- fix(iOS): Missing userId on iOS when the user is not set in the Scope (#2133)
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - fix: Do not report empty measurements #1983
 - fix(iOS): Bump Sentry Cocoa to 7.10.1 and report slow and frozen measurements (#2132)
-- fix(iOS): Missing userId on iOS when userId is not set (#)
+- fix(iOS): Missing userId on iOS when userId is not set (#2133)
 
 ## 3.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix: Do not report empty measurements #1983
 - fix(iOS): Bump Sentry Cocoa to 7.10.1 and report slow and frozen measurements (#2132)
+- fix(iOS): Missing userId on iOS when userId is not set (#)
 
 ## 3.3.1
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -164,8 +164,19 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts:(RCTPromiseResolveBlock)resolve
         NSDictionary<NSString *, id> *serializedScope = [scope serialize];
         // Scope serializes as 'context' instead of 'contexts' as it does for the event.
         NSDictionary<NSString *, id> *tempContexts = [serializedScope valueForKey:@"context"];
+    
+        NSMutableDictionary<NSString *, id> *user = [NSMutableDictionary new];
+        
+        NSDictionary<NSString *, id> *tempUser = [serializedScope valueForKey:@"user"];
+        if (tempUser != nil) {
+            [user addEntriesFromDictionary:[tempUser valueForKey:@"user"]];
+        } else {
+            [user setValue:PrivateSentrySDKOnly.installationID forKey:@"id"];
+        }
+        [contexts setValue:user forKey:@"user"];
+        
         if (tempContexts != nil) {
-            [contexts addEntriesFromDictionary:tempContexts];
+            [contexts setValue:tempContexts forKey:@"context"];
         }
         if (sentryOptions != nil && sentryOptions.debug) {
             NSData *data = [NSJSONSerialization dataWithJSONObject:contexts options:0 error:nil];

--- a/src/js/integrations/devicecontext.ts
+++ b/src/js/integrations/devicecontext.ts
@@ -1,5 +1,5 @@
 import { addGlobalEventProcessor, getCurrentHub } from "@sentry/core";
-import { Event, Integration } from "@sentry/types";
+import { Contexts, Event, Integration } from "@sentry/types";
 import { logger } from "@sentry/utils";
 
 import { NATIVE } from "../wrapper";
@@ -27,8 +27,16 @@ export class DeviceContext implements Integration {
       }
 
       try {
-        const deviceContexts = await NATIVE.fetchNativeDeviceContexts();
-        event.contexts = { ...deviceContexts, ...event.contexts };
+        const contexts = await NATIVE.fetchNativeDeviceContexts();
+
+        const context = contexts['context'] as Contexts ?? {};
+        const user = contexts['user'] ?? {};
+
+        event.contexts = { ...context, ...event.contexts };
+
+        if (!event.user) {
+          event.user = { ...user };
+        }
       } catch (e) {
         logger.log(`Failed to get device context from native: ${e}`);
       }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Missing userId on iOS when userId is not set


## :bulb: Motivation and Context
Similar to https://github.com/getsentry/sentry-dart/pull/782


## :green_heart: How did you test it?
Running on Android and iOS

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
