### PR TITLE
chore: sample react-native updater

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -57,3 +57,11 @@ jobs:
       name: CLI
     secrets:
       api_token: ${{ secrets.CI_DEPLOY_KEY }}
+
+  sample-rn:
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    with:
+      path: sample/scripts/update-rn.sh
+      name: Sample React Native
+    secrets:
+      api_token: ${{ secrets.CI_DEPLOY_KEY }}

--- a/sample/scripts/update-rn.sh
+++ b/sample/scripts/update-rn.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tagPrefix='v' # wizard has a prefix in the repo, but the package.json doesn't have that - we must align
+repo="https://github.com/facebook/react-native.git"
+packages=('react-native')
+
+. $(dirname "$0")/../../scripts/update-package-json.sh
+
+# Also update package.json with all other dependencies
+cd $(dirname "$0")/..
+yarn upgrade
+npx -y syncyarnlock --save --keepPrefix
+yarn install

--- a/scripts/update-package-json.sh
+++ b/scripts/update-package-json.sh
@@ -7,7 +7,7 @@ case $1 in
 get-version)
     regex='"'${packages[0]}'": *"([0-9.]+)"'
     if ! [[ $content =~ $regex ]]; then
-        echo "Failed to find the plugin version in $file"
+        echo "Failed to find plugin '${packages[0]}' version in $file"
         exit 1
     fi
     echo $tagPrefix${BASH_REMATCH[1]}


### PR DESCRIPTION
resolves https://github.com/getsentry/team-mobile/issues/20#issuecomment-1162982754

Note: I've added `npx -y syncyarnlock --save --keepPrefix` to update `sample/package.json` - not tested in CI though - should I make a custom setup in my fork or do we merge this and fix afterwards if it doesn't work on `main`?