### PR TITLE
ci: bump updater to v2

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -11,58 +11,56 @@ on:
 
 jobs:
   android:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-android.sh
       name: Android SDK
+      pr-strategy: update
     secrets:
-      # If a custom token is used instead, a CI would be triggered on a created PR.
-      api_token: ${{ secrets.CI_DEPLOY_KEY }}
-      # api_token: ${{ github.token }}
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   cocoa:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-cocoa.sh
       name: Cocoa SDK
+      pr-strategy: update
     secrets:
-      # If a custom token is used instead, a CI would be triggered on a created PR.
-      api_token: ${{ secrets.CI_DEPLOY_KEY }}
-      # api_token: ${{ github.token }}
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   javascript:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-javascript.sh
       name: JavaScript SDK
+      pr-strategy: update
     secrets:
-      # If a custom token is used instead, a CI would be triggered on a created PR.
-      api_token: ${{ secrets.CI_DEPLOY_KEY }}
-      # api_token: ${{ github.token }}
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   wizard:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-wizard.sh
       name: Wizard
+      pr-strategy: update
     secrets:
-      # If a custom token is used instead, a CI would be triggered on a created PR.
-      api_token: ${{ secrets.CI_DEPLOY_KEY }}
-      # api_token: ${{ github.token }}
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   cli:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-cli.sh
       name: CLI
+      pr-strategy: update
     secrets:
-      api_token: ${{ secrets.CI_DEPLOY_KEY }}
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   sample-rn:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v1
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: sample/scripts/update-rn.sh
       name: Sample React Native
       pattern: '^v[0-9.]+$' # only match non-preview versions, also ignores "latest"
+      pr-strategy: update
     secrets:
-      api_token: ${{ secrets.CI_DEPLOY_KEY }}
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}


### PR DESCRIPTION
One notable difference this brings is the "PR Stragegy" change from "creating new PRs for each dependency, while old unmerged PRs stay untached" to "update the same PR until finally merged". This will require existing open PRs for the affected dependencies to be closed (& branches deleted) or merged. It's OK to merge this even without doing the change, but then the updater workflow will fail.

#skip-changelog