### PR TITLE
fix: maximum call stack exceeded error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7290)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.28.0...7.29.0)
 
+### Fixes
+
+- Fixed maximum call stack exceeded error resulting from large payloads ([#2579](https://github.com/getsentry/sentry-react-native/pull/2579))
+
 ## 4.7.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Fixes
 
 - Message event can have attached stacktrace ([#2577](https://github.com/getsentry/sentry-react-native/pull/2577))
+- Fixed maximum call stack exceeded error resulting from large payloads ([#2579](https://github.com/getsentry/sentry-react-native/pull/2579))
 
 ### Dependencies
 
@@ -14,10 +15,6 @@
 - Bump Cocoa SDK from v7.28.0 to v7.29.0 ([#2571](https://github.com/getsentry/sentry-react-native/pull/2571))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7290)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.28.0...7.29.0)
-
-### Fixes
-
-- Fixed maximum call stack exceeded error resulting from large payloads ([#2579](https://github.com/getsentry/sentry-react-native/pull/2579))
 
 ## 4.7.1
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -118,7 +118,7 @@ export const NATIVE: SentryNativeWrapper = {
 
       envelopeBytes.push(...utf8ToBytes(serializedItemHeader));
       envelopeBytes.push(EOL);
-      envelopeBytes.push(...bytesPayload);
+      bytesPayload.forEach(byte => envelopeBytes.push(byte))
       envelopeBytes.push(EOL);
     }
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -118,7 +118,7 @@ export const NATIVE: SentryNativeWrapper = {
 
       envelopeBytes.push(...utf8ToBytes(serializedItemHeader));
       envelopeBytes.push(EOL);
-      bytesPayload.forEach(byte => envelopeBytes.push(byte))
+      bytesPayload.forEach(byte => envelopeBytes.push(byte));
       envelopeBytes.push(EOL);
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
fixed `Sentry Logger [error]: Error while sending event: RangeError: Maximum call stack size exceeded` error that occurs when adding large attachments to sentry capture

## :bulb: Motivation and Context
fixes `Sentry Logger [error]: Error while sending event: RangeError: Maximum call stack size exceeded` error which happens when the sentry payload bytes exceeds the number of arguments the `Array.prototype.push` method can support

it is recommended to only use the spread operator for smaller arrays. So when adding a large attachment such as a json file that contains a lot of data this will result in the `maximum call stack size exceeded error` which drops the sentry capture 


> The spread syntax fails to work with larger Arrays. When testing with 100,000 elements, the spread syntax generated a RangeError with the message: Maximum call stack size exceeded. I manually adjusted the number in the tool to identify the actual number of elements that caused this error. I found that number of elements to be 63,653. It’s unclear to me at this time why this number of elements causes this error. I don’t know if it’s my specific environment, specific code, or something else. I believe it’s beyond the scope of this article though

## :green_heart: How did you test it?
sample app and in my project that uses this repo

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
