### PR TITLE
Add transaction source for dynamic sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bump JavaScript SDK from v7.9.0 to v7.12.1 ([#2451](https://github.com/getsentry/sentry-react-native/pull/2451))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md#7121)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.9.0...7.12.1)
+- Add Transaction Source for Dynamic Sampling Context ([#2454](https://github.com/getsentry/sentry-react-native/pull/2454))
 
 ## 4.2.4
 

--- a/src/js/tracing/reactnativenavigation.ts
+++ b/src/js/tracing/reactnativenavigation.ts
@@ -8,7 +8,7 @@ import {
   TransactionCreator,
 } from './routingInstrumentation';
 import { BeforeNavigate, RouteChangeContextData } from './types';
-import { defaultTransactionSource, getBlankTransactionContext } from './utils';
+import { customTransactionSource, defaultTransactionSource, getBlankTransactionContext } from './utils';
 
 interface ReactNativeNavigationOptions {
   routeChangeTimeoutMs: number;
@@ -177,7 +177,7 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
         const isCustomName = updatedContext.name !== finalContext.name;
         this._latestTransaction.setName(
           finalContext.name,
-          isCustomName ? 'custom' : defaultTransactionSource,
+          isCustomName ? customTransactionSource : defaultTransactionSource,
         );
 
         this._onConfirmRoute?.(finalContext);

--- a/src/js/tracing/reactnativenavigation.ts
+++ b/src/js/tracing/reactnativenavigation.ts
@@ -142,7 +142,6 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
         this._clearStateChangeTimeout();
 
         const originalContext = this._latestTransaction.toContext();
-        const originalMetadataSource = this._latestTransaction.metadata.source;
         const routeHasBeenSeen = this._recentComponentIds.includes(
           event.componentId
         );
@@ -175,11 +174,11 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
         const finalContext = this._prepareFinalContext(updatedContext);
         this._latestTransaction.updateWithContext(finalContext);
 
-        const notCustomName = updatedContext.name === finalContext.name;
-        if (notCustomName) {
-          const newSource = originalMetadataSource || defaultTransactionSource;
-          this._latestTransaction.setName(finalContext.name, newSource);
-        }
+        const isCustomName = updatedContext.name !== finalContext.name;
+        this._latestTransaction.setName(
+          finalContext.name,
+          isCustomName ? 'custom' : defaultTransactionSource,
+        );
 
         this._onConfirmRoute?.(finalContext);
         this._prevComponentEvent = event;
@@ -193,7 +192,7 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
 
   /** Creates final transaction context before confirmation */
   private _prepareFinalContext(updatedContext: TransactionContext): TransactionContext {
-    let finalContext = this._beforeNavigate?.(updatedContext);
+    let finalContext = this._beforeNavigate?.({ ...updatedContext });
 
     // This block is to catch users not returning a transaction context
     if (!finalContext) {

--- a/src/js/tracing/reactnavigation.ts
+++ b/src/js/tracing/reactnavigation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Transaction as TransactionType } from '@sentry/types';
+import { Transaction as TransactionType, TransactionContext } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
 
 import {
@@ -12,7 +12,7 @@ import {
   ReactNavigationTransactionContext,
   RouteChangeContextData,
 } from './types';
-import { getBlankTransactionContext } from './utils';
+import { defaultTransactionSource, getBlankTransactionContext } from './utils';
 
 export interface NavigationRoute {
   name: string;
@@ -199,6 +199,7 @@ export class ReactNavigationInstrumentation extends InternalRoutingInstrumentati
       if (this._latestTransaction) {
         if (!previousRoute || previousRoute.key !== route.key) {
           const originalContext = this._latestTransaction.toContext() as typeof BLANK_TRANSACTION_CONTEXT;
+          const originalMetadataSource = this._latestTransaction.metadata.source;
           const routeHasBeenSeen = this._recentRouteKeys.includes(route.key);
 
           const data: RouteChangeContextData = {
@@ -228,31 +229,15 @@ export class ReactNavigationInstrumentation extends InternalRoutingInstrumentati
             data,
           };
 
-          let finalContext = this._beforeNavigate?.(updatedContext);
-
-          // This block is to catch users not returning a transaction context
-          if (!finalContext) {
-            logger.error(
-              `[ReactNavigationInstrumentation] beforeNavigate returned ${finalContext}, return context.sampled = false to not send transaction.`
-            );
-
-            finalContext = {
-              ...updatedContext,
-              sampled: false,
-            };
-          }
-
-          // Note: finalContext.sampled will be false at this point only if the user sets it to be so in beforeNavigate.
-          if (finalContext.sampled === false) {
-            logger.log(
-              `[ReactNavigationInstrumentation] Will not send transaction "${finalContext.name}" due to beforeNavigate.`
-            );
-          } else {
-            // Clear the timeout so the transaction does not get cancelled.
-            this._clearStateChangeTimeout();
-          }
-
+          const finalContext = this._prepareFinalContext(updatedContext);
           this._latestTransaction.updateWithContext(finalContext);
+
+          const notCustomName = updatedContext.name === finalContext.name;
+          if (notCustomName) {
+            const newSource = originalMetadataSource || defaultTransactionSource;
+            this._latestTransaction.setName(finalContext.name, newSource);
+          }
+
           this._onConfirmRoute?.(finalContext);
         }
 
@@ -263,6 +248,35 @@ export class ReactNavigationInstrumentation extends InternalRoutingInstrumentati
 
     // Clear the latest transaction as it has been handled.
     this._latestTransaction = undefined;
+  }
+
+  /** Creates final transaction context before confirmation */
+  private _prepareFinalContext(updatedContext: TransactionContext): TransactionContext {
+    let finalContext = this._beforeNavigate?.(updatedContext);
+
+    // This block is to catch users not returning a transaction context
+    if (!finalContext) {
+      logger.error(
+        `[ReactNavigationInstrumentation] beforeNavigate returned ${finalContext}, return context.sampled = false to not send transaction.`
+      );
+
+      finalContext = {
+        ...updatedContext,
+        sampled: false,
+      };
+    }
+
+    // Note: finalContext.sampled will be false at this point only if the user sets it to be so in beforeNavigate.
+    if (finalContext.sampled === false) {
+      logger.log(
+        `[ReactNavigationInstrumentation] Will not send transaction "${finalContext.name}" due to beforeNavigate.`
+      );
+    } else {
+      // Clear the timeout so the transaction does not get cancelled.
+      this._clearStateChangeTimeout();
+    }
+
+    return finalContext;
   }
 
   /** Pushes a recent route key, and removes earlier routes when there is greater than the max length */

--- a/src/js/tracing/reactnavigation.ts
+++ b/src/js/tracing/reactnavigation.ts
@@ -12,7 +12,7 @@ import {
   ReactNavigationTransactionContext,
   RouteChangeContextData,
 } from './types';
-import { defaultTransactionSource, getBlankTransactionContext } from './utils';
+import { customTransactionSource, defaultTransactionSource, getBlankTransactionContext } from './utils';
 
 export interface NavigationRoute {
   name: string;
@@ -234,7 +234,7 @@ export class ReactNavigationInstrumentation extends InternalRoutingInstrumentati
           const isCustomName = updatedContext.name !== finalContext.name;
           this._latestTransaction.setName(
             finalContext.name,
-            isCustomName ? 'custom' : defaultTransactionSource,
+            isCustomName ? customTransactionSource : defaultTransactionSource,
           );
 
           this._onConfirmRoute?.(finalContext);

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -12,7 +12,7 @@ import {
   ReactNavigationTransactionContext,
   RouteChangeContextData,
 } from './types';
-import { defaultTransactionSource } from './utils';
+import { customTransactionSource, defaultTransactionSource } from './utils';
 
 export interface NavigationRouteV4 {
   routeName: string;
@@ -239,7 +239,7 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
         const isCustomName = mergedContext.name !== finalContext.name;
         this._latestTransaction.setName(
           finalContext.name,
-          isCustomName ? 'custom' : defaultTransactionSource,
+          isCustomName ? customTransactionSource : defaultTransactionSource,
         );
       } else {
         this._latestTransaction = this.onRouteWillChange(finalContext);

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -222,7 +222,6 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
         currentRoute,
         this._prevRoute
       );
-      const originalMetadataSource = originalContext.metadata?.source;
 
       let mergedContext = originalContext;
       if (updateLatestTransaction && this._latestTransaction) {
@@ -237,11 +236,11 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
       if (updateLatestTransaction && this._latestTransaction) {
         // Update the latest transaction instead of calling onRouteWillChange
         this._latestTransaction.updateWithContext(finalContext);
-        const notCustomName = mergedContext.name === finalContext.name;
-        if (notCustomName) {
-          const newSource = originalMetadataSource || defaultTransactionSource;
-          this._latestTransaction.setName(finalContext.name, newSource);
-        }
+        const isCustomName = mergedContext.name !== finalContext.name;
+        this._latestTransaction.setName(
+          finalContext.name,
+          isCustomName ? 'custom' : defaultTransactionSource,
+        );
       } else {
         this._latestTransaction = this.onRouteWillChange(finalContext);
       }
@@ -255,7 +254,7 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
 
   /** Creates final transaction context before confirmation */
   private _prepareFinalContext(mergedContext: TransactionContext): TransactionContext {
-    let finalContext = this._beforeNavigate?.(mergedContext);
+    let finalContext = this._beforeNavigate?.({ ...mergedContext });
 
     // This block is to catch users not returning a transaction context
     if (!finalContext) {

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Transaction } from '@sentry/types';
+import { Transaction, TransactionContext } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
 
 import {
@@ -12,6 +12,7 @@ import {
   ReactNavigationTransactionContext,
   RouteChangeContextData,
 } from './types';
+import { defaultTransactionSource } from './utils';
 
 export interface NavigationRouteV4 {
   routeName: string;
@@ -221,6 +222,7 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
         currentRoute,
         this._prevRoute
       );
+      const originalMetadataSource = originalContext.metadata?.source;
 
       let mergedContext = originalContext;
       if (updateLatestTransaction && this._latestTransaction) {
@@ -230,27 +232,16 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
         };
       }
 
-      let finalContext = this._beforeNavigate?.(mergedContext);
-
-      // This block is to catch users not returning a transaction context
-      if (!finalContext) {
-        logger.error(
-          `[ReactNavigationV4Instrumentation] beforeNavigate returned ${finalContext}, return context.sampled = false to not send transaction.`
-        );
-
-        finalContext = {
-          ...mergedContext,
-          sampled: false,
-        };
-      }
-
-      if (finalContext.sampled === false) {
-        this._onBeforeNavigateNotSampled(finalContext.name);
-      }
+      const finalContext = this._prepareFinalContext(mergedContext);
 
       if (updateLatestTransaction && this._latestTransaction) {
         // Update the latest transaction instead of calling onRouteWillChange
         this._latestTransaction.updateWithContext(finalContext);
+        const notCustomName = mergedContext.name === finalContext.name;
+        if (notCustomName) {
+          const newSource = originalMetadataSource || defaultTransactionSource;
+          this._latestTransaction.setName(finalContext.name, newSource);
+        }
       } else {
         this._latestTransaction = this.onRouteWillChange(finalContext);
       }
@@ -260,6 +251,29 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
       this._pushRecentRouteKey(currentRoute.key);
       this._prevRoute = currentRoute;
     }
+  }
+
+  /** Creates final transaction context before confirmation */
+  private _prepareFinalContext(mergedContext: TransactionContext): TransactionContext {
+    let finalContext = this._beforeNavigate?.(mergedContext);
+
+    // This block is to catch users not returning a transaction context
+    if (!finalContext) {
+      logger.error(
+        `[ReactNavigationV4Instrumentation] beforeNavigate returned ${finalContext}, return context.sampled = false to not send transaction.`
+      );
+
+      finalContext = {
+        ...mergedContext,
+        sampled: false,
+      };
+    }
+
+    if (finalContext.sampled === false) {
+      this._onBeforeNavigateNotSampled(finalContext.name);
+    }
+
+    return finalContext;
   }
 
   /**
@@ -345,7 +359,7 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
   }
 }
 
-const INITIAL_TRANSACTION_CONTEXT_V4 = {
+const INITIAL_TRANSACTION_CONTEXT_V4: TransactionContext = {
   name: 'App Launch',
   op: 'navigation',
   tags: {
@@ -353,6 +367,9 @@ const INITIAL_TRANSACTION_CONTEXT_V4 = {
       ReactNavigationV4Instrumentation.instrumentationName,
   },
   data: {},
+  metadata: {
+    source: 'view',
+  },
 };
 
 export { ReactNavigationV4Instrumentation, INITIAL_TRANSACTION_CONTEXT_V4 };

--- a/src/js/tracing/utils.ts
+++ b/src/js/tracing/utils.ts
@@ -2,7 +2,8 @@ import { IdleTransaction, Span, Transaction } from '@sentry/tracing';
 import { TransactionContext, TransactionSource } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
 
-export const defaultTransactionSource: TransactionSource = 'view';
+export const defaultTransactionSource: TransactionSource = 'component';
+export const customTransactionSource: TransactionSource = 'custom';
 
 export const getBlankTransactionContext = (
   name: string

--- a/src/js/tracing/utils.ts
+++ b/src/js/tracing/utils.ts
@@ -1,6 +1,8 @@
 import { IdleTransaction, Span, Transaction } from '@sentry/tracing';
-import { TransactionContext } from '@sentry/types';
+import { TransactionContext, TransactionSource } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
+
+export const defaultTransactionSource: TransactionSource = 'view';
 
 export const getBlankTransactionContext = (
   name: string
@@ -12,6 +14,9 @@ export const getBlankTransactionContext = (
       'routing.instrumentation': name,
     },
     data: {},
+    metadata: {
+      source: defaultTransactionSource,
+    },
   };
 };
 

--- a/test/tracing/reactnativenavigation.test.ts
+++ b/test/tracing/reactnativenavigation.test.ts
@@ -92,6 +92,7 @@ describe('React Native Navigation Instrumentation', () => {
       },
       previousRoute: null,
     });
+    expect(mockTransaction.metadata.source).toBe('view');
   });
 
   test('Transaction context is changed with beforeNavigate', () => {
@@ -144,6 +145,7 @@ describe('React Native Navigation Instrumentation', () => {
       },
       previousRoute: null,
     });
+    expect(mockTransaction.metadata.source).toBe('view');
   });
 
   test('Transaction not sent on a cancelled route change', () => {
@@ -258,6 +260,8 @@ describe('React Native Navigation Instrumentation', () => {
       expect(confirmedContext).toBeDefined();
       if (confirmedContext) {
         expect(confirmedContext.name).toBe(mockEvent2.componentName);
+        expect(confirmedContext.metadata).toBeDefined();
+        expect(confirmedContext.metadata?.source).toBe('view');
         expect(confirmedContext.data).toBeDefined();
         if (confirmedContext.data) {
           expect(confirmedContext.data.route.name).toBe(

--- a/test/tracing/reactnativenavigation.test.ts
+++ b/test/tracing/reactnativenavigation.test.ts
@@ -145,7 +145,7 @@ describe('React Native Navigation Instrumentation', () => {
       },
       previousRoute: null,
     });
-    expect(mockTransaction.metadata.source).toBe('view');
+    expect(mockTransaction.metadata.source).toBe('custom');
   });
 
   test('Transaction not sent on a cancelled route change', () => {

--- a/test/tracing/reactnativenavigation.test.ts
+++ b/test/tracing/reactnativenavigation.test.ts
@@ -92,7 +92,7 @@ describe('React Native Navigation Instrumentation', () => {
       },
       previousRoute: null,
     });
-    expect(mockTransaction.metadata.source).toBe('view');
+    expect(mockTransaction.metadata.source).toBe('component');
   });
 
   test('Transaction context is changed with beforeNavigate', () => {

--- a/test/tracing/reactnativenavigation.test.ts
+++ b/test/tracing/reactnativenavigation.test.ts
@@ -260,8 +260,7 @@ describe('React Native Navigation Instrumentation', () => {
       expect(confirmedContext).toBeDefined();
       if (confirmedContext) {
         expect(confirmedContext.name).toBe(mockEvent2.componentName);
-        expect(confirmedContext.metadata).toBeDefined();
-        expect(confirmedContext.metadata?.source).toBe('view');
+        expect(confirmedContext.metadata).toBeUndefined();
         expect(confirmedContext.data).toBeDefined();
         if (confirmedContext.data) {
           expect(confirmedContext.data.route.name).toBe(

--- a/test/tracing/reactnavigation.test.ts
+++ b/test/tracing/reactnavigation.test.ts
@@ -80,6 +80,7 @@ describe('ReactNavigationInstrumentation', () => {
       },
       previousRoute: null,
     });
+    expect(mockTransaction.metadata.source).toBe('view');
   });
 
   test('transaction sent on navigation', async () => {
@@ -140,6 +141,7 @@ describe('ReactNavigationInstrumentation', () => {
             params: {},
           },
         });
+        expect(mockTransaction.metadata.source).toBe('view');
 
         resolve();
       }, 50);
@@ -192,6 +194,7 @@ describe('ReactNavigationInstrumentation', () => {
         expect(mockTransaction.sampled).toBe(false);
         expect(mockTransaction.name).toBe('New Name');
         expect(mockTransaction.description).toBe('Description');
+        expect(mockTransaction.metadata.source).toBe('view');
         resolve();
       }, 50);
     });
@@ -488,6 +491,8 @@ describe('ReactNavigationInstrumentation', () => {
       expect(confirmedContext).toBeDefined();
       if (confirmedContext) {
         expect(confirmedContext.name).toBe(route2.name);
+        expect(confirmedContext.metadata).toBeDefined();
+        expect(confirmedContext.metadata?.source).toBe('view');
         expect(confirmedContext.data).toBeDefined();
         if (confirmedContext.data) {
           expect(confirmedContext.data.route.name).toBe(route2.name);

--- a/test/tracing/reactnavigation.test.ts
+++ b/test/tracing/reactnavigation.test.ts
@@ -194,7 +194,7 @@ describe('ReactNavigationInstrumentation', () => {
         expect(mockTransaction.sampled).toBe(false);
         expect(mockTransaction.name).toBe('New Name');
         expect(mockTransaction.description).toBe('Description');
-        expect(mockTransaction.metadata.source).toBe('view');
+        expect(mockTransaction.metadata.source).toBe('custom');
         resolve();
       }, 50);
     });

--- a/test/tracing/reactnavigation.test.ts
+++ b/test/tracing/reactnavigation.test.ts
@@ -491,8 +491,7 @@ describe('ReactNavigationInstrumentation', () => {
       expect(confirmedContext).toBeDefined();
       if (confirmedContext) {
         expect(confirmedContext.name).toBe(route2.name);
-        expect(confirmedContext.metadata).toBeDefined();
-        expect(confirmedContext.metadata?.source).toBe('view');
+        expect(confirmedContext.metadata).toBeUndefined();
         expect(confirmedContext.data).toBeDefined();
         if (confirmedContext.data) {
           expect(confirmedContext.data.route.name).toBe(route2.name);

--- a/test/tracing/reactnavigation.test.ts
+++ b/test/tracing/reactnavigation.test.ts
@@ -80,7 +80,7 @@ describe('ReactNavigationInstrumentation', () => {
       },
       previousRoute: null,
     });
-    expect(mockTransaction.metadata.source).toBe('view');
+    expect(mockTransaction.metadata.source).toBe('component');
   });
 
   test('transaction sent on navigation', async () => {
@@ -141,7 +141,7 @@ describe('ReactNavigationInstrumentation', () => {
             params: {},
           },
         });
-        expect(mockTransaction.metadata.source).toBe('view');
+        expect(mockTransaction.metadata.source).toBe('component');
 
         resolve();
       }, 50);

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -139,7 +139,7 @@ describe('ReactNavigationV4Instrumentation', () => {
       previousRoute: null,
     });
     expect(mockTransaction.sampled).toBe(true);
-    expect(mockTransaction.metadata.source).toBe('view');
+    expect(mockTransaction.metadata.source).toBe('component');
   });
 
   test('transaction sent on navigation', () => {
@@ -200,7 +200,7 @@ describe('ReactNavigationV4Instrumentation', () => {
     });
 
     expect(mockTransaction.sampled).toBe(true);
-    expect(mockTransaction.metadata.source).toBe('view');
+    expect(mockTransaction.metadata.source).toBe('component');
   });
 
   test('transaction context changed with beforeNavigate', () => {

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -139,6 +139,7 @@ describe('ReactNavigationV4Instrumentation', () => {
       previousRoute: null,
     });
     expect(mockTransaction.sampled).toBe(true);
+    expect(mockTransaction.metadata.source).toBe('view');
   });
 
   test('transaction sent on navigation', () => {
@@ -199,6 +200,7 @@ describe('ReactNavigationV4Instrumentation', () => {
     });
 
     expect(mockTransaction.sampled).toBe(true);
+    expect(mockTransaction.metadata.source).toBe('view');
   });
 
   test('transaction context changed with beforeNavigate', () => {
@@ -262,6 +264,7 @@ describe('ReactNavigationV4Instrumentation', () => {
     });
 
     expect(mockTransaction.sampled).toBe(false);
+    expect(mockTransaction.metadata.source).toBe('view');
   });
 
   test('transaction not attached on a cancelled navigation', () => {

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -264,7 +264,7 @@ describe('ReactNavigationV4Instrumentation', () => {
     });
 
     expect(mockTransaction.sampled).toBe(false);
-    expect(mockTransaction.metadata.source).toBe('view');
+    expect(mockTransaction.metadata.source).toBe('custom');
   });
 
   test('transaction not attached on a cancelled navigation', () => {

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -501,6 +501,7 @@ describe('ReactNavigationV4Instrumentation', () => {
       if (confirmedContext) {
         expect(confirmedContext.name).toBe(route2.routeName);
         expect(confirmedContext.data).toBeDefined();
+        expect(confirmedContext.metadata).toBeUndefined();
         if (confirmedContext.data) {
           expect(confirmedContext.data.route.name).toBe(route2.routeName);
           expect(confirmedContext.data.previousRoute).toBeDefined();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description

I've added default `view` source for all the integration, which can be overwritten by the user.

I've picked `view` as its description fitted the most to what it actually is. Example `Home`, `Menu`, `ProfilePage` etc.
https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations

## :bulb: Motivation and Context

At the moment the source is always `custom`, because we first create empty transaction and then update it with the correct route data, which causes the source to be set as `custom`.

https://github.com/getsentry/team-mobile/issues/46

## :green_heart: How did you test it?

🚨 To be done when sentry backend will allow dynamic sampling for React Native.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
