### PR TITLE
fix(repo): Move e2e iOS Simulator to iPhone 14

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - platform: ios
             runtime: '15.2'
-            device: 'iPhone 12'
+            device: 'iPhone 14'
     env:
       PLATFORM: ${{ matrix.platform }}
       RUNTIME: ${{ matrix.runtime }}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The e2e test were failing due to missing iP 12 Simulator.

## :bulb: Motivation and Context
https://github.com/getsentry/sentry-react-native/actions/runs/3375901115/jobs/5603011338


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
