### PR TITLE
fix: Respect given release if no dist is given during SDK init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: Respect given release if no dist is given during SDK init (#)
+- fix: Respect given release if no dist is given during SDK init (#2163)
 
 ## 3.3.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Respect given release if no dist is given during SDK init (#)
+
 ## 3.3.5
 
 - Bump: Sentry Cocoa to 7.11.0 and Sentry Android to 5.7.0 (#2160)

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -60,8 +60,8 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // Sets the `release` and `dist` on Sentry events. Make sure this matches EXACTLY with the values on your sourcemaps
   // otherwise they will not work.
-  release: '1.2.3',
-  dist: `1.2.3.0`,
+  release: 'myapp@1.2.3+1',
+  dist: `1`,
 });
 
 const Stack = createStackNavigator();

--- a/src/js/integrations/release.ts
+++ b/src/js/integrations/release.ts
@@ -47,10 +47,14 @@ export class Release implements Integration {
       }
 
       try {
-        const release = await NATIVE.fetchNativeRelease();
-        if (release) {
-          event.release = `${release.id}@${release.version}+${release.build}`;
-          event.dist = `${release.build}`;
+        const nativeRelease = await NATIVE.fetchNativeRelease();
+        if (nativeRelease) {
+          if (!event.release) {
+            event.release = `${nativeRelease.id}@${nativeRelease.version}+${nativeRelease.build}`;
+          }
+          if (!event.dist) {
+            event.dist = `${nativeRelease.build}`;
+          }
         }
       } catch (_Oo) {
         // Something went wrong, we just continue

--- a/test/integrations/release.test.ts
+++ b/test/integrations/release.test.ts
@@ -52,6 +52,50 @@ describe("Tests the Release integration", () => {
     expect(event?.dist).toBe("native_build");
   });
 
+  test("Uses release from native SDK if release is not present in options.", async () => {
+    const releaseIntegration = new Release();
+
+    let eventProcessor: EventProcessor = () => null;
+
+    // @ts-ignore Mock
+    addGlobalEventProcessor.mockImplementation((e) => (eventProcessor = e));
+    releaseIntegration.setupOnce();
+
+    const client = getCurrentHub().getClient();
+
+    // @ts-ignore Mock
+    client.getOptions.mockImplementation(() => ({
+      dist: "options_dist",
+    }));
+
+    const event = await eventProcessor({});
+
+    expect(event?.release).toBe(`native_id@native_version+native_build`);
+    expect(event?.dist).toBe("options_dist");
+  });
+
+  test("Uses dist from native SDK if dist is not present in options.", async () => {
+    const releaseIntegration = new Release();
+
+    let eventProcessor: EventProcessor = () => null;
+
+    // @ts-ignore Mock
+    addGlobalEventProcessor.mockImplementation((e) => (eventProcessor = e));
+    releaseIntegration.setupOnce();
+
+    const client = getCurrentHub().getClient();
+
+    // @ts-ignore Mock
+    client.getOptions.mockImplementation(() => ({
+      release: "options_release",
+    }));
+
+    const event = await eventProcessor({});
+
+    expect(event?.release).toBe(`options_release`);
+    expect(event?.dist).toBe("native_build");
+  });
+
   test("Uses release and dist from options", async () => {
     const releaseIntegration = new Release();
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
If you pass the `release`, it respects the given release.
If you pass the `dist`, it respects the given dist.
If you pass `release` but not `dist`, the `dist` from the Native SDK is used, and vice versa.


## :bulb: Motivation and Context
If you pass `release` to SDK init but not `dist`, the `release` isn't respected and it's used the Native `release`.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
