### PR TITLE
Fix: SDK overwrites the user defined ReactNativeTracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix: SDK overwrites the user defined ReactNativeTracing ([#2313](https://github.com/getsentry/sentry-react-native/pull/2313))
+- Fix: SDK overwrites the user defined ReactNativeTracing ([#2319](https://github.com/getsentry/sentry-react-native/pull/2319))
 
 ## 4.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ By bumping Sentry Javascript, new breaking changes were introduced, to know more
 ## 4.0.0-beta.4
 
 - Bump Sentry Cocoa 7.17.0 ([#2300](https://github.com/getsentry/sentry-react-native/pull/2300))
-
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/7.17.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.16.1...7.17.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: SDK overwrites the user defined ReactNativeTracing ([#2313](https://github.com/getsentry/sentry-react-native/pull/2313))
+
 ## 4.0.2
 
 - Fix Calculate the absolute number of Android versionCode ([#2313](https://github.com/getsentry/sentry-react-native/pull/2313))
@@ -31,6 +35,7 @@ By bumping Sentry Javascript, new breaking changes were introduced, to know more
 ## 4.0.0-beta.4
 
 - Bump Sentry Cocoa 7.17.0 ([#2300](https://github.com/getsentry/sentry-react-native/pull/2300))
+
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/7.17.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.16.1...7.17.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ By bumping Sentry Javascript, new breaking changes were introduced, to know more
 ## 4.0.0-beta.4
 
 - Bump Sentry Cocoa 7.17.0 ([#2300](https://github.com/getsentry/sentry-react-native/pull/2300))
-
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/7.17.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.16.1...7.17.0)
 

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -2,7 +2,7 @@ import { getIntegrationsToSetup, initAndBind, setExtra } from '@sentry/core';
 import { Hub, makeMain } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
 import { defaultIntegrations, defaultStackParser, getCurrentHub } from '@sentry/react';
-import { StackFrame } from '@sentry/types';
+import { Integration, StackFrame } from '@sentry/types';
 import { getGlobalObject, logger, stackParserFromStackParserOptions } from '@sentry/utils';
 import * as React from 'react';
 
@@ -50,59 +50,64 @@ export function init(passedOptions: ReactNativeOptions): void {
     stackParser: stackParserFromStackParserOptions(passedOptions.stackParser || defaultStackParser)
   };
 
+  function addIntegration(integration: Integration): void {
+    if (options.integrations.filter((i) => i.name == integration.name).length === 0) {
+      options.integrations.push(integration);
+    }
+  }
+
   // As long as tracing is opt in with either one of these options, then this is how we determine tracing is enabled.
   const tracingEnabled =
     typeof options.tracesSampler !== 'undefined' ||
     typeof options.tracesSampleRate !== 'undefined';
 
   if (passedOptions.defaultIntegrations === undefined) {
+    addIntegration(new ReactNativeErrorHandlers({
+      patchGlobalPromise: options.patchGlobalPromise,
+    }));
+    addIntegration(new Release());
     options.integrations.push(...[
-      new ReactNativeErrorHandlers({
-        patchGlobalPromise: options.patchGlobalPromise,
-      }),
-      new Release(),
       ...defaultIntegrations.filter(
         (i) => !IGNORED_DEFAULT_INTEGRATIONS.includes(i.name)
       ),
-      new EventOrigin(),
-      new SdkInfo(),
     ]);
 
+    addIntegration(new EventOrigin());
+    addIntegration(new SdkInfo());
+
     if (__DEV__) {
-      options.integrations.push(new DebugSymbolicator());
+      addIntegration(new DebugSymbolicator());
     }
 
-    options.integrations.push(
-      new RewriteFrames({
-        iteratee: (frame: StackFrame) => {
-          if (frame.filename) {
-            frame.filename = frame.filename
-              .replace(/^file:\/\//, '')
-              .replace(/^address at /, '')
-              .replace(/^.*\/[^.]+(\.app|CodePush|.*(?=\/))/, '');
+    addIntegration(new RewriteFrames({
+      iteratee: (frame: StackFrame) => {
+        if (frame.filename) {
+          frame.filename = frame.filename
+            .replace(/^file:\/\//, '')
+            .replace(/^address at /, '')
+            .replace(/^.*\/[^.]+(\.app|CodePush|.*(?=\/))/, '');
 
-            if (
-              frame.filename !== '[native code]' &&
-              frame.filename !== 'native'
-            ) {
-              const appPrefix = 'app://';
-              // We always want to have a triple slash
-              frame.filename =
-                frame.filename.indexOf('/') === 0
-                  ? `${appPrefix}${frame.filename}`
-                  : `${appPrefix}/${frame.filename}`;
-            }
+          if (
+            frame.filename !== '[native code]' &&
+            frame.filename !== 'native'
+          ) {
+            const appPrefix = 'app://';
+            // We always want to have a triple slash
+            frame.filename =
+              frame.filename.indexOf('/') === 0
+                ? `${appPrefix}${frame.filename}`
+                : `${appPrefix}/${frame.filename}`;
           }
-          return frame;
-        },
-      })
-    );
+        }
+        return frame;
+      },
+    }));
     if (options.enableNative) {
-      options.integrations.push(new DeviceContext());
+      addIntegration(new DeviceContext());
     }
     if (tracingEnabled) {
       if (options.enableAutoPerformanceTracking) {
-        options.integrations.push(new ReactNativeTracing());
+        addIntegration(new ReactNativeTracing());
       }
     }
   }
@@ -114,6 +119,15 @@ export function init(passedOptions: ReactNativeOptions): void {
     getCurrentHub().setTag('hermes', 'true');
   }
 }
+
+// /**
+//  * Adds an integration to 'options.integrations' if not added yet
+//  */
+// export function addIntegration(options: ReactNativeClientOptions, integration: Integration): void {
+//   if (options.integrations.filter((i) => i.name == integration.name).length === 0) {
+//     options.integrations.push(integration);
+//   }
+// }
 
 /**
  * Inits the Sentry React Native SDK with automatic instrumentation and wrapped features.

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -120,15 +120,6 @@ export function init(passedOptions: ReactNativeOptions): void {
   }
 }
 
-// /**
-//  * Adds an integration to 'options.integrations' if not added yet
-//  */
-// export function addIntegration(options: ReactNativeClientOptions, integration: Integration): void {
-//   if (options.integrations.filter((i) => i.name == integration.name).length === 0) {
-//     options.integrations.push(integration);
-//   }
-// }
-
 /**
  * Inits the Sentry React Native SDK with automatic instrumentation and wrapped features.
  */

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -80,6 +80,11 @@ describe('Tests the SDK functionality', () => {
         );
       };
 
+      const reactNavigationInstrumentation = (): ReactNativeTracing => {
+        const nav = new ReactNavigationInstrumentation();
+        return new ReactNativeTracing({ routingInstrumentation: nav });
+      }
+
       it('Auto Performance is enabled when tracing is enabled (tracesSampler)', () => {
         init({
           tracesSampler: () => true,
@@ -98,13 +103,25 @@ describe('Tests the SDK functionality', () => {
         expect(autoPerformanceIsEnabled()).toBe(true);
       });
 
-      it('Do not overwrite user defined integrations', () => {
-        const nav = new ReactNavigationInstrumentation();
-        const tracing = new ReactNativeTracing({ routingInstrumentation: nav });
+      it('Do not overwrite user defined integrations when passing integrations', () => {
+        const tracing = reactNavigationInstrumentation();
         init({
           tracesSampleRate: 0.5,
           enableAutoPerformanceTracking: true,
           integrations: [tracing],
+        });
+
+        const options = usedOptions();
+        expect(options.filter((integration) => integration.name === ReactNativeTracing.id).length).toBe(1);
+        expect(options.some((integration) => integration === tracing)).toBe(true);
+      });
+
+      it('Do not overwrite user defined integrations when passing defaultIntegrations', () => {
+        const tracing = reactNavigationInstrumentation();
+        init({
+          tracesSampleRate: 0.5,
+          enableAutoPerformanceTracking: true,
+          defaultIntegrations: [tracing],
         });
 
         const options = usedOptions();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
SDK overwrites the user-defined ReactNativeTracing and because of that, slow and frozen frames are not reported.


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-react-native/issues/2317
Bug introduced by https://github.com/getsentry/sentry-react-native/pull/2250 likely because `ReactNativeClientOptions` does not have a `defaultIntegrations` anymore.


## :green_heart: How did you test it?
Running and unit test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
