### PR TITLE
fix(docs): Missing SentryPrivate in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,7 @@ target 'sample' do
   # ... react native config
 
 +  pod 'Sentry/HybridSDK', :path => '../../../sentry-cocoa'
++  pod 'SentryPrivate', :path => '../../../sentry-cocoa/SentryPrivate.podspec'
 
   # ... rest of the configuration
 


### PR DESCRIPTION
Fix the local sentry-cocoa dev guide

#skip-changelog 