### PR TITLE
ReactNativeTracing wrongly marks transactions as deadline_exceeded when it reaches the idleTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- ReactNativeTracing wrongly marks transactions as deadline_exceeded when it reaches the idleTimeout ([#2398](https://github.com/getsentry/sentry-react-native/pull/2398))
+- ReactNativeTracing wrongly marks transactions as deadline_exceeded when it reaches the idleTimeout ([#2427](https://github.com/getsentry/sentry-react-native/pull/2427))
 
 ## 4.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- ReactNativeTracing wrongly marks transactions as deadline_exceeded when it reaches the idleTimeout ([#2398](https://github.com/getsentry/sentry-react-native/pull/2398))
+
 ## 4.2.3
 
 ### Fixes

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -361,7 +361,7 @@ export class ReactNativeTracing implements Integration {
       hub as Hub,
       expandedContext,
       idleTimeout,
-      idleTimeout, // BREAKCHANGE: check the correct parameter here
+      maxTransactionDuration,
       true
     );
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
ReactNativeTracing wrongly marks transactions as deadline_exceeded when it reaches the idleTimeout


## :bulb: Motivation and Context
Bug was introduced when migrating the JS SDK to v7
Fix https://github.com/getsentry/sentry-react-native/issues/2426


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
