### PR TITLE
fix(changelog): Adjust heading for 4.8.0 Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 4.8.0
 
-## Fixes
+### Fixes
 
 - Message event can have attached stacktrace ([#2577](https://github.com/getsentry/sentry-react-native/pull/2577))
 - Fixed maximum call stack exceeded error resulting from large payloads ([#2579](https://github.com/getsentry/sentry-react-native/pull/2579))


### PR DESCRIPTION
This isn't needed, but was the reason for the wrong publish behavior and Might be good to avoid copy pasta.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Craft will parse changelog sections by looking for content between `## <Title>` sections. This caused the last publish to create a new Fixes section because it saw "## Unreleased" -> "## Fixes" as the section

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent future copy pasta mistakes, otherwise this isn't really needed.

## :green_heart: How did you test it?
Tested running craft locally with `--dry-run`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [X] I added tests to verify changes
- [X] All tests passing
- [X] No breaking changes

## :crystal_ball: Next steps
Merge? :P

#skip-changelog