### PR TITLE
setContext serializes as Context for Android instead of Extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix(android): setContext serializes as Context for Android instead of Extra (#)
+
 ## 3.3.3
 
 - Bump: Sentry Cocoa to 7.10.2 and Sentry Android to 5.6.3 (#2145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(android): setContext serializes as Context for Android instead of Extra (#2155)
+- fix(android): setContext serializes as context for Android instead of extra (#2155)
 
 ## 3.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix(android): setContext serializes as Context for Android instead of Extra (#)
+- fix(android): setContext serializes as Context for Android instead of Extra (#2155)
 
 ## 3.3.3
 

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -442,6 +442,18 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setContext(final String key, final ReadableMap context) {
+        if (key == null || context == null) {
+            return;
+        }
+        Sentry.configureScope(scope -> {
+            final HashMap<String, Object> contextHashMap = context.toHashMap();
+
+            scope.setContexts(key, contextHashMap);
+        });
+    }
+
+    @ReactMethod
     public void setTag(String key, String value) {
         Sentry.configureScope(scope -> {
             scope.setTag(key, value);

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -433,15 +433,10 @@ export const NATIVE: SentryNativeWrapper = {
       throw this._NativeClientError;
     }
 
-    if (this.platform === "android") {
-      // setContext not available on the Android SDK yet.
-      this.setExtra(key, context);
-    } else {
-      RNSentry.setContext(
-        key,
-        context !== null ? this._serializeObject(context) : null
-      );
-    }
+    RNSentry.setContext(
+      key,
+      context !== null ? this._serializeObject(context) : null
+    );
   },
 
   /**


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
setContext serializes as Context for Android instead of Extra


## :bulb: Motivation and Context
Found by debugging https://github.com/getsentry/sentry-react-native/issues/2154


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
