### PR TITLE
ref(js): Use `Scope` class rather than `Scope` type for top-level functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add `maxQueueSize` option ([#2578](https://github.com/getsentry/sentry-react-native/pull/2578))
 
+### Fixes
+- Use `Scope` class rather than `Scope` type for top-level functions ([#2627](https://github.com/getsentry/sentry-react-native/pull/2627))
+
 ### Dependencies
 
 - Bump JavaScript SDK from v7.16.0 to v7.17.4 ([#2582](https://github.com/getsentry/sentry-react-native/pull/2582), [#2598](https://github.com/getsentry/sentry-react-native/pull/2598))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `maxQueueSize` option ([#2578](https://github.com/getsentry/sentry-react-native/pull/2578))
 
 ### Fixes
+
 - Use `Scope` class rather than `Scope` type for top-level functions ([#2627](https://github.com/getsentry/sentry-react-native/pull/2627))
 
 ### Dependencies

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -1,11 +1,11 @@
-import { getIntegrationsToSetup, Hub, initAndBind, makeMain,setExtra } from '@sentry/core';
+import { getIntegrationsToSetup, Hub, initAndBind, makeMain, Scope, setExtra } from '@sentry/core';
 import { RewriteFrames } from '@sentry/integrations';
 import {
   defaultIntegrations as reactDefaultIntegrations,
   defaultStackParser,
   getCurrentHub,
 } from '@sentry/react';
-import { Integration, Scope, StackFrame, UserFeedback } from '@sentry/types';
+import { Integration, StackFrame, UserFeedback } from '@sentry/types';
 import { logger, stackParserFromStackParserOptions } from '@sentry/utils';
 import * as React from 'react';
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This switches the functions defined in `sdk.ts` from using the `Scope` interface for typing to using the `Scope` class for typing, so that the types of `withScope` here and `withScope` from the main JS repo match.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/getsentry/sentry-javascript/issues/6217.

I steered the OP of the above issue toward a different approach, so in the end he may avoid this problem regardless, but the error he was getting points out the mismatched types.


## :green_heart: How did you test it?

I have not tested it. Total mea culpa, I didn't want to go through and set up a whole RN SDK dev environment just for this tiny change, so I did it through the GH UI. I'm hoping that one of my esteemed colleagues might be willing to test it out and see if I've messed up the types anywhere else in the SDK. 🙏🏻

I'll leave this a draft for now, until it's tested.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes

I guess _conceivably_ this could be a breaking change, but only if someone has explicitly typed their `withScope` callback, which feels pretty unlikely.

## :crystal_ball: Next steps

Figure out if any other types need to be changed elsewhere in the SDK.