### PR TITLE
chore(changelog): Remove autogenerated duplicate entries from 4.8.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,6 @@
 
 ## 4.8.0
 
-### Various fixes & improvements
-
-- fix(attachments): Maximum call stack exceeded error for large attachments (#2579) by @old
-- fix(event): Message event contains stacktrace if `attachStacktrace` o… (#2577) by @krystofwoldrich
-- chore: update scripts/update-cocoa.sh to 7.29.0 (#2571) by @github-actions
-- chore: update scripts/update-android.sh to 6.6.0 (#2572) by @github-actions
-
 ## Fixes
 
 - Message event can have attached stacktrace ([#2577](https://github.com/getsentry/sentry-react-native/pull/2577))


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Craft added duplicate entries to our changelog.

## :bulb: Motivation and Context
https://github.com/getsentry/sentry-react-native/commit/9abdd867fc7663c4208bd89776b848d5d882d54a

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog