### PR TITLE
chore: auto-update sentry-cli

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -49,3 +49,11 @@ jobs:
       # If a custom token is used instead, a CI would be triggered on a created PR.
       api_token: ${{ secrets.CI_DEPLOY_KEY }}
       # api_token: ${{ github.token }}
+
+  cli:
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    with:
+      path: scripts/update-cli.sh
+      name: CLI
+    secrets:
+      api_token: ${{ secrets.CI_DEPLOY_KEY }}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@sentry/browser": "7.5.0",
-    "@sentry/cli": "^1.74.4",
+    "@sentry/cli": "1.74.4",
     "@sentry/core": "7.5.0",
     "@sentry/hub": "7.5.0",
     "@sentry/integrations": "7.5.0",

--- a/scripts/update-cli.sh
+++ b/scripts/update-cli.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="https://github.com/getsentry/sentry-cli.git"
+packages=('@sentry/cli')
+
+. $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
closes #2305 via the next PR that would be created after this is merged

ideally, there should be tests first, but I wanted to get this PR off my mind (and hit the checkbox in https://github.com/getsentry/team-mobile/issues/20)

#skip-changelog