### PR TITLE
fix(modules): Android builds without ext config, auto create assets dir for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- Android builds without ext config, auto create assets dir for modules ([#2652](https://github.com/getsentry/sentry-react-native/pull/2652))
+
 ## 4.10.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixes
+
 - Android builds without ext config, auto create assets dir for modules ([#2652](https://github.com/getsentry/sentry-react-native/pull/2652))
 
 ## 4.10.0

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -163,10 +163,10 @@ gradle.projectsEvaluated {
 
               workingDir reactRoot
 
-              def collectModulesScript = config.containsKey('collectModulesScript')
+              def collectModulesScript = config.collectModulesScript
                   ? file(config.collectModulesScript).getAbsolutePath()
                   : "$reactRoot/node_modules/@sentry/react-native/dist/js/tools/collectModules.js"
-              def modulesPaths = config.containsKey('modulesPaths')
+              def modulesPaths = config.modulesPaths
                   ? config.modulesPaths.join(',')
                   : "$reactRoot/node_modules"
               def args = ["node",
@@ -179,7 +179,7 @@ gradle.projectsEvaluated {
               project.logger.info("Sentry-CollectModules arguments: ${args}")
               commandLine(*args)
 
-              def skip = config.containsKey('skipCollectModules')
+              def skip = config.skipCollectModules
                   ? config.skipCollectModules == true
                   : false
               enabled !skip

--- a/src/js/tools/collectModules.ts
+++ b/src/js/tools/collectModules.ts
@@ -1,5 +1,6 @@
 import { logger } from '@sentry/utils';
-import { readFileSync, writeFileSync } from 'fs';
+import { mkdirSync,readFileSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
 import { argv, exit } from 'process';
 
 import ModulesCollector from './ModulesCollector';
@@ -28,6 +29,7 @@ if (!map.sources) {
 const sources: string[] = map.sources;
 const modules = ModulesCollector.collect(sources, modulesPaths);
 
+mkdirSync(dirname(outputModulesPath), { recursive: true });
 writeFileSync(outputModulesPath, JSON.stringify(modules, null, 2));
 
 function exitGracefully(message: string): never {

--- a/src/js/tools/collectModules.ts
+++ b/src/js/tools/collectModules.ts
@@ -1,5 +1,5 @@
 import { logger } from '@sentry/utils';
-import { mkdirSync,readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname } from 'path';
 import { argv, exit } from 'process';
 
@@ -29,7 +29,10 @@ if (!map.sources) {
 const sources: string[] = map.sources;
 const modules = ModulesCollector.collect(sources, modulesPaths);
 
-mkdirSync(dirname(outputModulesPath), { recursive: true });
+const outputModulesDirPath = dirname(outputModulesPath);
+if (!existsSync(outputModulesDirPath)) {
+  mkdirSync(outputModulesDirPath, { recursive: true });
+}
 writeFileSync(outputModulesPath, JSON.stringify(modules, null, 2));
 
 function exitGracefully(message: string): never {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description



## :bulb: Motivation and Context
fixes: https://github.com/getsentry/sentry-react-native/issues/2650
fixes: https://github.com/getsentry/sentry-react-native/issues/2642

```bash
No signature of method: java.util.ArrayList.containsKey() is applicable for argument types: (String) values: [collectModulesScript]
Possible solutions: contains(java.lang.Object), containsAll(java.util.Collection), contains(java.lang.Object), containsAll([Ljava.lang.Object;)
```

This happens when `project.ext.sentryCli` is not defined in `sample/android/app/build.gradle`.

## :green_heart: How did you test it?
Sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
