### PR TITLE
Send DidBecomeActiveNotification when OOM enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: Send DidBecomeActiveNotification when OOM enabled ([#2326](https://github.com/getsentry/sentry-react-native/pull/2326))
 - Fix: SDK overwrites the user defined ReactNativeTracing ([#2319](https://github.com/getsentry/sentry-react-native/pull/2319))
 - Bump Sentry JavaScript 7.3.1 ([#2306](https://github.com/getsentry/sentry-react-native/pull/2306))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/7.3.1/CHANGELOG.md)

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -105,7 +105,7 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
 #endif
 
     // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.
-    if (appIsActive && !sentHybridSdkDidBecomeActive && sentryOptions.enableAutoSessionTracking) {
+    if (appIsActive && !sentHybridSdkDidBecomeActive && (sentryOptions.enableAutoSessionTracking || sentryOptions.enableOutOfMemoryTracking) {
         [[NSNotificationCenter defaultCenter]
             postNotificationName:@"SentryHybridSdkDidBecomeActive"
             object:nil];

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -105,7 +105,7 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
 #endif
 
     // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive notification, send it.
-    if (appIsActive && !sentHybridSdkDidBecomeActive && (sentryOptions.enableAutoSessionTracking || sentryOptions.enableOutOfMemoryTracking) {
+    if (appIsActive && !sentHybridSdkDidBecomeActive && (sentryOptions.enableAutoSessionTracking || sentryOptions.enableOutOfMemoryTracking)) {
         [[NSNotificationCenter defaultCenter]
             postNotificationName:@"SentryHybridSdkDidBecomeActive"
             object:nil];


### PR DESCRIPTION


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The OOM code of the Cocoa SDK also relies on the
SentryHybridSdkDidBecomeActive to work properly.
If a user has enableAutoSessionTracking disabled wrong
OOM events would be created.


## :bulb: Motivation and Context
Came up when investigating https://github.com/getsentry/sentry-cocoa/issues/1852.


## :green_heart: How did you test it?
Hard to test as there are no unit tests for this.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
