### PR TITLE
MacOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.3
+
+- feat: Support macOS (#2240) by @ospfranco
+
 ## 3.4.2
 
 - fix: Fix cold start appearing again after js bundle reload on Android. #2229

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.4.3
+## Unreleased
 
 - feat: Support macOS (#2240) by @ospfranco
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -33,14 +33,6 @@ static bool didFetchAppStart;
     return YES;
 }
 
-+ (NSNotificationName)didBecomeActiveNotificationName {
-#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
-    return UIApplicationDidBecomeActiveNotification;
-#else
-    return NSApplicationDidBecomeActiveNotification;
-#endif
-}
-
 RCT_EXPORT_MODULE()
 
 - (NSDictionary<NSString *, id> *)constantsToExport
@@ -107,24 +99,20 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
 
     [SentrySDK startWithOptionsObject:sentryOptions];
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+    BOOL appIsActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
+#else
+    BOOL appIsActive = [[NSApplication sharedApplication] isActive];
+#endif
+
     // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.
-    if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
+    if (appIsActive && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
         [[NSNotificationCenter defaultCenter]
             postNotificationName:@"SentryHybridSdkDidBecomeActive"
             object:nil];
 
         sentHybridSdkDidBecomeActive = true;
     }
-#else
-    if([[NSApplication sharedApplication] isActive] && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
-        [[NSNotificationCenter defaultCenter]
-         postNotificationName:@"SentryHybridSdkDidBecomeActive"
-         object:nil];
-
-        sentHybridSdkDidBecomeActive = true;
-    }
-#endif
 
 
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -85,7 +85,6 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
         }
     }
 
-
     // Enable the App start and Frames tracking measurements
     if ([mutableOptions valueForKey:@"enableAutoPerformanceTracking"] != nil) {
         BOOL enableAutoPerformanceTracking = (BOOL)[mutableOptions valueForKey:@"enableAutoPerformanceTracking"];

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -33,6 +33,14 @@ static bool didFetchAppStart;
     return YES;
 }
 
++ (NSNotificationName)didBecomeActiveNotificationName {
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+    return UIApplicationDidBecomeActiveNotification;
+#else
+    return NSApplicationDidBecomeActiveNotification;
+#endif
+}
+
 RCT_EXPORT_MODULE()
 
 - (NSDictionary<NSString *, id> *)constantsToExport
@@ -85,15 +93,17 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
         }
     }
 
-#if TARGET_OS_IPHONE
+
     // Enable the App start and Frames tracking measurements
     if ([mutableOptions valueForKey:@"enableAutoPerformanceTracking"] != nil) {
         BOOL enableAutoPerformanceTracking = (BOOL)[mutableOptions valueForKey:@"enableAutoPerformanceTracking"];
 
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = enableAutoPerformanceTracking;
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
         PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = enableAutoPerformanceTracking;
-    }
 #endif
+    }
+
 
     [SentrySDK startWithOptionsObject:sentryOptions];
 
@@ -227,7 +237,7 @@ RCT_EXPORT_METHOD(fetchNativeFrames:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
     if (PrivateSentrySDKOnly.isFramesTrackingRunning) {
         SentryScreenFrames *frames = PrivateSentrySDKOnly.currentScreenFrames;
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -95,7 +95,6 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
 #endif
     }
 
-
     [SentrySDK startWithOptionsObject:sentryOptions];
 
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -85,6 +85,7 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
         }
     }
 
+#if TARGET_OS_IPHONE
     // Enable the App start and Frames tracking measurements
     if ([mutableOptions valueForKey:@"enableAutoPerformanceTracking"] != nil) {
         BOOL enableAutoPerformanceTracking = (BOOL)[mutableOptions valueForKey:@"enableAutoPerformanceTracking"];
@@ -92,9 +93,11 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = enableAutoPerformanceTracking;
         PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = enableAutoPerformanceTracking;
     }
+#endif
 
     [SentrySDK startWithOptionsObject:sentryOptions];
 
+#if TARGET_OS_IPHONE
     // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.
     if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateActive && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
         [[NSNotificationCenter defaultCenter]
@@ -103,6 +106,15 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
 
         sentHybridSdkDidBecomeActive = true;
     }
+#else
+    if([[NSApplication sharedApplication] isActive] && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
+        [[NSNotificationCenter defaultCenter]
+         postNotificationName:@"SentryHybridSdkDidBecomeActive"
+         object:nil];
+
+        sentHybridSdkDidBecomeActive = true;
+    }
+#endif
 
 
 
@@ -164,9 +176,9 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts:(RCTPromiseResolveBlock)resolve
         NSDictionary<NSString *, id> *serializedScope = [scope serialize];
         // Scope serializes as 'context' instead of 'contexts' as it does for the event.
         NSDictionary<NSString *, id> *tempContexts = [serializedScope valueForKey:@"context"];
-    
+
         NSMutableDictionary<NSString *, id> *user = [NSMutableDictionary new];
-        
+
         NSDictionary<NSString *, id> *tempUser = [serializedScope valueForKey:@"user"];
         if (tempUser != nil) {
             [user addEntriesFromDictionary:[tempUser valueForKey:@"user"]];
@@ -174,7 +186,7 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts:(RCTPromiseResolveBlock)resolve
             [user setValue:PrivateSentrySDKOnly.installationID forKey:@"id"];
         }
         [contexts setValue:user forKey:@"user"];
-        
+
         if (tempContexts != nil) {
             [contexts setValue:tempContexts forKey:@"context"];
         }
@@ -215,6 +227,7 @@ RCT_EXPORT_METHOD(fetchNativeFrames:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
 
+#if TARGET_OS_IPHONE
     if (PrivateSentrySDKOnly.isFramesTrackingRunning) {
         SentryScreenFrames *frames = PrivateSentrySDKOnly.currentScreenFrames;
 
@@ -241,6 +254,9 @@ RCT_EXPORT_METHOD(fetchNativeFrames:(RCTPromiseResolveBlock)resolve
     } else {
       resolve(nil);
     }
+#else
+    resolve(nil);
+#endif
 }
 
 RCT_EXPORT_METHOD(fetchNativeRelease:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
By conditionally compiling some of the more advanced functionality the SDK now compiles on react-native-macos applications. Don't know how the commented functionality works, XCode was simply throwing errors on the methods, which I guess are not exposed/defined based on platform checks too.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I need react-native-macos support for my applications. The commented functionality (performance tracking) is not vital for my use case, for now getting the errors is better than nothing.

## :green_heart: How did you test it?
I built my own [app](https://ospfranco.com/sol) with support and the events are being received on Sentry. Not sure how to add tests for the macOS target though, since I didn't change any functionality not sure if this is necessary.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Please review, let me know if you **need** me to add tests (and if so how/which). If everything is working a prompt release would be much appreciatted 