### PR TITLE
fix(sample): Metro-config renamed backlist to exclusionList

### DIFF
--- a/sample/metro.config.js
+++ b/sample/metro.config.js
@@ -6,7 +6,7 @@
  */
 
 const path = require('path');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const blacklist = require('metro-config/src/defaults/exclusionList');
 const resolve = require('metro-resolver/src/resolve');
 
 const parentDir = path.resolve(__dirname, '..');


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

https://github.com/facebook/metro/tree/v0.60.0/packages/metro-config/src/defaults

In version 0.60 was introduced `exclusionList`.

Although this should have been issue earlier, it started crsahing now.

## :bulb: Motivation and Context

The metro bundle would not start in the sample app.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog
