### PR TITLE
fix: Upload correctly regardless of version codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(android): Upload source maps correctly regardless of version codes #2144
+
 ## 3.3.2
 
 - fix: Do not report empty measurements #1983

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -60,16 +60,23 @@ gradle.projectsEvaluated {
         def previousCliTask = null
 
         def nameCleanup = "${bundleTask.name}_SentryUploadCleanUp"
-        // create an upload task per variant
+        // Upload the source map several times if necessary: once for each release and versionCode.
         currentVariants.each { key, currentVariant ->
           variant = currentVariant[0]
           releaseName = currentVariant[1]
           versionCode = currentVariant[2]
 
-          def nameCliTask = "${bundleTask.name}_SentryUpload_${versionCode}"
+          // The Sentry server distinguishes source maps by release (`--release` in the command
+          // below) and distribution identifier (`--dist` below).  Give the task a unique name
+          // based on where we're uploading to.
+          def nameCliTask = "${bundleTask.name}_SentryUpload_${releaseName}_${versionCode}"
+
+          // If several outputs have the same releaseName and versionCode, we'd do the exact same
+          // upload for each of them.  No need to repeat.
+          try { tasks.named(nameCliTask); return } catch (Exception e) {}
 
           /** Upload source map file to the sentry server via CLI call. */
-          def cliTask = tasks.create(name: nameCliTask, type: Exec) {
+          def cliTask = tasks.create(nameCliTask, Exec) {
               description = "upload debug symbols to sentry"
               group = 'sentry.io'
 
@@ -135,7 +142,8 @@ gradle.projectsEvaluated {
               commandLine(*osCompatibility, *args)
 
               enabled true
-            }
+          }
+
           // chain the upload tasks so they run sequentially in order to run
           // the cliCleanUpTask after the final upload task is run
           if (previousCliTask != null) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This PR causes no changes for anyone not building multiple APKs.
It also causes no changes for anyone building multiple APKs and giving
them each a distinct `versionCode`, as the React Native template app
does.

What it does affect is building multiple APKs and giving each of them
the same `versionCode`: currently this causes sentry.gradle to crash,
and with this commit it instead uploads correctly.

The crash in sentry.gradle comes because we're naming the upload task
based on the version code, and Gradle task names must be unique.  We
can fix it by simply not attempting to create a task if it would be a
duplicate.  To be exactly correct, we have the task name include the
release name as well as the version code: when both of these are the
same, the two tasks would run exactly the same Sentry CLI command,
and so we only need to have one such task.



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The reason the React Native template app assigns different version
codes to different APKs is that that was a requirement when
publishing multiple APKs on Google Play:
  https://developer.android.com/google/play/publishing/multiple-apks#VersionCodes

But the preferred approach on Google Play is now to upload a single
AAB (Android App Bundle) rather than multiple APKs:
  https://developer.android.com/guide/app-bundle
An AAB is simpler to manage, makes smaller downloads and smaller
installs on user devices, and since 2021 is required for new apps
on Google Play.  So the rules for publishing multiple APKs there
are now relevant only for legacy apps that haven't migrated to AABs.
The remaining use cases for building multiple APKs are primarily
outside of Google Play.

That means that it's now perfectly reasonable for an app to build
multiple APKs and give them all the same version code.  In fact with
Sentry this is a convenient thing to do, because it keeps the issues
grouped together on a single release.


## :green_heart: How did you test it?

Built my own app (https://github.com/zulip/zulip-mobile) with and without multiple APKs.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
