### PR TITLE
feat(tracing): Tabs auto instrumentation for React Native Navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add Tabs auto instrumentation for React Native Navigation
+- Add Tabs auto instrumentation for React Native Navigation ([#2932](https://github.com/getsentry/sentry-react-native/pull/2932))
 
 ## 5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add Tabs auto instrumentation for React Native Navigation
+
 ## 5.2.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Features
 
-- Add Tabs auto instrumentation for React Native Navigation ([#2932](https://github.com/getsentry/sentry-react-native/pull/2932))
 - Add `enableTracing` option ([#2933](https://github.com/getsentry/sentry-react-native/pull/2933))
+- Add Tabs auto instrumentation for React Native Navigation ([#2932](https://github.com/getsentry/sentry-react-native/pull/2932))
+  - This is enabled by default, if you want to disable tabs instrumentation see the example below.
+
+```js
+const routingInstrumentation = new Sentry.ReactNativeNavigationInstrumentation(Navigation, { enableTabsInstrumentation: false })
+```
 
 ### Fixes
 

--- a/src/js/tracing/reactnativenavigation.ts
+++ b/src/js/tracing/reactnativenavigation.ts
@@ -24,14 +24,14 @@ interface ReactNativeNavigationOptions {
    * Instrumentation will create a transaction on tab change.
    * By default only navigation commands create transactions.
    *
-   * Default: false
+   * Default: true
    */
   enableTabsInstrumentation: boolean;
 }
 
 const defaultOptions: ReactNativeNavigationOptions = {
   routeChangeTimeoutMs: 1000,
-  enableTabsInstrumentation: false,
+  enableTabsInstrumentation: true,
 };
 
 interface ComponentEvent {

--- a/src/js/tracing/reactnativenavigation.ts
+++ b/src/js/tracing/reactnativenavigation.ts
@@ -164,10 +164,7 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
    * To be called AFTER the state has been changed to populate the transaction with the current route.
    */
   private _onComponentWillAppear(event: ComponentWillAppearEvent): void {
-    const { _latestTransaction: latestTransaction } = this;
-
-    const noNavigationComponentWillAppear = !latestTransaction;
-    if (noNavigationComponentWillAppear) {
+    if (!this._latestTransaction) {
       return;
     }
 
@@ -181,7 +178,7 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
 
     this._clearStateChangeTimeout();
 
-    const originalContext = latestTransaction.toContext();
+    const originalContext = this._latestTransaction.toContext();
     const routeHasBeenSeen = this._recentComponentIds.includes(
       event.componentId
     );
@@ -212,10 +209,10 @@ export class ReactNativeNavigationInstrumentation extends InternalRoutingInstrum
     };
 
     const finalContext = this._prepareFinalContext(updatedContext);
-    latestTransaction.updateWithContext(finalContext);
+    this._latestTransaction.updateWithContext(finalContext);
 
     const isCustomName = updatedContext.name !== finalContext.name;
-    latestTransaction.setName(
+    this._latestTransaction.setName(
       finalContext.name,
       isCustomName ? customTransactionSource : defaultTransactionSource,
     );

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -21,5 +21,6 @@
     "module": "es6",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
+    "strictBindCallApply": true,
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
RNN instrumentation can be initialized with an option to instrument tab switches.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- closes: https://github.com/getsentry/sentry-react-native/issues/2285

## :green_heart: How did you test it?
- wix navigation sample https://github.com/krystofwoldrich/sentry-react-native-navigation-example
- unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- [ ] Add docs