### PR TITLE
fix(envelope): Remove duplicate sdk package record from envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Remove duplicate sdk package record from envelope ([#2570](https://github.com/getsentry/sentry-react-native/pull/2570))
+
 ### Dependencies
 
 - Bump Android SDK from v6.4.3 to v6.5.0 ([#2535](https://github.com/getsentry/sentry-react-native/pull/2535))

--- a/src/js/integrations/sdkinfo.ts
+++ b/src/js/integrations/sdkinfo.ts
@@ -57,7 +57,6 @@ export class SdkInfo implements Integration {
         packages: [
           ...((event.sdk && event.sdk.packages) || []),
           ...((this._nativeSdkInfo && [this._nativeSdkInfo]) || []),
-          ...defaultSdkInfo.packages,
         ],
       };
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
I've introduced this bug in https://github.com/getsentry/sentry-react-native/pull/2492 while fixing missing SDK information in the envelope header. I didn't know that the JS SDK adds information from metadata also to the packages as RN does in SdkInfo integration, therefore this needed to be removed.

## :bulb: Motivation and Context

Closes: https://github.com/getsentry/sentry-react-native/issues/2531

## :green_heart: How did you test it?
Sample app and integrations tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
