### PR TITLE
Remove shutdownTimeout since BrowserOptions already have it

### DIFF
--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -118,6 +118,9 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
             if (rnOptions.hasKey("sessionTrackingIntervalMillis")) {
                 options.setSessionTrackingIntervalMillis(rnOptions.getInt("sessionTrackingIntervalMillis"));
             }
+            if (rnOptions.hasKey("shutdownTimeout")) {
+                options.setShutdownTimeout(rnOptions.getInt("shutdownTimeout"));
+            }
             if (rnOptions.hasKey("enableNdkScopeSync")) {
                 options.setEnableScopeSync(rnOptions.getBoolean("enableNdkScopeSync"));
             }

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -37,9 +37,6 @@ export interface ReactNativeOptions extends BrowserOptions {
    */
   autoInitializeNativeSdk?: boolean;
 
-  /** Maximum time to wait to drain the request queue, before the process is allowed to exit. */
-  shutdownTimeout?: number;
-
   /** Should the native nagger alert be shown or not. */
   enableNativeNagger?: boolean;
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
Remove shutdownTimeout since BrowserOptions already have it
_#skip-changelog_


## :bulb: Motivation and Context
Already exists on JS https://github.com/getsentry/sentry-javascript/blob/38278210118576d041117e11e2bd6507677625f6/packages/types/src/options.ts#L104-L111


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
