### PR TITLE
Move `wizard` to dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
     "@sentry/react": "7.9.0",
     "@sentry/tracing": "7.9.0",
     "@sentry/types": "7.9.0",
-    "@sentry/utils": "7.9.0",
-    "@sentry/wizard": "2.0.0"
+    "@sentry/utils": "7.9.0"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "7.9.0",
     "@sentry-internal/eslint-plugin-sdk": "7.9.0",
     "@sentry/typescript": "^5.20.1",
+    "@sentry/wizard": "2.0.0",
     "@types/jest": "^26.0.15",
     "@types/react": "^16.9.49",
     "@types/react-native": "^0.66.11",


### PR DESCRIPTION
_#skip-changelog_

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
`wizard` was added back in as a dependency because of https://github.com/getsentry/sentry-react-native/pull/2015
on v5, we don't support RN < 0.69 so it's not a problem anymore.


## :bulb: Motivation and Context
Fix https://github.com/getsentry/sentry-react-native/issues/2409


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
