### PR TITLE
feat(sdk): Custom touch tracking property instead of accessibilityLabel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Breaking changes
 
 - Message event current stack trace moved from exception to threads ([#2694](https://github.com/getsentry/sentry-react-native/pull/2694))
+- `touchEventBoundaryProps.labelName` property instead of default `accessibilityLabel` fallback ([#2712](https://github.com/getsentry/sentry-react-native/pull/2712))
 
 ### Fixes
 
@@ -1074,10 +1075,10 @@ This release is a breaking change an code changes are necessary.
 New way to import and init the SDK:
 
 ```js
-import * as Sentry from "@sentry/react-native";
+import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
-  dsn: "DSN",
+  dsn: 'DSN',
 });
 ```
 
@@ -1312,7 +1313,7 @@ We decided to deactivate stack trace merging by default on iOS since it seems to
 To activate it set:
 
 ```js
-Sentry.config("___DSN___", {
+Sentry.config('___DSN___', {
   deactivateStacktraceMerging: false,
 });
 ```

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -105,6 +105,6 @@ const App = () => {
 // Wrap your app to get more features out of the box such as auto performance monitoring.
 export default Sentry.wrap(App, {
   touchEventBoundaryProps: {
-    labelName: 'custom-sentry-label',
+    labelName: 'custom-sentry-label-name',
   },
 });

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -103,4 +103,8 @@ const App = () => {
 };
 
 // Wrap your app to get more features out of the box such as auto performance monitoring.
-export default Sentry.wrap(App);
+export default Sentry.wrap(App, {
+  touchEventBoundaryProps: {
+    labelName: 'custom-sentry-label',
+  },
+});

--- a/sample/src/screens/HomeScreen.tsx
+++ b/sample/src/screens/HomeScreen.tsx
@@ -172,7 +172,7 @@ const HomeScreen = (props: Props) => {
               onPress={() => {
                 Sentry.captureException(new Error('Test Error'));
               }}
-              custom-sentry-label="captureException via custom Sentry label">
+              custom-sentry-label-name="captureException via custom Sentry label">
               <Text style={styles.buttonText}>Capture Exception</Text>
             </TouchableOpacity>
             <View style={styles.spacer} />

--- a/sample/src/screens/HomeScreen.tsx
+++ b/sample/src/screens/HomeScreen.tsx
@@ -172,7 +172,7 @@ const HomeScreen = (props: Props) => {
               onPress={() => {
                 Sentry.captureException(new Error('Test Error'));
               }}
-              accessibilityLabel="captureException">
+              custom-sentry-label="captureException via custom Sentry label">
               <Text style={styles.buttonText}>Capture Exception</Text>
             </TouchableOpacity>
             <View style={styles.spacer} />

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -31,6 +31,10 @@ export type TouchEventBoundaryProps = {
    * React Node wrapped by TouchEventBoundary.
    */
   children?: React.ReactNode;
+  /**
+   * React Node wrapped by TouchEventBoundary.
+   */
+  labelName?: string;
 };
 
 const touchEventStyles = StyleSheet.create({
@@ -96,8 +100,8 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
       message: activeLabel
         ? `Touch event within element: ${activeLabel}`
         : 'Touch event within component tree',
-      type: this.props.breadcrumbType
-    }
+      type: this.props.breadcrumbType,
+    };
     addBreadcrumb(crumb);
 
     logger.log(`[TouchEvents] ${crumb.message}`);
@@ -159,6 +163,12 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
             ? `${props[PROP_KEY]}`
             : undefined;
 
+        // For some reason type narrowing doesn't work as expected with indexing when checking it all in one go in
+        // the "check-label" if sentence, so we have to assign it to a variable here first
+        let labelValue;
+        if (typeof this.props.labelName === 'string')
+          labelValue = props?.[this.props.labelName];
+
         // Check the label first
         if (label && !this._isNameIgnored(label)) {
           if (!activeLabel) {
@@ -166,13 +176,13 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
           }
           componentTreeNames.push(label);
         } else if (
-          typeof props?.accessibilityLabel === 'string' &&
-          !this._isNameIgnored(props.accessibilityLabel)
+          typeof labelValue === 'string' &&
+          !this._isNameIgnored(labelValue)
         ) {
           if (!activeLabel) {
-            activeLabel = props.accessibilityLabel;
+            activeLabel = labelValue;
           }
-          componentTreeNames.push(props.accessibilityLabel);
+          componentTreeNames.push(labelValue);
         } else if (currentInst.elementType) {
           const { elementType } = currentInst;
 

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -32,7 +32,7 @@ export type TouchEventBoundaryProps = {
    */
   children?: React.ReactNode;
   /**
-   * React Node wrapped by TouchEventBoundary.
+   * Label Name used to identify the touched element.
    */
   labelName?: string;
 };

--- a/test/touchevents.test.tsx
+++ b/test/touchevents.test.tsx
@@ -46,9 +46,12 @@ describe('TouchEventBoundary._onTouchStart', () => {
     expect(addBreadcrumb).not.toBeCalled();
   });
 
-  it('label is preferred over accessibilityLabel and displayName', () => {
+  it('label is preferred over labelName and displayName', () => {
     const { defaultProps } = TouchEventBoundary;
-    const boundary = new TouchEventBoundary(defaultProps);
+    const boundary = new TouchEventBoundary({
+      ...defaultProps,
+      labelName: 'custom-sentry-label-name',
+    });
 
     const event = {
       _targetInst: {
@@ -66,7 +69,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
             return: {
               memoizedProps: {
                 'sentry-label': 'LABEL!',
-                accessibilityLabel: 'access!',
+                'custom-sentry-label-name': 'access!',
               },
             },
           },
@@ -92,6 +95,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
     const { defaultProps } = TouchEventBoundary;
     const boundary = new TouchEventBoundary({
       ...defaultProps,
+      labelName: 'custom-sentry-label-name',
       ignoreNames: ['View', 'Ignore', /^Connect\(/, new RegExp('^Happy\\(')],
     });
 
@@ -111,7 +115,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
             return: {
               memoizedProps: {
                 'sentry-label': 'Ignore',
-                accessibilityLabel: 'Ignore',
+                'custom-sentry-label-name': 'Ignore',
               },
               elementType: {
                 displayName: 'Styled(View2)',
@@ -151,6 +155,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
     const boundary = new TouchEventBoundary({
       ...defaultProps,
       maxComponentTreeSize: 2,
+      labelName: 'custom-sentry-label-name',
     });
 
     const event = {
@@ -164,7 +169,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
           },
           return: {
             memoizedProps: {
-              accessibilityLabel: 'Connect(View)',
+              'custom-sentry-label-name': 'Connect(View)',
             },
             return: {
               elementType: {

--- a/test/touchevents.test.tsx
+++ b/test/touchevents.test.tsx
@@ -46,7 +46,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
     expect(addBreadcrumb).not.toBeCalled();
   });
 
-  it('label is preferred over labelName and displayName', () => {
+  it('sentry-label is preferred over labelName and displayName', () => {
     const { defaultProps } = TouchEventBoundary;
     const boundary = new TouchEventBoundary({
       ...defaultProps,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
This PR removes the default usage of `accessibilityLabel` for automatic touch tracking due to GDPR issues. As a replacement, the PR adds a custom `labelName` property to the `TouchEventBoundary` that can be used to set a custom property name to be used for touch tracking. 


## :bulb: Motivation and Context
Currently, the `sentry-react-native` uses [`accessibilityLabel` for automatic touch tracking](https://docs.sentry.io/platforms/react-native/touchevents/#tracking-specific-components). This means that if no `sentry-label` is provided it falls back to using `accessibilityLabel` as part of the uploaded breadcrumbs. However, `accessibilityLabel` often contains PII data that can help accessibility users with e.g. TalkBack or VoiceOver (this be for instance home address, phone number, social security number etc.). This means that whenever a touch event is logged to sentry.io for a component that has an `accessibilityLabel` and not a `sentry-label` the PII data will end up at Sentry. This is a GDPR issue for European companies. 

I think for a lot of users/companies it is not desirable (or even legal) to have their `accessibilityLabel` data logged by default. This PR adds a custom `labelName` property to the `TouchEventBoundary` that will then be used as fallback in case no `sentry-label` is present. This can then be set to for instance `"accessibilityLabel"` for users that would like to continue using their `accessibilityLabel` in touch tracking, but it will then make sure that it is a conscious choice to log this as it will potentially hold PII data. In my own case, we would like to use our existing `testID` property for touch tracking (currently, we have an npm patch applied to Sentry that does exactly this because logging `accessibilityLabel` is definitely not an option, an even though we could get around this by adding a `sentry-label` to all components that have an `accessibilityLabel` the default fallback is simply to dangerous for us in case we miss a `sentry-label` and an `accessibilityLabel` instead slips through), as it gives us a lot of context information about what interactions the app user performed up to a crash.

I was motivated to create this PR by our support contacts from Sentry, Will C. and Hazid M.


## :green_heart: How did you test it?
I replaced the `accessibilityLabel` tests with `custom-sentry-label-name` and verified that clicking the "Capture Exception" button is logging the value stored in `custom-sentry-label-name` in the Metro bundler in "Event beforeSend:" instead of the previously logged `accessibilityLabel`.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
This is a breaking change as `accessibilityLabel` will no longer be logged by default. The migration for existing users is to simply add it to your `touchEventBoundaryProps.labelName`:

```
Sentry.wrap(App, {
  touchEventBoundaryProps: {
    labelName: 'accessibilityLabel',
  },
})
```
or when using the component variant:
```
<Sentry.TouchEventBoundary
  labelName='accessibilityLabel'
>
  <RestOfTheApp />
</Sentry.TouchEventBoundary>
```