### PR TITLE
Adds Attach Screenshot Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- feat: Adds `attachScreenshot` option.
+### Features
+
+- feat: Adds `attachScreenshot` option ([#2373](https://github.com/getsentry/sentry-react-native/pull/2373))
 
 ## 4.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: Adds `attachScreenshot` option.
+
 ## 4.1.3
 
 fix: Solve reference to private cocoa SDK class #2369

--- a/android/src/main/java/io/sentry/react/RNSentryModule.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModule.java
@@ -133,6 +133,9 @@ public class RNSentryModule extends ReactContextBaseJavaModule {
                 // by default we hide.
                 options.setAttachThreads(rnOptions.getBoolean("attachThreads"));
             }
+            if (rnOptions.hasKey("attachScreenshot")) {
+                options.setAttachScreenshot(rnOptions.getBoolean("attachScreenshot"));
+            }
             if (rnOptions.hasKey("sendDefaultPii")) {
                 options.setSendDefaultPii(rnOptions.getBoolean("sendDefaultPii"));
             }

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -62,6 +62,8 @@ Sentry.init({
   // release: 'myapp@1.2.3+1',
   // dist: `1`,
   attachStacktrace: true,
+  // Attach screenshots to events.
+  attachScreenshot: true,
 });
 
 const Stack = createStackNavigator();

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -93,11 +93,18 @@ export interface BaseReactNativeOptions {
   patchGlobalPromise?: boolean;
 
   /**
- * The max cache items for capping the number of envelopes.
- *
- * @default 30
- */
+   * The max cache items for capping the number of envelopes.
+   *
+   * @default 30
+   */
   maxCacheItems?: number;
+
+  /**
+   * When enabled and a user experiences an error, Sentry provides the ability to take a screenshot and include it as an attachment.
+   *
+   * @default false
+   */
+  attachScreenshot?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes #2362

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds a `attachScreenshot` option that sets the `attachScreenshot` in cocoa project and calls `setAttachScreenshot` in java project. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Excited about using the new Sentry screenshot feature in React Native projects.

## :green_heart: How did you test it?
Ran the sample projects.

iOS:
![image](https://user-images.githubusercontent.com/4108718/179298024-1caeaf5c-d719-48d2-bbc9-8784ac164147.png)

Android:
![image](https://user-images.githubusercontent.com/4108718/179300831-3d1cb9b3-80bc-464a-b694-57b47222ed9d.png)
(Not sure what I have to do to trigger a screenshot, didn't work for me, but did verify the setting was indeed set at init)


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
