### PR TITLE
fix: Avoid sending invalid/empty file paths to Sentry-CLI

### DIFF
--- a/sentry.gradle
+++ b/sentry.gradle
@@ -51,132 +51,139 @@ gradle.projectsEvaluated {
         //     .findAll{!['class', 'active'].contains(it.key)}
         //     .join('\n')
 
-        def currentVariants = extractCurrentVariants(bundleTask, releases)
-        if (currentVariants == null) return
+        File bundleOutputFile = new File(bundleOutput)
+        File sourcemapOutputFile = new File(sourcemapOutput)
 
-        def variant = null
-        def releaseName = null
-        def versionCode = null
-        def previousCliTask = null
+        def bofExists = bundleOutputFile.exists()
+        def sofExists = sourcemapOutputFile.exists()
+        if (bofExists && sofExists){
+            def currentVariants = extractCurrentVariants(bundleTask, releases)
+            if (currentVariants == null) return
 
-        def nameCleanup = "${bundleTask.name}_SentryUploadCleanUp"
-        // Upload the source map several times if necessary: once for each release and versionCode.
-        currentVariants.each { key, currentVariant ->
-          variant = currentVariant[0]
-          releaseName = currentVariant[1]
-          versionCode = currentVariant[2]
+            def variant = null
+            def releaseName = null
+            def versionCode = null
+            def previousCliTask = null
 
-          try {
-            if (versionCode instanceof String) {
-                versionCode = Integer.parseInt(versionCode)
-                versionCode = Math.abs(versionCode)
+            def nameCleanup = "${bundleTask.name}_SentryUploadCleanUp"
+            // Upload the source map several times if necessary: once for each release and versionCode.
+            currentVariants.each { key, currentVariant ->
+                variant = currentVariant[0]
+                releaseName = currentVariant[1]
+                versionCode = currentVariant[2]
+
+                try {
+                    if (versionCode instanceof String) {
+                        versionCode = Integer.parseInt(versionCode)
+                        versionCode = Math.abs(versionCode)
+                    }
+                } catch (NumberFormatException e) {
+                    project.logger.info("versionCode: '$versionCode' isn't an Integer, using the plain value.")
+                }
+
+                // The Sentry server distinguishes source maps by release (`--release` in the command
+                // below) and distribution identifier (`--dist` below).  Give the task a unique name
+                // based on where we're uploading to.
+                def nameCliTask = "${bundleTask.name}_SentryUpload_${releaseName}_${versionCode}"
+
+                // If several outputs have the same releaseName and versionCode, we'd do the exact same
+                // upload for each of them.  No need to repeat.
+                try { tasks.named(nameCliTask); return } catch (Exception e) {}
+
+                /** Upload source map file to the sentry server via CLI call. */
+                def cliTask = tasks.create(nameCliTask, Exec) {
+                    description = "upload debug symbols to sentry"
+                    group = 'sentry.io'
+
+                    workingDir reactRoot
+
+                    def propertiesFile = config.sentryProperties
+                            ? config.sentryProperties
+                            : "$reactRoot/android/sentry.properties"
+
+                    if (config.flavorAware) {
+                        propertiesFile = "$reactRoot/android/sentry-${variant}.properties"
+                        project.logger.info("For $variant using: $propertiesFile")
+                    } else {
+                        environment("SENTRY_PROPERTIES", propertiesFile)
+                    }
+
+                    Properties sentryProps = new Properties()
+                    try {
+                        sentryProps.load(new FileInputStream(propertiesFile))
+                    } catch (FileNotFoundException e) {
+                        project.logger.info("file not found '$propertiesFile' for '$variant'")
+                    }
+
+                    def resolvedCliPackage = null
+                    try {
+                        resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
+                    } catch (Throwable ignored) {}
+                    def cliPackage = resolvedCliPackage != null && resolvedCliPackage.exists() ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
+                    def cliExecutable = sentryProps.get("cli.executable", "$cliPackage/bin/sentry-cli")
+
+                    // fix path separator for Windows
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        cliExecutable = cliExecutable.replaceAll("/", "\\\\")
+                    }
+
+                    //
+                    // based on:
+                    //   https://github.com/getsentry/sentry-cli/blob/master/src/commands/react_native_gradle.rs
+                    //
+                    def args = [cliExecutable]
+
+                    args.addAll(!config.logLevel ? [] : [
+                            "--log-level", config.logLevel      // control verbosity of the output
+                    ])
+                    args.addAll(!config.flavorAware ? [] : [
+                            "--url", sentryProps.get("defaults.url"),
+                            "--auth-token", sentryProps.get("auth.token")
+                    ])
+                    args.addAll(["react-native", "gradle",
+                                "--bundle", bundleOutput,           // The path to a bundle that should be uploaded.
+                                "--sourcemap", sourcemapOutput,     // The path to a sourcemap that should be uploaded.
+                                "--release", releaseName,            // The name of the release to publish.
+                                "--dist", versionCode
+                    ])
+                    args.addAll(!config.flavorAware ? [] : [
+                            "--org", sentryProps.get("defaults.org"),
+                            "--project", sentryProps.get("defaults.project")
+                    ])
+
+                    project.logger.info("Sentry-CLI arguments: ${args}")
+
+                    def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
+                    commandLine(*osCompatibility, *args)
+
+                    enabled true
+                }
+
+                // chain the upload tasks so they run sequentially in order to run
+                // the cliCleanUpTask after the final upload task is run
+                if (previousCliTask != null) {
+                    previousCliTask.finalizedBy cliTask
+                } else {
+                    bundleTask.finalizedBy cliTask
+                }
+                previousCliTask = cliTask
             }
-          } catch (NumberFormatException e) {
-            project.logger.info("versionCode: '$versionCode' isn't an Integer, using the plain value.")
-          }
 
-          // The Sentry server distinguishes source maps by release (`--release` in the command
-          // below) and distribution identifier (`--dist` below).  Give the task a unique name
-          // based on where we're uploading to.
-          def nameCliTask = "${bundleTask.name}_SentryUpload_${releaseName}_${versionCode}"
+            /** Delete sourcemap files */
+            def cliCleanUpTask = tasks.create(name: nameCleanup, type: Delete) {
+                description = "clean up extra sourcemap"
+                group = 'sentry.io'
 
-          // If several outputs have the same releaseName and versionCode, we'd do the exact same
-          // upload for each of them.  No need to repeat.
-          try { tasks.named(nameCliTask); return } catch (Exception e) {}
+                delete sourcemapOutput
+                delete "$buildDir/intermediates/assets/release/index.android.bundle.map" // react native default bundle dir
+            }
 
-          /** Upload source map file to the sentry server via CLI call. */
-          def cliTask = tasks.create(nameCliTask, Exec) {
-              description = "upload debug symbols to sentry"
-              group = 'sentry.io'
-
-              workingDir reactRoot
-
-              def propertiesFile = config.sentryProperties
-                      ? config.sentryProperties
-                      : "$reactRoot/android/sentry.properties"
-
-              if (config.flavorAware) {
-                  propertiesFile = "$reactRoot/android/sentry-${variant}.properties"
-                  project.logger.info("For $variant using: $propertiesFile")
-              } else {
-                  environment("SENTRY_PROPERTIES", propertiesFile)
-              }
-
-              Properties sentryProps = new Properties()
-              try {
-                  sentryProps.load(new FileInputStream(propertiesFile))
-              } catch (FileNotFoundException e) {
-                  project.logger.info("file not found '$propertiesFile' for '$variant'")
-              }
-
-              def resolvedCliPackage = null
-              try {
-                  resolvedCliPackage = new File(["node", "--print", "require.resolve('@sentry/cli/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
-              } catch (Throwable ignored) {}
-              def cliPackage = resolvedCliPackage != null && resolvedCliPackage.exists() ? resolvedCliPackage.getAbsolutePath() : "$reactRoot/node_modules/@sentry/cli"
-              def cliExecutable = sentryProps.get("cli.executable", "$cliPackage/bin/sentry-cli")
-
-              // fix path separator for Windows
-              if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                  cliExecutable = cliExecutable.replaceAll("/", "\\\\")
-              }
-
-              //
-              // based on:
-              //   https://github.com/getsentry/sentry-cli/blob/master/src/commands/react_native_gradle.rs
-              //
-              def args = [cliExecutable]
-
-              args.addAll(!config.logLevel ? [] : [
-                      "--log-level", config.logLevel      // control verbosity of the output
-              ])
-              args.addAll(!config.flavorAware ? [] : [
-                      "--url", sentryProps.get("defaults.url"),
-                      "--auth-token", sentryProps.get("auth.token")
-              ])
-              args.addAll(["react-native", "gradle",
-                           "--bundle", bundleOutput,           // The path to a bundle that should be uploaded.
-                           "--sourcemap", sourcemapOutput,     // The path to a sourcemap that should be uploaded.
-                           "--release", releaseName,            // The name of the release to publish.
-                           "--dist", versionCode
-              ])
-              args.addAll(!config.flavorAware ? [] : [
-                      "--org", sentryProps.get("defaults.org"),
-                      "--project", sentryProps.get("defaults.project")
-              ])
-
-              project.logger.info("Sentry-CLI arguments: ${args}")
-
-              def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
-              commandLine(*osCompatibility, *args)
-
-              enabled true
-          }
-
-          // chain the upload tasks so they run sequentially in order to run
-          // the cliCleanUpTask after the final upload task is run
-          if (previousCliTask != null) {
-            previousCliTask.finalizedBy cliTask
-          } else {
-            bundleTask.finalizedBy cliTask
-          }
-          previousCliTask = cliTask
+            // register clean task extension
+            cliCleanUpTask.onlyIf { shouldCleanUp }
+            // due to chaining the last value of previousCliTask will be the final
+            // upload task, after which the cleanup can be done
+            previousCliTask.finalizedBy cliCleanUpTask
         }
-
-        /** Delete sourcemap files */
-        def cliCleanUpTask = tasks.create(name: nameCleanup, type: Delete) {
-            description = "clean up extra sourcemap"
-            group = 'sentry.io'
-
-            delete sourcemapOutput
-            delete "$buildDir/intermediates/assets/release/index.android.bundle.map" // react native default bundle dir
-        }
-
-        // register clean task extension
-        cliCleanUpTask.onlyIf { shouldCleanUp }
-        // due to chaining the last value of previousCliTask will be the final
-        // upload task, after which the cleanup can be done
-        previousCliTask.finalizedBy cliCleanUpTask
     }
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
We are using CircleCI to prepare our builds and so far, all of them failed to build as the Sentry-CLI error out the moment it tries to upload the sourcemaps.

## :bulb: Motivation and Context
Since, we want to automatically create a new release on Sentry and have the sourcemaps uploaded, we looked into this situation and found out that the `sentry.gradle` file was feeding invalid/non-existent filenames to the Sentry-CLI.  This fix checks if the bundleOutput and sourcemapOutput files exist first and then send them to be executed/uploaded by the CLI.

## :green_heart: How did you test it?
On our own CircleCI project.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
To have this merged and released as a patch version or in the next release.
