### PR TITLE
ci: Change stale GitHub workflow to run once a day

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'close stale issues/PRs'
 on:
   schedule:
-    - cron: '* */3 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
 jobs:
   stale:


### PR DESCRIPTION
Running it 32 times a day is a waste of resources and unnecessarily pollutes the actions list.

Running it 32 times a day is a waste of resources and unnecessarily pollutes the actions list.

#skip-changelog