### PR TITLE
fix(modules): Modules create only one cleanup task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - [diff](https://github.com/getsentry/sentry-wizard/compare/v1.2.17...v1.4.0)
 - Android builds without ext config, auto create assets dir for modules ([#2652](https://github.com/getsentry/sentry-react-native/pull/2652))
 - Exit gracefully if source map file for collecting modules doesn't exist ([#2655](https://github.com/getsentry/sentry-react-native/pull/2655))
-- Don't create duplicate clean-up tasks for modules collection ([#2657](https://github.com/getsentry/sentry-react-native/pull/2657))
+- Create only one clean-up tasks for modules collection ([#2657](https://github.com/getsentry/sentry-react-native/pull/2657))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - [diff](https://github.com/getsentry/sentry-wizard/compare/v1.2.17...v1.4.0)
 - Android builds without ext config, auto create assets dir for modules ([#2652](https://github.com/getsentry/sentry-react-native/pull/2652))
 - Exit gracefully if source map file for collecting modules doesn't exist ([#2655](https://github.com/getsentry/sentry-react-native/pull/2655))
+- Don't create duplicate clean up tasks for modules collection
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - [diff](https://github.com/getsentry/sentry-wizard/compare/v1.2.17...v1.4.0)
 - Android builds without ext config, auto create assets dir for modules ([#2652](https://github.com/getsentry/sentry-react-native/pull/2652))
 - Exit gracefully if source map file for collecting modules doesn't exist ([#2655](https://github.com/getsentry/sentry-react-native/pull/2655))
-- Don't create duplicate clean up tasks for modules collection
+- Don't create duplicate clean-up tasks for modules collection ([#2657](https://github.com/getsentry/sentry-react-native/pull/2657))
 
 ### Dependencies
 

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -62,7 +62,6 @@ gradle.projectsEvaluated {
         def previousCliTask = null
 
         def nameCleanup = "${bundleTask.name}_SentryUploadCleanUp"
-        def nameModulesCleanup = "${bundleTask.name}_SentryCollectModulesCleanUp"
         // Upload the source map several times if necessary: once for each release and versionCode.
         currentVariants.each { key, currentVariant ->
           variant = currentVariant[0]
@@ -83,6 +82,7 @@ gradle.projectsEvaluated {
           // based on where we're uploading to.
           def nameCliTask = "${bundleTask.name}_SentryUpload_${releaseName}_${versionCode}"
           def nameModulesTask = "${bundleTask.name}_SentryCollectModules_${releaseName}_${versionCode}"
+          def nameModulesCleanup = "${bundleTask.name}_SentryCollectModulesCleanUp_${releaseName}_${versionCode}"
 
           // If several outputs have the same releaseName and versionCode, we'd do the exact same
           // upload for each of them.  No need to repeat.

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -203,7 +203,10 @@ gradle.projectsEvaluated {
             delete modulesOutput
         }
 
-        def packageTasks = tasks.findAll { task -> "package${variant}".equalsIgnoreCase(task.name) && task.enabled }
+        def variantTaskName = variant.replaceAll("[\\s\\-()]", "") // variant is dev-release beta-release etc.
+        def packageTasks = tasks.findAll {
+          task -> "package${variantTaskName}".equalsIgnoreCase(task.name) && task.enabled
+        }
         packageTasks.each { packageTask ->
             packageTask.dependsOn modulesTask
             packageTask.finalizedBy modulesCleanUpTask

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -204,6 +204,8 @@ gradle.projectsEvaluated {
         }
 
         def variantTaskName = variant.replaceAll("[\\s\\-()]", "") // variant is dev-release beta-release etc.
+        // task.name could be packageDev-debugRelease but in that case currentVariants == null
+        // because of the regex in `extractCurrentVariants` and this code doesn't run
         def packageTasks = tasks.findAll {
           task -> "package${variantTaskName}".equalsIgnoreCase(task.name) && task.enabled
         }

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -62,6 +62,7 @@ gradle.projectsEvaluated {
         def previousCliTask = null
 
         def nameCleanup = "${bundleTask.name}_SentryUploadCleanUp"
+        def nameModulesCleanup = "${bundleTask.name}_SentryCollectModulesCleanUp"
         // Upload the source map several times if necessary: once for each release and versionCode.
         currentVariants.each { key, currentVariant ->
           variant = currentVariant[0]
@@ -82,7 +83,6 @@ gradle.projectsEvaluated {
           // based on where we're uploading to.
           def nameCliTask = "${bundleTask.name}_SentryUpload_${releaseName}_${versionCode}"
           def nameModulesTask = "${bundleTask.name}_SentryCollectModules_${releaseName}_${versionCode}"
-          def nameModulesCleanup = "${bundleTask.name}_SentryCollectModulesCleanUp_${releaseName}_${versionCode}"
 
           // If several outputs have the same releaseName and versionCode, we'd do the exact same
           // upload for each of them.  No need to repeat.
@@ -194,19 +194,19 @@ gradle.projectsEvaluated {
           }
           previousCliTask = cliTask
           cliTask.finalizedBy modulesTask
+        }
 
-          def modulesCleanUpTask = tasks.create(name: nameModulesCleanup, type: Delete) {
-              description = "clean up collected modules generated file"
-              group = 'sentry.io'
+        def modulesCleanUpTask = tasks.create(name: nameModulesCleanup, type: Delete) {
+            description = "clean up collected modules generated file"
+            group = 'sentry.io'
 
-              delete modulesOutput
-          }
+            delete modulesOutput
+        }
 
-          def packageTasks = tasks.findAll { task -> "package${variant}".equalsIgnoreCase(task.name) && task.enabled }
-          packageTasks.each { packageTask ->
-              packageTask.dependsOn modulesTask
-              packageTask.finalizedBy modulesCleanUpTask
-          }
+        def packageTasks = tasks.findAll { task -> "package${variant}".equalsIgnoreCase(task.name) && task.enabled }
+        packageTasks.each { packageTask ->
+            packageTask.dependsOn modulesTask
+            packageTask.finalizedBy modulesCleanUpTask
         }
 
         /** Delete sourcemap files */


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The cleanup task was missing `releaseName` and `versionCode` and was created with the same name for multiple variants.
One cleanup task is enough as there is one source map file.

## :bulb: Motivation and Context
fixes: https://github.com/getsentry/sentry-react-native/issues/2656


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- [x] Test with an app with multiple variants