### PR TITLE
Allows collecting app start and slow/frozen frames if Native SDK is inited manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Make `configureScope` callback safe [#2510](https://github.com/getsentry/sentry-react-native/pull/2510)
+- Allows collecting app start and slow/frozen frames if Native SDK is inited manually [#2517](https://github.com/getsentry/sentry-react-native/pull/2517)
 
 ### Dependencies
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -394,7 +394,7 @@ RCT_EXPORT_METHOD(crash)
 {
     [SentrySDK crash];
 }
-tracesSampleRate
+
 RCT_EXPORT_METHOD(closeNativeSdk:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -89,6 +89,16 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
         }
     }
 
+    // Enable the App start and Frames tracking measurements
+    if ([mutableOptions valueForKey:@"enableAutoPerformanceTracking"] != nil) {
+        BOOL enableAutoPerformanceTracking = (BOOL)[mutableOptions valueForKey:@"enableAutoPerformanceTracking"];
+
+        PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = enableAutoPerformanceTracking;
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+        PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = enableAutoPerformanceTracking;
+#endif
+    }
+
     [SentrySDK startWithOptionsObject:sentryOptions];
 
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
@@ -384,7 +394,7 @@ RCT_EXPORT_METHOD(crash)
 {
     [SentrySDK crash];
 }
-
+tracesSampleRate
 RCT_EXPORT_METHOD(closeNativeSdk:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -394,18 +404,15 @@ RCT_EXPORT_METHOD(closeNativeSdk:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(disableNativeFramesTracking)
 {
-    PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false;
-#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
-    PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = false;
-#endif
+    // Do nothing on iOS, this bridge method only has an effect on android.
 }
 
 RCT_EXPORT_METHOD(enableNativeFramesTracking)
 {
-    PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true;
-#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
-    PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = true;
-#endif
+    // Do nothing on iOS, this bridge method only has an effect on android.
+    // If yu're starting the Cocoa SDK manually,
+    // you can set the 'enableAutoPerformanceTracking: true' option and
+    // the tracesSampleRate ortracesSampler option.
 }
 
 @end

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -89,16 +89,6 @@ RCT_EXPORT_METHOD(initNativeSdk:(NSDictionary *_Nonnull)options
         }
     }
 
-    // Enable the App start and Frames tracking measurements
-    if ([mutableOptions valueForKey:@"enableAutoPerformanceTracking"] != nil) {
-        BOOL enableAutoPerformanceTracking = (BOOL)[mutableOptions valueForKey:@"enableAutoPerformanceTracking"];
-
-        PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = enableAutoPerformanceTracking;
-#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
-        PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = enableAutoPerformanceTracking;
-#endif
-    }
-
     [SentrySDK startWithOptionsObject:sentryOptions];
 
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
@@ -404,7 +394,18 @@ RCT_EXPORT_METHOD(closeNativeSdk:(RCTPromiseResolveBlock)resolve
 
 RCT_EXPORT_METHOD(disableNativeFramesTracking)
 {
-    // Do nothing on iOS, this bridge method only has an effect on android.
+    PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false;
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+    PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = false;
+#endif
+}
+
+RCT_EXPORT_METHOD(enableNativeFramesTracking)
+{
+    PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true;
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+    PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = true;
+#endif
 }
 
 @end

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -410,9 +410,9 @@ RCT_EXPORT_METHOD(disableNativeFramesTracking)
 RCT_EXPORT_METHOD(enableNativeFramesTracking)
 {
     // Do nothing on iOS, this bridge method only has an effect on android.
-    // If yu're starting the Cocoa SDK manually,
+    // If you're starting the Cocoa SDK manually,
     // you can set the 'enableAutoPerformanceTracking: true' option and
-    // the tracesSampleRate ortracesSampler option.
+    // the 'tracesSampleRate' or 'tracesSampler' option.
 }
 
 @end

--- a/src/js/definitions.ts
+++ b/src/js/definitions.ts
@@ -42,6 +42,7 @@ export interface SentryNativeBridgeModule {
   crash(): void;
   closeNativeSdk(): PromiseLike<void>;
   disableNativeFramesTracking(): void;
+  enableNativeFramesTracking(): void;
   fetchNativeRelease(): Promise<{
     build: string;
     id: string;

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -163,6 +163,7 @@ export class ReactNativeTracing implements Integration {
     }
 
     if (enableNativeFramesTracking) {
+      NATIVE.enableNativeFramesTracking();
       this.nativeFramesInstrumentation = new NativeFramesInstrumentation(
         addGlobalEventProcessor,
         () => {

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -56,6 +56,7 @@ interface SentryNativeWrapper {
   fetchNativeSdkInfo(): PromiseLike<Package | null>;
 
   disableNativeFramesTracking(): void;
+  enableNativeFramesTracking(): void;
 
   addBreadcrumb(breadcrumb: Breadcrumb): void;
   setContext(key: string, context: { [key: string]: unknown } | null): void;
@@ -417,6 +418,17 @@ export const NATIVE: SentryNativeWrapper = {
     }
 
     RNSentry.disableNativeFramesTracking();
+  },
+
+  enableNativeFramesTracking(): void {
+    if (!this.enableNative) {
+      return;
+    }
+    if (!this._isModuleLoaded(RNSentry)) {
+      return;
+    }
+
+    RNSentry.enableNativeFramesTracking();
   },
 
   isNativeTransportAvailable(): boolean {

--- a/test/integrations/eventorigin.test.ts
+++ b/test/integrations/eventorigin.test.ts
@@ -10,7 +10,7 @@ describe('Event Origin', () => {
 
     integration.setupOnce(async (eventProcessor) => {
       try {
-        const processedEvent = await eventProcessor(mockEvent);
+        const processedEvent = await eventProcessor(mockEvent, {});
 
         expect(processedEvent).toBeDefined();
         if (processedEvent) {

--- a/test/integrations/release.test.ts
+++ b/test/integrations/release.test.ts
@@ -46,7 +46,7 @@ describe('Tests the Release integration', () => {
     // @ts-ignore Mock
     client.getOptions.mockImplementation(() => ({}));
 
-    const event = await eventProcessor({});
+    const event = await eventProcessor({}, {});
 
     expect(event?.release).toBe('native_id@native_version+native_build');
     expect(event?.dist).toBe('native_build');
@@ -68,7 +68,7 @@ describe('Tests the Release integration', () => {
       dist: 'options_dist',
     }));
 
-    const event = await eventProcessor({});
+    const event = await eventProcessor({}, {});
 
     expect(event?.release).toBe('native_id@native_version+native_build');
     expect(event?.dist).toBe('options_dist');
@@ -90,7 +90,7 @@ describe('Tests the Release integration', () => {
       release: 'options_release',
     }));
 
-    const event = await eventProcessor({});
+    const event = await eventProcessor({}, {});
 
     expect(event?.release).toBe('options_release');
     expect(event?.dist).toBe('native_build');
@@ -115,7 +115,7 @@ describe('Tests the Release integration', () => {
       release: 'options_release',
     }));
 
-    const event = await eventProcessor({});
+    const event = await eventProcessor({}, {});
 
     expect(event?.release).toBe('options_release');
     expect(event?.dist).toBe('options_dist');
@@ -145,7 +145,7 @@ describe('Tests the Release integration', () => {
         __sentry_dist: 'sentry_dist',
         __sentry_release: 'sentry_release',
       },
-    });
+    }, {});
 
     expect(event?.release).toBe('sentry_release');
     expect(event?.dist).toBe('sentry_dist');

--- a/test/tracing/nativeframes.test.ts
+++ b/test/tracing/nativeframes.test.ts
@@ -97,7 +97,7 @@ describe('NativeFramesInstrumentation', () => {
               },
               start_timestamp: finishTimestamp - 10,
               timestamp: finishTimestamp,
-            });
+            }, {});
 
             jest.runOnlyPendingTimers();
 
@@ -182,7 +182,7 @@ describe('NativeFramesInstrumentation', () => {
             start_timestamp: finishTimestamp - 10,
             timestamp: finishTimestamp,
             measurements: {},
-          });
+          }, {});
 
           jest.runOnlyPendingTimers();
 
@@ -259,7 +259,7 @@ describe('NativeFramesInstrumentation', () => {
               },
               start_timestamp: finishTimestamp - 10,
               timestamp: finishTimestamp,
-            });
+            }, {});
 
             jest.runOnlyPendingTimers();
 
@@ -334,7 +334,7 @@ describe('NativeFramesInstrumentation', () => {
               },
               start_timestamp: finishTimestamp - 10,
               timestamp: finishTimestamp,
-            });
+            }, {});
 
             expect(event).toBeDefined();
 

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -518,6 +518,21 @@ describe('ReactNativeTracing', () => {
   });
 
   describe('Native Frames', () => {
+    it('Initialize native frames instrumentation if flag is true', (done) => {
+      const integration = new ReactNativeTracing({
+        enableNativeFramesTracking: true,
+      });
+      const mockHub = getMockHub();
+      integration.setupOnce(addGlobalEventProcessor, () => mockHub);
+
+      setImmediate(() => {
+        expect(integration.nativeFramesInstrumentation).toBeDefined();
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(NATIVE.enableNativeFramesTracking).toBeCalledTimes(1);
+
+        done();
+      });
+    });
     it('Does not initialize native frames instrumentation if flag is false', (done) => {
       const integration = new ReactNativeTracing({
         enableNativeFramesTracking: false,

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -12,6 +12,7 @@ jest.mock('../../src/js/wrapper', () => {
       fetchNativeAppStart: jest.fn(),
       fetchNativeFrames: jest.fn(() => Promise.resolve()),
       disableNativeFramesTracking: jest.fn(() => Promise.resolve()),
+      enableNativeFramesTracking: jest.fn(() => Promise.resolve()),
       enableNative: true,
     },
   };


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Allows collecting app start and slow/frozen frames if Native SDK is inited manually
https://docs.sentry.io/platforms/react-native/manual-setup/native-init/


## :bulb: Motivation and Context
Fixes https://github.com/getsentry/sentry-react-native/issues/2367


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
