### PR TITLE
fix(init): Integrations factory gets default integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add typings for app hang functionality ([#2479](https://github.com/getsentry/sentry-react-native/pull/2479))
 - Update warm/cold start span ops ([#2487](https://github.com/getsentry/sentry-react-native/pull/2487))
 - Detect hard crash the same as native sdks ([#2480](https://github.com/getsentry/sentry-react-native/pull/2480))
+- Integrations factory receives default integrations ([#2494](https://github.com/getsentry/sentry-react-native/pull/2494))
 
 ### Dependencies
 

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -1,7 +1,11 @@
 import { getIntegrationsToSetup, initAndBind, setExtra } from '@sentry/core';
 import { Hub, makeMain } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
-import { defaultStackParser, getCurrentHub } from '@sentry/react';
+import {
+  defaultIntegrations as reactDefaultIntegrations,
+  defaultStackParser,
+  getCurrentHub,
+} from '@sentry/react';
 import { Integration, StackFrame, UserFeedback } from '@sentry/types';
 import { getGlobalObject, logger, stackParserFromStackParserOptions } from '@sentry/utils';
 import * as React from 'react';
@@ -69,8 +73,8 @@ export function init(passedOptions: ReactNativeOptions): void {
       patchGlobalPromise: options.patchGlobalPromise,
     }));
     defaultIntegrations.push(new Release());
-    options.integrations.push(...[
-      ...defaultIntegrations.filter(
+    defaultIntegrations.push(...[
+      ...reactDefaultIntegrations.filter(
         (i) => !IGNORED_DEFAULT_INTEGRATIONS.includes(i.name)
       ),
     ]);

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -1,7 +1,7 @@
 import { getIntegrationsToSetup, initAndBind, setExtra } from '@sentry/core';
 import { Hub, makeMain } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
-import { defaultIntegrations, defaultStackParser, getCurrentHub } from '@sentry/react';
+import { defaultStackParser, getCurrentHub } from '@sentry/react';
 import { Integration, StackFrame, UserFeedback } from '@sentry/types';
 import { getGlobalObject, logger, stackParserFromStackParserOptions } from '@sentry/utils';
 import * as React from 'react';
@@ -54,40 +54,35 @@ export function init(passedOptions: ReactNativeOptions): void {
       ...DEFAULT_OPTIONS.transportOptions,
       ...(passedOptions.transportOptions ?? {}),
     },
-    integrations: getIntegrationsToSetup(passedOptions),
+    integrations: [],
     stackParser: stackParserFromStackParserOptions(passedOptions.stackParser || defaultStackParser)
   };
-
-  function addIntegration(integration: Integration): void {
-    if (options.integrations.filter((i) => i.name == integration.name).length === 0) {
-      options.integrations.push(integration);
-    }
-  }
 
   // As long as tracing is opt in with either one of these options, then this is how we determine tracing is enabled.
   const tracingEnabled =
     typeof options.tracesSampler !== 'undefined' ||
     typeof options.tracesSampleRate !== 'undefined';
 
+  const defaultIntegrations: Integration[] = passedOptions.defaultIntegrations || [];
   if (passedOptions.defaultIntegrations === undefined) {
-    addIntegration(new ReactNativeErrorHandlers({
+    defaultIntegrations.push(new ReactNativeErrorHandlers({
       patchGlobalPromise: options.patchGlobalPromise,
     }));
-    addIntegration(new Release());
+    defaultIntegrations.push(new Release());
     options.integrations.push(...[
       ...defaultIntegrations.filter(
         (i) => !IGNORED_DEFAULT_INTEGRATIONS.includes(i.name)
       ),
     ]);
 
-    addIntegration(new EventOrigin());
-    addIntegration(new SdkInfo());
+    defaultIntegrations.push(new EventOrigin());
+    defaultIntegrations.push(new SdkInfo());
 
     if (__DEV__) {
-      addIntegration(new DebugSymbolicator());
+      defaultIntegrations.push(new DebugSymbolicator());
     }
 
-    addIntegration(new RewriteFrames({
+    defaultIntegrations.push(new RewriteFrames({
       iteratee: (frame: StackFrame) => {
         if (frame.filename) {
           frame.filename = frame.filename
@@ -111,15 +106,19 @@ export function init(passedOptions: ReactNativeOptions): void {
       },
     }));
     if (options.enableNative) {
-      addIntegration(new DeviceContext());
+      defaultIntegrations.push(new DeviceContext());
     }
     if (tracingEnabled) {
       if (options.enableAutoPerformanceTracking) {
-        addIntegration(new ReactNativeTracing());
+        defaultIntegrations.push(new ReactNativeTracing());
       }
     }
   }
 
+  options.integrations = getIntegrationsToSetup({
+    integrations: passedOptions.integrations,
+    defaultIntegrations,
+  });
   initAndBind(ReactNativeClient, options);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -261,6 +261,18 @@ describe('Tests the SDK functionality', () => {
 
       expect(actualIntegrations).toEqual([mockIntegration]);
     });
+
+    it('passes no defaults to the function', () => {
+      const mockIntegrationFactory = jest.fn((_integrations: Integration[]) => []);
+      init({
+        integrations: mockIntegrationFactory,
+        defaultIntegrations: false,
+      });
+
+      const actualPassedIntegrations = mockIntegrationFactory.mock.calls[0][firstArg];
+
+      expect(actualPassedIntegrations).toEqual([]);
+    });
   });
 });
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -17,7 +17,7 @@ jest.mock('@sentry/react', () => {
       getClient: jest.fn(() => mockClient),
       setTag: jest.fn(),
     })),
-    defaultIntegrations: [],
+    defaultIntegrations: [ { name: 'MockedDefaultReactIntegration', setupOnce: jest.fn() } ],
   };
 });
 
@@ -272,6 +272,16 @@ describe('Tests the SDK functionality', () => {
       const actualPassedIntegrations = mockIntegrationFactory.mock.calls[0][firstArg];
 
       expect(actualPassedIntegrations).toEqual([]);
+    });
+
+    it('adds react default integrations', () => {
+      init({});
+
+      const actualOptions = mockedInitAndBind.mock.calls[0][secondArg] as ReactNativeClientOptions;
+      const actualIntegrations = actualOptions.integrations;
+
+      expect(actualIntegrations)
+        .toEqual(expect.arrayContaining([expect.objectContaining({ name: 'MockedDefaultReactIntegration' })]));
     });
   });
 });

--- a/test/testutils.ts
+++ b/test/testutils.ts
@@ -20,6 +20,7 @@ export const getMockTransaction = (name: string): Transaction => {
 };
 
 export const firstArg = 0;
+export const secondArg = 1;
 export const envelopeHeader = 0;
 export const envelopeItems = 1;
 export const envelopeItemHeader = 0;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
I mainly wrote tests to lock in the behaviour of `integrations` and `defaultIntegrations` attributes of the Sentry.init function.

## :bulb: Motivation and Context
Fix: https://github.com/getsentry/sentry-react-native/issues/2462

## :green_heart: How did you test it?

Sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
