### PR TITLE
Use shutdownTimeoutMillis instead of shutdownTimeout

### DIFF
--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -120,7 +120,7 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                 options.setSessionTrackingIntervalMillis(rnOptions.getInt("sessionTrackingIntervalMillis"));
             }
             if (rnOptions.hasKey("shutdownTimeout")) {
-                options.setShutdownTimeout(rnOptions.getInt("shutdownTimeout"));
+                options.setShutdownTimeoutMillis(rnOptions.getInt("shutdownTimeout"));
             }
             if (rnOptions.hasKey("enableNdkScopeSync")) {
                 options.setEnableScopeSync(rnOptions.getBoolean("enableNdkScopeSync"));


### PR DESCRIPTION
_#skip-changelog_

https://docs.sentry.io/platforms/android/migration/#migrating-from-iosentrysentry-android-5x-to-iosentrysentry-android-600