### PR TITLE
dep update use deploy key

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,8 +17,8 @@ jobs:
       name: Android SDK
     secrets:
       # If a custom token is used instead, a CI would be triggered on a created PR.
-      # api_token: ${{ secrets.CI_DEPLOY_KEY }}
-      api_token: ${{ github.token }}
+      api_token: ${{ secrets.CI_DEPLOY_KEY }}
+      # api_token: ${{ github.token }}
 
   cocoa:
     uses: getsentry/github-workflows/.github/workflows/updater.yml@v1


### PR DESCRIPTION
_#skip-changelog_

Similar to https://github.com/getsentry/sentry-dart/pull/907 otherwise CI won't run and we can't merge it.