### PR TITLE
fix: Make withTouchEventBoundary options optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Make withTouchEventBoundary options optional #2196
+
 ## 3.4.0
 
 ### Various fixes & improvements

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -204,7 +204,7 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
 const withTouchEventBoundary = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   InnerComponent: React.ComponentType<any>,
-  boundaryProps: TouchEventBoundaryProps
+  boundaryProps?: TouchEventBoundaryProps
 ): React.FunctionComponent => {
   const WrappedComponent: React.FunctionComponent = (props) => (
     <TouchEventBoundary {...boundaryProps}>

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -207,7 +207,7 @@ const withTouchEventBoundary = (
   boundaryProps?: TouchEventBoundaryProps
 ): React.FunctionComponent => {
   const WrappedComponent: React.FunctionComponent = (props) => (
-    <TouchEventBoundary {...boundaryProps}>
+    <TouchEventBoundary {...(boundaryProps ?? {})}>
       <InnerComponent {...props} />
     </TouchEventBoundary>
   );


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Make the second argument to withTouchEventBoundary optional instead of required.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-docs/issues/4910

## :green_heart: How did you test it?
Local sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes
