### PR TITLE
RNSentry.podspec: remove hardcoded Folly version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Remove hardcoded Folly version ([#2558](https://github.com/getsentry/sentry-react-native/pull/2558))
+
 ### Features
 
 - Send react native js engine, turbo module, fabric flags and component stack in Event contexts ([#2552](https://github.com/getsentry/sentry-react-native/pull/2552))

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -1,7 +1,6 @@
 require 'json'
 version = JSON.parse(File.read('package.json'))["version"]
 
-folly_version = '2021.07.22.00'
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
@@ -34,7 +33,7 @@ Pod::Spec.new do |s|
     }
 
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly", folly_version
+    s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
This is done, because that makes it incompatible with react-native versions that hardcode a different version

Fixes #2557 

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Do not hardcode RCT-Folly version

## :bulb: Motivation and Context
This makes it compatible with a react-native version that uses a different Folly version. See #2557 


## :green_heart: How did you test it?
Manually patched the file in `node_modules`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
