### PR TITLE
fix(e2e): Remove runtime from e2e tests as it requires number 

### DIFF
--- a/sample/test/e2e.test.ts
+++ b/sample/test/e2e.test.ts
@@ -58,10 +58,6 @@ beforeAll(async () => {
     };
   }
 
-  if (process.env.RUNTIME !== undefined) {
-    conf.capabilities['appium:platformVersion'] = process.env.RUNTIME;
-  }
-
   if (process.env.DEVICE !== undefined) {
     conf.capabilities['appium:deviceName'] = process.env.DEVICE;
   }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
After switching to the lastest tag to fix builds the ios e2e tests are not working. 

## :bulb: Motivation and Context
```
    2023-01-23T20:00:56.033Z WARN webdriver: Request failed with status 500 due to An unknown server-side error occurred while processing the command. Original error: 'platformVersion' must be a valid version number. 'latest' is given instead.
```

https://github.com/getsentry/sentry-react-native/actions/runs/3989908849/jobs/6842902079
## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 