### PR TITLE
chore(sample): Remove EventHint log from sample app before send

### DIFF
--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -27,8 +27,8 @@ Sentry.init({
   // Replace the example DSN below with your own DSN:
   dsn: SENTRY_INTERNAL_DSN,
   debug: true,
-  beforeSend: (e, hint) => {
-    console.log('Event beforeSend:', e, 'hint:', hint);
+  beforeSend: (e: Sentry.Event) => {
+    console.log('Event beforeSend:', e);
     return e;
   },
   // This will be called with a boolean `didCallNativeInit` when the native SDK has been contacted.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
As logs are collected in breadcrumbs, logging the event hint with attachments causes too big an envelope size, and events are not sent, which is a terrible out-of-the-box experience.

## :bulb: Motivation and Context
```
01-12 10:09:37.075 18611 18713 D Sentry  : Request failed, API returned 413
01-12 10:09:37.076 18611 18713 D Sentry  : {"detail":"failed to read request body","causes":["A payload reached size limit."]}
01-12 10:09:37.076 18611 18713 D Sentry  : The transport failed to send the envelope with response code 413
01-12 10:09:37.076 18611 18713 E Sentry  : Envelope submission failed
```

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 