### PR TITLE
fix(modules): Modules loaders integration handles native error and event modules are prioritised over native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Missing `originalException` in `beforeSend` for events from react native error handler ([#2706](https://github.com/getsentry/sentry-react-native/pull/2706))
+- ModulesLoader integration returns original event if native is not available and event modules overwrite native modules ([#](https://github.com/getsentry/sentry-react-native/pull/))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Missing `originalException` in `beforeSend` for events from react native error handler ([#2706](https://github.com/getsentry/sentry-react-native/pull/2706))
-- ModulesLoader integration returns original event if native is not available and event modules overwrite native modules ([#](https://github.com/getsentry/sentry-react-native/pull/))
+- ModulesLoader integration returns original event if native is not available and event modules overwrite native modules ([#2730](https://github.com/getsentry/sentry-react-native/pull/2730))
 
 ### Dependencies
 

--- a/src/js/integrations/modulesloader.ts
+++ b/src/js/integrations/modulesloader.ts
@@ -1,4 +1,5 @@
 import { Event,EventProcessor, Integration } from '@sentry/types';
+import { logger } from '@sentry/utils';
 
 import { NATIVE } from '../wrapper';
 
@@ -23,13 +24,17 @@ export class ModulesLoader implements Integration {
 
     addGlobalEventProcessor(async (event: Event) => {
       if (!isSetup) {
-        modules = await NATIVE.fetchModules();
+        try {
+          modules = await NATIVE.fetchModules();
+        } catch (e) {
+          logger.log(`Failed to get modules from native: ${e}`);
+        }
         isSetup = true;
       }
       if (modules) {
         event.modules = {
-          ...event.modules,
           ...modules,
+          ...event.modules,
         };
       }
       return event;

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -84,6 +84,9 @@ interface SentryNativeWrapper {
  */
 export const NATIVE: SentryNativeWrapper = {
   async fetchModules(): Promise<Record<string, string> | null> {
+    if (!this.enableNative) {
+      throw this._DisabledNativeError;
+    }
     if (!this._isModuleLoaded(RNSentry)) {
       throw this._NativeClientError;
     }

--- a/test/integrations/modulesloader.test.ts
+++ b/test/integrations/modulesloader.test.ts
@@ -1,0 +1,59 @@
+import { Event, EventHint } from '@sentry/types';
+
+import { ModulesLoader } from '../../src/js/integrations';
+import { NATIVE } from '../../src/js/wrapper';
+
+jest.mock('../../src/js/wrapper');
+
+describe('Modules Loader', () => {
+  let integration: ModulesLoader;
+
+  beforeEach(() => {
+    integration = new ModulesLoader();
+  });
+
+  it('integration event processor does not throw on native error', async () => {
+    (NATIVE.fetchModules as jest.Mock).mockImplementation(() => { throw new Error('Test Error') });
+    const mockEvent: Event = {
+      modules: {
+        eventModule: 'eventModuleVersion',
+      },
+    };
+    const processedEvent = await executeIntegrationFor(mockEvent);
+
+    expect(processedEvent).toEqual(mockEvent);
+  });
+
+  it('merges event modules with native modules', async () => {
+    (NATIVE.fetchModules as jest.Mock).mockImplementation(() => ({
+      nativeModules: 'nativeModuleVersion',
+      duplicateModule: 'duplicateNativeModuleVersion',
+    }));
+    const mockEvent: Event = {
+      modules: {
+        eventModule: 'eventModuleVersion',
+        duplicateModule: 'duplicateEventModuleVersion',
+      }
+    };
+    const processedEvent = await executeIntegrationFor(mockEvent);
+
+    expect(processedEvent?.modules).toEqual({
+      eventModule: 'eventModuleVersion',
+      nativeModules: 'nativeModuleVersion',
+      duplicateModule: 'duplicateEventModuleVersion',
+    });
+  });
+
+  function executeIntegrationFor(mockedEvent: Event, mockedHint: EventHint = {}): Promise<Event | null> {
+    return new Promise((resolve, reject) => {
+      integration.setupOnce(async (eventProcessor) => {
+        try {
+          const processedEvent = await eventProcessor(mockedEvent, mockedHint);
+          resolve(processedEvent);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
The modules loader would throw an error if the native layer was unavailable.
Also, the native event modules were overwriting the event modules.

## :bulb: Motivation and Context
closes: https://github.com/getsentry/sentry-react-native/issues/2718

## :green_heart: How did you test it?
unit tests and sentry-testkit

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [ ] No breaking changes

Ttechnically the event modules prioritization is breaking change but it never should be like that so I consider that a fix

## :crystal_ball: Next steps
