### PR TITLE
fix(ios): Disable HTTP Client Errors on all platforms by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- Enable iOS HTTP Client Reports only if enabled in RN ([#](https://github.com/getsentry/sentry-react-native/pull/))
+- Enable iOS HTTP Client Errors only if enabled in RN ([#](https://github.com/getsentry/sentry-react-native/pull/))
+  - Add [HttpClient](https://docs.sentry.io/platforms/javascript/configuration/integrations/plugin/#httpclient) to enable HTTP Client Errors on iOS.
 
 ## 5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Enable iOS HTTP Client Reports only if enabled in RN ([#](https://github.com/getsentry/sentry-react-native/pull/))
+
 ## 5.2.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Enable iOS HTTP Client Errors only if enabled in RN ([#](https://github.com/getsentry/sentry-react-native/pull/))
+- Enable iOS HTTP Client Errors only if enabled in RN ([#2931](https://github.com/getsentry/sentry-react-native/pull/2931))
   - Add [HttpClient](https://docs.sentry.io/platforms/javascript/configuration/integrations/plugin/#httpclient) to enable HTTP Client Errors on iOS.
 
 ## 5.2.0

--- a/sample-new-architecture/src/App.tsx
+++ b/sample-new-architecture/src/App.tsx
@@ -56,6 +56,7 @@ Sentry.init({
         },
       }),
       new HttpClient({
+        // These options are effective only in JS.
         // This array can contain tuples of `[begin, end]` (both inclusive),
         // Single status codes, or a combinations of both.
         // default: [[500, 599]]
@@ -77,6 +78,8 @@ Sentry.init({
   attachScreenshot: true,
   // Attach view hierarchy to events.
   attachViewHierarchy: true,
+  // Enables capture failed requests in JS and native.
+  enableCaptureFailedRequests: true,
   // Sets the `release` and `dist` on Sentry events. Make sure this matches EXACTLY with the values on your sourcemaps
   // otherwise they will not work.
   // release: 'myapp@1.2.3+1',

--- a/sample-new-architecture/src/App.tsx
+++ b/sample-new-architecture/src/App.tsx
@@ -19,6 +19,7 @@ import { store } from './reduxApp';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import GesturesTracingScreen from './Screens/GesturesTracingScreen';
 import { StyleSheet } from 'react-native';
+import { HttpClient } from '@sentry/integrations';
 
 const reactNavigationInstrumentation =
   new Sentry.ReactNavigationInstrumentation({
@@ -53,6 +54,15 @@ Sentry.init({
 
           return context;
         },
+      }),
+      new HttpClient({
+        // This array can contain tuples of `[begin, end]` (both inclusive),
+        // Single status codes, or a combinations of both.
+        // default: [[500, 599]]
+        failedRequestStatusCodes: [[400, 599]],
+        // This array can contain Regexes or strings, or combinations of both.
+        // default: [/.*/]
+        failedRequestTargets: [/.*/],
       }),
     );
     return integrations.filter(i => i.name !== 'Dedupe');

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -141,6 +141,15 @@ export interface BaseReactNativeOptions {
    * @default false
    */
   attachViewHierarchy?: boolean;
+
+  /**
+   * When enabled, Sentry will capture failed XHR/Fetch requests. This option also enabled HTTP Errors on iOS.
+   * [Sentry Android Gradle Plugin](https://docs.sentry.io/platforms/android/configuration/integrations/okhttp/)
+   * is needed to capture HTTP Errors on Android.
+   *
+   * @default false
+   */
+  enableCaptureFailedRequests?: boolean;
 }
 
 export interface ReactNativeTransportOptions extends BrowserTransportOptions {

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -1,5 +1,6 @@
 import type { Scope } from '@sentry/core';
 import { getIntegrationsToSetup, Hub, initAndBind, makeMain, setExtra } from '@sentry/core';
+import { HttpClient } from '@sentry/integrations';
 import {
   defaultIntegrations as reactDefaultIntegrations,
   defaultStackParser,
@@ -50,6 +51,7 @@ const DEFAULT_OPTIONS: ReactNativeOptions = {
   sendClientReports: true,
   maxQueueSize: DEFAULT_BUFFER_SIZE,
   attachStacktrace: true,
+  enableCaptureFailedRequests: false,
 };
 
 /**
@@ -127,6 +129,9 @@ export function init(passedOptions: ReactNativeOptions): void {
     }
     if (options.attachViewHierarchy) {
       defaultIntegrations.push(new ViewHierarchy());
+    }
+    if (options.enableCaptureFailedRequests) {
+      defaultIntegrations.push(new HttpClient());
     }
   }
 

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-import { HttpClient } from '@sentry/integrations';
 import type {
   BaseEnvelopeItemHeaders,
   Breadcrumb,
@@ -85,13 +84,6 @@ interface SentryNativeWrapper {
 }
 
 /**
- * Internal interface for options passed to native SDKs
- */
-interface NativeClientOptions extends ReactNativeClientOptions {
-  enableCaptureFailedRequests: boolean;
-}
-
-/**
  * Our internal interface for calling native functions
  */
 export const NATIVE: SentryNativeWrapper = {
@@ -172,15 +164,11 @@ export const NATIVE: SentryNativeWrapper = {
    * @param options ReactNativeClientOptions
    */
   async initNativeSdk(originalOptions: Partial<ReactNativeClientOptions>): Promise<boolean> {
-    const options: Partial<NativeClientOptions> = {
+    const options: Partial<ReactNativeClientOptions> = {
       enableNative: true,
       autoInitializeNativeSdk: true,
       ...originalOptions,
     };
-
-    const httpClientIntegration = originalOptions.integrations
-      ?.find(i => i.name === HttpClient.id) as HttpClient | undefined;
-    options.enableCaptureFailedRequests = httpClientIntegration ? true : false;
 
     if (!options.enableNative) {
       if (options.enableNativeNagger) {

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -358,6 +358,28 @@ describe('Tests the SDK functionality', () => {
       expect(actualIntegrations).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'HttpClient' })]));
     });
 
+    it('user defined http client integration overwrites default', () => {
+      init({
+        enableCaptureFailedRequests: true,
+        integrations: [
+          <Integration>{
+            name: 'HttpClient',
+            setupOnce: () => { },
+            isUserDefined: true,
+          },
+        ],
+      });
+
+      const actualOptions = mockedInitAndBind.mock.calls[0][secondArg] as ReactNativeClientOptions;
+      const actualIntegrations = actualOptions.integrations;
+
+      expect(actualIntegrations).toEqual(expect.arrayContaining([expect.objectContaining({
+        name: 'HttpClient',
+        isUserDefined: true,
+      })]));
+      expect(actualIntegrations.filter(integration => integration.name === 'HttpClient')).toHaveLength(1);
+    });
+
     it('no screenshot integration by default', () => {
       init({});
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -338,6 +338,26 @@ describe('Tests the SDK functionality', () => {
       expect(actualIntegrations).toEqual([mockDefaultIntegration]);
     });
 
+    it('no http client integration by default', () => {
+      init({});
+
+      const actualOptions = mockedInitAndBind.mock.calls[0][secondArg] as ReactNativeClientOptions;
+      const actualIntegrations = actualOptions.integrations;
+
+      expect(actualIntegrations).toEqual(expect.not.arrayContaining([expect.objectContaining({ name: 'HttpClient' })]));
+    });
+
+    it('adds http client integration', () => {
+      init({
+        enableCaptureFailedRequests: true,
+      });
+
+      const actualOptions = mockedInitAndBind.mock.calls[0][secondArg] as ReactNativeClientOptions;
+      const actualIntegrations = actualOptions.integrations;
+
+      expect(actualIntegrations).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'HttpClient' })]));
+    });
+
     it('no screenshot integration by default', () => {
       init({});
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import { HttpClient } from '@sentry/integrations';
 import type { Event, EventEnvelope, EventItem, SeverityLevel } from '@sentry/types';
 import { createEnvelope, logger } from '@sentry/utils';
 import * as RN from 'react-native';
@@ -194,6 +195,30 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.setTag).not.toBeCalled();
       expect(RNSentry.setContext).not.toBeCalled();
       expect(RNSentry.setExtra).not.toBeCalled();
+    });
+
+    test('enables http client errors on ios', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        integrations: [new HttpClient()],
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalledWith(expect.objectContaining({
+        enableCaptureFailedRequests: true,
+      }));
+    });
+
+    test('disables http client errors on ios', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        integrations: [],
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalledWith(expect.objectContaining({
+        enableCaptureFailedRequests: false,
+      }));
     });
   });
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { HttpClient } from '@sentry/integrations';
 import type { Event, EventEnvelope, EventItem, SeverityLevel } from '@sentry/types';
 import { createEnvelope, logger } from '@sentry/utils';
 import * as RN from 'react-native';
@@ -195,30 +194,6 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.setTag).not.toBeCalled();
       expect(RNSentry.setContext).not.toBeCalled();
       expect(RNSentry.setExtra).not.toBeCalled();
-    });
-
-    test('enables http client errors on ios', async () => {
-      await NATIVE.initNativeSdk({
-        dsn: 'test',
-        enableNative: true,
-        integrations: [new HttpClient()],
-      });
-
-      expect(RNSentry.initNativeSdk).toBeCalledWith(expect.objectContaining({
-        enableCaptureFailedRequests: true,
-      }));
-    });
-
-    test('disables http client errors on ios', async () => {
-      await NATIVE.initNativeSdk({
-        dsn: 'test',
-        enableNative: true,
-        integrations: [],
-      });
-
-      expect(RNSentry.initNativeSdk).toBeCalledWith(expect.objectContaining({
-        enableCaptureFailedRequests: false,
-      }));
     });
   });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
In JS this feature is enabled by integration, the presence of the integration is transformed to a bool flag for the ios SDK.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- closes: https://github.com/getsentry/sentry-react-native/issues/2882

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
