### PR TITLE
fix: Solve reference to private cocoa SDK class

### DIFF
--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -8,7 +8,10 @@
 
 #import <Sentry/Sentry.h>
 #import <Sentry/SentryScreenFrames.h>
-#import <Sentry/SentryTraceContext.h>
+
+@interface SentryTraceContext : NSObject
+- (nullable instancetype)initWithDict:(NSDictionary<NSString *, id> *)dictionary;
+@end
 
 @interface SentrySDK (RNSentry)
 


### PR DESCRIPTION
Solved a reference to a private cocoa SDK class that keeps projects from compiling when using cocoa pods and dynamic libraries.

close #2353 

_#skip-changelog_ 


