### PR TITLE
Revert "chore(deps): update Android SDK to v6.9.0 (#2643)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Dependencies
-
-- Bump Android SDK from v6.8.0 to v6.9.0 ([#2643](https://github.com/getsentry/sentry-react-native/pull/2643))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#690)
-  - [diff](https://github.com/getsentry/sentry-java/compare/6.8.0...6.9.0)
-
 ## 4.10.0
 
 ### Features

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,5 +24,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:6.9.0'
+    api 'io.sentry:sentry-android:6.8.0'
 }


### PR DESCRIPTION
This reverts commit fcbe8ce98f89602d435c240eefe3ffedb6e397d3.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Going back to 6.8.0.

## :bulb: Motivation and Context
I've merged the new Android SDK to the main before the messages about the failing release.
Since I want to release some fixes from the main I need to revert this change.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 