### PR TITLE
Duplicate Breadcrumbs when captuing messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(android): Duplicate Breadcrumbs when captuing messages #2144
+
 ## 3.3.3
 
 - Bump: Sentry Cocoa to 7.10.2 and Sentry Android to 5.6.3 (#2145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(android): Duplicate Breadcrumbs when captuing messages #2144
+- fix(android): Duplicate Breadcrumbs when captuing messages #2153
 
 ## 3.3.3
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -105,7 +105,7 @@ export const NATIVE: SentryNativeWrapper = {
         this is a signal that the app would crash and android would lose the breadcrumbs by the time the app is restarted to read
         the envelope.
       */
-      if (event.exception?.values?.[0]?.mechanism?.handled) {
+      if (event.exception?.values?.[0]?.mechanism?.handled != false) {
         event.breadcrumbs = [];
       }
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -105,7 +105,7 @@ export const NATIVE: SentryNativeWrapper = {
         this is a signal that the app would crash and android would lose the breadcrumbs by the time the app is restarted to read
         the envelope.
       */
-      if (event.exception?.values?.[0]?.mechanism?.handled != false) {
+      if (event.exception?.values?.[0]?.mechanism?.handled != false && event.breadcrumbs) {
         event.breadcrumbs = [];
       }
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -101,7 +101,7 @@ export const NATIVE: SentryNativeWrapper = {
         We do this to avoid duplicate breadcrumbs on Android as sentry-android applies the breadcrumbs
         from the native scope onto every envelope sent through it. This scope will contain the breadcrumbs
         sent through the scope sync feature. This causes duplicate breadcrumbs.
-        We then remove the breadcrumbs here but only when mechanism.handled is true. If it is handled == false,
+        We then remove the breadcrumbs in all cases but if it is handled == false,
         this is a signal that the app would crash and android would lose the breadcrumbs by the time the app is restarted to read
         the envelope.
       */

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -380,6 +380,43 @@ describe("Tests Native Wrapper", () => {
         `${header}\n${item}\n${payload}`
       );
     });
+    test("Clears breadcrumbs on Android if there is no exception", async () => {
+      NATIVE.platform = "android";
+
+      const event: Event = {
+        event_id: "event0",
+        message: "test",
+        breadcrumbs: [
+          {
+            message: "crumb!",
+          },
+        ],
+      };
+
+      const payload = JSON.stringify({
+        ...event,
+        breadcrumbs: [],
+        message: {
+          message: event.message,
+        },
+      });
+      const header = JSON.stringify({
+        event_id: event.event_id,
+        sdk: event.sdk,
+      });
+      const item = JSON.stringify({
+        content_type: "application/json",
+        length: 1,
+        type: "event",
+      });
+
+      await NATIVE.sendEvent(event);
+
+      // @ts-ignore testing method
+      expect(RNSentry._getLastPayload().envelopePayload).toMatch(
+        `${header}\n${item}\n${payload}`
+      );
+    });
     test("Does not clear breadcrumbs on Android if mechanism.handled is false", async () => {
       NATIVE.platform = "android";
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Duplicate Breadcrumbs when captuing messages 

## :bulb: Motivation and Context
Closes https://github.com/getsentry/sentry-react-native/issues/1409


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
