### PR TITLE
Add support for NODE_BINARY for xcode script to collect modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Collect modules script for XCode builds supports NODE_BINARY to set path to node executable
+- Collect modules script for XCode builds supports NODE_BINARY to set path to node executable ([#2805](https://github.com/getsentry/sentry-react-native/pull/2805))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Collect modules script for XCode builds supports NODE_BINARY to set path to node executable
+
 ### Dependencies
 
 - Bump Android SDK from v6.12.1 to v6.13.0 ([#2790](https://github.com/getsentry/sentry-react-native/pull/2790))

--- a/scripts/collect-modules.sh
+++ b/scripts/collect-modules.sh
@@ -24,6 +24,10 @@ if [[ -z "$DERIVED_FILE_DIR" ]]; then
 fi
 
 nodePath="node"
+if [[ -n "$NODE_BINARY" ]]; then
+  nodePath="$NODE_BINARY"
+fi
+
 thisFilePath=$(dirname $0)
 collectModulesScript="$thisFilePath/../dist/js/tools/collectModules.js"
 
@@ -39,5 +43,12 @@ if [[ -z "$MODULES_PATHS" ]]; then
 else
   modulesPaths="$MODULES_PATHS"
 fi
+
+type $nodePath >/dev/null 2>&1 || {
+  echo >&2 "error: $nodePath not found! Modules won't be collected." \
+    "Please export NODE_BINARY in 'Build Phase' - 'Bundle React Native code and images'" \
+    "to an absolute path of your node binary. Check your node path by 'which node'."
+  exit 0 # Don't fail the build but inform about the problem
+}
 
 $nodePath "$collectModulesScript" "$sourceMap" "$modulesOutput" "$modulesPaths"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Depending on the setup node can't be always located automatically in the XCode builds.

Therefore it's handy to support a simple way to set your own node path. As React Native scripts do. 

- https://github.com/facebook/react-native/blob/0.67-stable/scripts/node-binary.sh#L7

![Screenshot 2023-02-03 at 17 30 07](https://user-images.githubusercontent.com/31292499/216656024-8d79b40c-9fd4-41ec-a3d3-f1a04d7bf3bd.png)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/getsentry/sentry-react-native/issues/2804

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
