### PR TITLE
When using SENTRY_DIST env. var. on Android, SDK fails to convert to an Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md#760)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.5.1...7.6.0)
 
+### Fixes
+
+- When using SENTRY_DIST env. var. on Android, SDK fails to convert to an Integer ([#2361](https://github.com/getsentry/sentry-react-native/pull/2361))
+
 ## 4.1.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- When using SENTRY_DIST env. var. on Android, SDK fails to convert to an Integer ([#2361](https://github.com/getsentry/sentry-react-native/pull/2361))
+- When using SENTRY_DIST env. var. on Android, SDK fails to convert to an Integer ([#2365](https://github.com/getsentry/sentry-react-native/pull/2365))
 
 ## 4.1.1
 

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -65,6 +65,15 @@ gradle.projectsEvaluated {
           variant = currentVariant[0]
           releaseName = currentVariant[1]
           versionCode = currentVariant[2]
+
+          try {
+            if (versionCode instanceof String) {
+                versionCode = Integer.parseInt(versionCode);
+            }
+          } catch (NumberFormatException e) {
+            project.logger.info("versionCode: '$versionCode' isn't an Integer, but it must be.")
+          }
+
           def absVersionCode = Math.abs(versionCode)
 
           // The Sentry server distinguishes source maps by release (`--release` in the command


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description



## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-react-native/issues/2322
`System.getenv("SENTRY_DIST")` returns a String and fails to `Math.abs`


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
