### PR TITLE
chore(sdk): Better DEX when native disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix use Fetch transport when option `enableNative` is `false`
+- Improve logs when `enableNative` is `false`
+
 ### Dependencies
 
 - Bump JavaScript SDK from v7.40.0 to v7.43.0 ([#2874](https://github.com/getsentry/sentry-react-native/pull/2874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-- Fix use Fetch transport when option `enableNative` is `false`
-- Improve logs when `enableNative` is `false`
+- Fix use Fetch transport when option `enableNative` is `false` ([#2897](https://github.com/getsentry/sentry-react-native/pull/2897))
+- Improve logs when `enableNative` is `false` ([#2897](https://github.com/getsentry/sentry-react-native/pull/2897))
 
 ### Dependencies
 

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -67,7 +67,13 @@ export function init(passedOptions: ReactNativeOptions): void {
     ...DEFAULT_OPTIONS,
     ...passedOptions,
     // If custom transport factory fails the SDK won't initialize
-    transport: passedOptions.transport || makeNativeTransportFactory() || makeFetchTransport,
+    transport: passedOptions.transport
+      || makeNativeTransportFactory({
+        enableNative: passedOptions.enableNative !== undefined
+          ? passedOptions.enableNative
+          : DEFAULT_OPTIONS.enableNative
+      })
+      || makeFetchTransport,
     transportOptions: {
       ...DEFAULT_OPTIONS.transportOptions,
       ...(passedOptions.transportOptions ?? {}),

--- a/src/js/tracing/nativeframes.ts
+++ b/src/js/tracing/nativeframes.ts
@@ -55,6 +55,8 @@ export class NativeFramesInstrumentation {
       if (framesMetrics) {
         transaction.setData('__startFrames', framesMetrics);
       }
+    }).then(undefined, (error) => {
+      logger.error(`[ReactNativeTracing] Error while fetching native frames: ${error}`);
     });
 
     instrumentChildSpanFinish(transaction, (_: Span, endTimestamp?: number) => {
@@ -85,6 +87,8 @@ export class NativeFramesInstrumentation {
           nativeFrames,
         };
       }
+    }).then(undefined, (error) => {
+      logger.error(`[ReactNativeTracing] Error while fetching native frames: ${error}`);
     });
   }
 

--- a/src/js/transports/native.ts
+++ b/src/js/transports/native.ts
@@ -53,8 +53,10 @@ export function makeNativeTransport(options: BaseNativeTransportOptions = {}): N
 /**
  * Creates a Native Transport factory if the native transport is available.
  */
-export function makeNativeTransportFactory(): typeof makeNativeTransport | null {
-  if (NATIVE.isNativeTransportAvailable()) {
+export function makeNativeTransportFactory(
+  { enableNative }: { enableNative?: boolean },
+): typeof makeNativeTransport | null {
+  if (enableNative && NATIVE.isNativeAvailable()) {
     return makeNativeTransport;
   }
   return null;

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -53,7 +53,7 @@ interface SentryNativeWrapper {
   ): module is Spec;
   _getBreadcrumbs(event: Event): Breadcrumb[] | undefined;
 
-  isNativeTransportAvailable(): boolean;
+  isNativeAvailable(): boolean;
 
   initNativeSdk(options: ReactNativeOptions): PromiseLike<boolean>;
   closeNativeSdk(): PromiseLike<void>;
@@ -267,10 +267,12 @@ export const NATIVE: SentryNativeWrapper = {
 
   async fetchNativeAppStart(): Promise<NativeAppStartResponse | null> {
     if (!this.enableNative) {
-      throw this._DisabledNativeError;
+      logger.warn(this._DisabledNativeError);
+      return null;
     }
     if (!this._isModuleLoaded(RNSentry)) {
-      throw this._NativeClientError;
+      logger.error(this._NativeClientError);
+      return null;
     }
 
     return RNSentry.fetchNativeAppStart();
@@ -468,16 +470,18 @@ export const NATIVE: SentryNativeWrapper = {
     RNSentry.enableNativeFramesTracking();
   },
 
-  isNativeTransportAvailable(): boolean {
+  isNativeAvailable(): boolean {
     return this.enableNative && this._isModuleLoaded(RNSentry);
   },
 
   async captureScreenshot(): Promise<Screenshot[] | null> {
     if (!this.enableNative) {
-      throw this._DisabledNativeError;
+      logger.warn(this._DisabledNativeError);
+      return null;
     }
     if (!this._isModuleLoaded(RNSentry)) {
-      throw this._NativeClientError;
+      logger.error(this._NativeClientError);
+      return null;
     }
 
     try {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -228,15 +228,29 @@ describe('Tests the SDK functionality', () => {
     });
 
     it('uses native transport', () => {
-      (NATIVE.isNativeTransportAvailable as jest.Mock).mockImplementation(() => true);
+      (NATIVE.isNativeAvailable as jest.Mock).mockImplementation(() => true);
       init({});
       expect(usedOptions()?.transport).toEqual(makeNativeTransport);
     });
 
     it('uses fallback fetch transport', () => {
-      (NATIVE.isNativeTransportAvailable as jest.Mock).mockImplementation(() => false);
+      (NATIVE.isNativeAvailable as jest.Mock).mockImplementation(() => false);
       init({});
       expect(usedOptions()?.transport).toEqual(makeFetchTransport);
+    });
+
+    it('checks sdk options first', () => {
+      (NATIVE.isNativeAvailable as jest.Mock).mockImplementation(() => true);
+      init({ enableNative: false });
+      expect(usedOptions()?.transport).toEqual(makeFetchTransport);
+      expect(NATIVE.isNativeAvailable).not.toBeCalled();
+    });
+
+    it('check both options and native availability', () => {
+      (NATIVE.isNativeAvailable as jest.Mock).mockImplementation(() => true);
+      init({ enableNative: true });
+      expect(usedOptions()?.transport).toEqual(makeNativeTransport);
+      expect(NATIVE.isNativeAvailable).toBeCalled();
     });
   });
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -243,6 +243,7 @@ describe('Tests the SDK functionality', () => {
       (NATIVE.isNativeAvailable as jest.Mock).mockImplementation(() => true);
       init({ enableNative: false });
       expect(usedOptions()?.transport).toEqual(makeFetchTransport);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(NATIVE.isNativeAvailable).not.toBeCalled();
     });
 
@@ -250,6 +251,7 @@ describe('Tests the SDK functionality', () => {
       (NATIVE.isNativeAvailable as jest.Mock).mockImplementation(() => true);
       init({ enableNative: true });
       expect(usedOptions()?.transport).toEqual(makeNativeTransport);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(NATIVE.isNativeAvailable).toBeCalled();
     });
   });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Do not ignore passed options when creating transport.
Minimalize log spam when people disable native.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I was trying out `enableNative: false` when trying options to solve this issue in Android SDK.

- https://github.com/getsentry/sentry-java/issues/2576

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
