### PR TITLE
maxTransactionDuration should be ms when passing to startIdleTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- ReactNativeTracingOptions maxTransactionDuration is in seconds ([#2469](https://github.com/getsentry/sentry-react-native/pull/2469))
+
 ## 4.3.0
 
 ### Features

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -361,7 +361,7 @@ export class ReactNativeTracing implements Integration {
       hub as Hub,
       expandedContext,
       idleTimeout,
-      maxTransactionDuration,
+      maxTransactionDuration * 1000, // convert seconds to milliseconds
       true
     );
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
https://github.com/getsentry/sentry-react-native/blob/b6fe2890eedc3c6f66e1f75d5fab6653106ec889/src/js/tracing/reactnativetracing.ts#L42-L49 `maxTransactionDuration` is documented as in `seconds`.

https://github.com/getsentry/sentry-javascript/blob/fbd4ef07dd4248a1a9f8a80e0c220628a663f91c/packages/tracing/src/idletransaction.ts#L79-L87
defines both values in `ms`

When passing the values to the idle transaction, we need to convert the one in seconds to milliseconds
https://github.com/getsentry/sentry-react-native/blob/b6fe2890eedc3c6f66e1f75d5fab6653106ec889/src/js/tracing/reactnativetracing.ts#L363-L364


## :bulb: Motivation and Context
https://github.com/getsentry/sentry-react-native/issues/2468
https://github.com/getsentry/sentry-react-native/issues/2467


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
