### PR TITLE
should not ignore `options.transport` function provided in `Sentry.init(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - SENTRY_DIST accepts non-number values on Android ([#2395](https://github.com/getsentry/sentry-react-native/pull/2395))
+- should not ignore `options.transport` function provided in `Sentry.init(...)` ([#2398](https://github.com/getsentry/sentry-react-native/pull/2398))
 
 ### Features
 

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -25,14 +25,14 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
    * @param options Configuration options for this SDK.
    */
    public constructor(options: ReactNativeClientOptions) {
-    const transport = (options: BrowserTransportOptions, nativeFetch?: FetchImpl): Transport => {
-      if (NATIVE.isNativeTransportAvailable()) {
-        return new NativeTransport();
-      }
-      return makeFetchTransport(options, nativeFetch);
+     if (!options.transport) {
+       options.transport = (options: BrowserTransportOptions, nativeFetch?: FetchImpl): Transport => {
+         if (NATIVE.isNativeTransportAvailable()) {
+           return new NativeTransport();
+         }
+         return makeFetchTransport(options, nativeFetch);
+       };
      }
-
-     options.transport = transport;
      super(options);
 
     // This is a workaround for now using fetch on RN, this is a known issue in react-native and only generates a warning

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -114,8 +114,9 @@ describe('Tests ReactNativeClient', () => {
         dsn: EXAMPLE_DSN,
         transport: myCustomTransportFn
       } as ReactNativeClientOptions);
-
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(client.getTransport()?.flush).toBe(myFlush);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(client.getTransport()?.send).toBe(mySend);
     });
   });

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -102,10 +102,12 @@ describe('Tests ReactNativeClient', () => {
     });
     
     test('use custom transport function', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const mySend = (request: Envelope) => Promise.resolve();
+      const myFlush = (timeout?: number) => Promise.resolve(Boolean(timeout));
       const myCustomTransportFn = (): Transport => ({
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        send: (request: Envelope) => Promise.resolve(),
-        flush: (timeout?: number) => Promise.resolve(Boolean(timeout))
+        send: mySend,
+        flush: myFlush
       });
       const client = new ReactNativeClient({
         ...DEFAULT_OPTIONS,
@@ -113,8 +115,8 @@ describe('Tests ReactNativeClient', () => {
         transport: myCustomTransportFn
       } as ReactNativeClientOptions);
 
-      await expect(client.getTransport()?.flush(1)).resolves.toBe(true);
-      await expect(client.getTransport()?.send({} as Envelope)).resolves.toBeUndefined();
+      expect(client.getTransport()?.flush).toBe(myFlush);
+      expect(client.getTransport()?.send).toBe(mySend);
     });
   });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,3 +1,4 @@
+import { Envelope, Transport } from '@sentry/types';
 import * as RN from 'react-native';
 
 import { ReactNativeClient } from '../src/js/client';
@@ -98,6 +99,22 @@ describe('Tests ReactNativeClient', () => {
       await expect(client.eventFromMessage('test')).resolves.toBeDefined();
       // eslint-disable-next-line deprecation/deprecation
       await expect(RN.YellowBox.ignoreWarnings).toBeCalled();
+    });
+    
+    test('use custom transport function', async () => {
+      const myCustomTransportFn = (): Transport => ({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        send: (request: Envelope) => Promise.resolve(),
+        flush: (timeout?: number) => Promise.resolve(Boolean(timeout))
+      });
+      const client = new ReactNativeClient({
+        ...DEFAULT_OPTIONS,
+        dsn: EXAMPLE_DSN,
+        transport: myCustomTransportFn
+      } as ReactNativeClientOptions);
+
+      await expect(client.getTransport()?.flush(1)).resolves.toBe(true);
+      await expect(client.getTransport()?.send({} as Envelope)).resolves.toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
I've updated the ReactNativeClient constructor to first check if `options.transport` is provided and if so - then it takes it and calls to `super(options)`. If `options.transport` not provided then keep the previous logic and conduct react-native transport layer and then calls to `super(options)`.


## :bulb: Motivation and Context
this resolves issue #2397 


## :green_heart: How did you test it?
I've added a test which gets the given custom transport layer and then runs and validates the customized `send` and `flush` functions.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
