### PR TITLE
fix: Fix cold start appearing again after js bundle reload on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Fix cold start appearing again after js bundle reload on Android.
+
 ## 3.4.1
 
 - fix: Make withTouchEventBoundary options optional #2196

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -55,9 +55,10 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
     private static final Logger logger = Logger.getLogger("react-native-sentry");
 
     private PackageInfo packageInfo = null;
-    private boolean didFetchAppStart;
     private FrameMetricsAggregator frameMetricsAggregator = null;
     private boolean androidXAvailable = true;
+
+    private static boolean didFetchAppStart;
 
     // 700ms to constitute frozen frames.
     private static final int FROZEN_FRAME_THRESHOLD = 700;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Make `didFetchAppStart` static on Android module so it does not get reset on js bundle refresh.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2224

## :green_heart: How did you test it?
Android sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

