### PR TITLE
fix(sample): Explicitly name sample source dirs to avoid conflicts 

### DIFF
--- a/sample/metro.config.js
+++ b/sample/metro.config.js
@@ -11,7 +11,11 @@ const parentDir = path.resolve(__dirname, '..');
 
 module.exports = {
   projectRoot: __dirname,
-  watchFolders: [path.resolve(__dirname, 'node_modules'), parentDir],
+  watchFolders: [
+    path.resolve(__dirname, 'node_modules'),
+    `${parentDir}/dist`,
+    `${parentDir}/node_modules`,
+  ],
   resolver: {
     blacklistRE: blacklist([
       new RegExp(`${parentDir}/node_modules/react-native/.*`),


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
When a developer has multiple RN project downloaded in the test dir the file conflict with the sample build as watchFolders paths are used as sourcePaths by Metro transformers

## :bulb: Motivation and Context
When developing locally without this fix you need to delete the downloaded RN project in the test folder which can be quite annoying.

## :green_heart: How did you test it?
ci, sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 