### PR TITLE
chore(deps): update JavaScript SDK to v7.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Dependencies
+
+- Bump JavaScript SDK from v7.47.0 to v7.48.0 ([#](https://github.com/getsentry/sentry-react-native/pull/)
+  - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7480)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.47.0...7.48.0)
+
 ## 5.3.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Dependencies
 
-- Bump JavaScript SDK from v7.47.0 to v7.48.0 ([#](https://github.com/getsentry/sentry-react-native/pull/)
+- Bump JavaScript SDK from v7.47.0 to v7.48.0 ([#2975](https://github.com/getsentry/sentry-react-native/pull/2975)
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7480)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.47.0...7.48.0)
 

--- a/package.json
+++ b/package.json
@@ -47,19 +47,18 @@
     "react-native": ">=0.65.0"
   },
   "dependencies": {
-    "@sentry-internal/tracing": "7.47.0",
-    "@sentry/browser": "7.47.0",
+    "@sentry/browser": "7.48.0",
     "@sentry/cli": "2.17.1",
-    "@sentry/core": "7.47.0",
-    "@sentry/hub": "7.47.0",
-    "@sentry/integrations": "7.47.0",
-    "@sentry/react": "7.47.0",
-    "@sentry/types": "7.47.0",
-    "@sentry/utils": "7.47.0"
+    "@sentry/core": "7.48.0",
+    "@sentry/hub": "7.48.0",
+    "@sentry/integrations": "7.48.0",
+    "@sentry/react": "7.48.0",
+    "@sentry/types": "7.48.0",
+    "@sentry/utils": "7.48.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.47.0",
-    "@sentry-internal/eslint-plugin-sdk": "7.47.0",
+    "@sentry-internal/eslint-config-sdk": "7.48.0",
+    "@sentry-internal/eslint-plugin-sdk": "7.48.0",
     "@sentry/typescript": "^5.20.1",
     "@sentry/wizard": "2.6.1",
     "@types/jest": "^29.2.5",

--- a/scripts/update-javascript.sh
+++ b/scripts/update-javascript.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 tagPrefix=''
 repo="https://github.com/getsentry/sentry-javascript.git"
 packages=('@sentry/browser' '@sentry/core' '@sentry/hub' '@sentry/integrations' '@sentry/react' '@sentry/types' '@sentry/utils')
-packages+=('@sentry-internal/tracing', '@sentry-internal/eslint-config-sdk' '@sentry-internal/eslint-plugin-sdk')
+packages+=('@sentry-internal/eslint-config-sdk' '@sentry-internal/eslint-plugin-sdk')
 
 . $(dirname "$0")/update-package-json.sh

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines */
-import type { RequestInstrumentationOptions } from '@sentry-internal/tracing';
-import { instrumentOutgoingRequests } from '@sentry-internal/tracing';
-import { defaultRequestInstrumentationOptions } from '@sentry/browser';
+import type { RequestInstrumentationOptions } from '@sentry/browser';
+import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from '@sentry/browser';
 import type { Hub, IdleTransaction, Transaction } from '@sentry/core';
 import { getActiveTransaction, getCurrentHub, startIdleTransaction } from '@sentry/core';
 import type { EventProcessor, Integration, Transaction as TransactionType, TransactionContext } from '@sentry/types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1693,13 +1693,13 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
-"@sentry-internal/eslint-config-sdk@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.47.0.tgz#dd9553edb099f83f8a8004ccfca7c308f78b8fbf"
-  integrity sha512-ANBwUy6l1xLisq2LGvJz1VlQ24mCf14EEjlwfcNC096NhBCuJBT3Fu2KUD+cDhZdpJ2X+IRNESqDrbJMl/tycg==
+"@sentry-internal/eslint-config-sdk@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.48.0.tgz#9e0725da7da6f92e20630997fccb1903d96a35df"
+  integrity sha512-M3LOE51Wst5raQnS+hWi3q1Wi2omRRhtfn3AmyyYqLy65RY5EdiuU/Rjrea4H5AepTT2UAzX4EPhASjaBLehOA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.47.0"
-    "@sentry-internal/typescript" "7.47.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.48.0"
+    "@sentry-internal/typescript" "7.48.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -1708,38 +1708,38 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.47.0.tgz#08522599b83660c6d320b0c2f3e5491873dbbbd6"
-  integrity sha512-Pa7jGUg+J6IjUJGFUo1UHWXc7lx2GEyKWlemSvt2LeWndlVCsrQjjlIS3KyOhOIXOoNQqY74+19jXrs85WQ0Ow==
+"@sentry-internal/eslint-plugin-sdk@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.48.0.tgz#4810513571d820e4b16d85c1f81f0bbca5d4389a"
+  integrity sha512-yHyArKCgg8rgLjeUMxo4EQ8YSO4pKZBl0QP2oI375+fN1sqW1Wk7VGD6oe2QvFN+xp5eqQCfZLpbB/SlnnACqg==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/tracing@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.47.0.tgz#45e92eb4c8d049d93bd4fab961eaa38a4fb680f3"
-  integrity sha512-udpHnCzF8DQsWf0gQwd0XFGp6Y8MOiwnl8vGt2ohqZGS3m1+IxoRLXsSkD8qmvN6KKDnwbaAvYnK0z0L+AW95g==
+"@sentry-internal/tracing@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.48.0.tgz#d0c1eac1c046fda5c79d16dc1c918fee3bae3e9d"
+  integrity sha512-MFAPDTrvCtfSm0/Zbmx7HA0Q5uCfRadOUpN8Y8rP1ndz+329h2kA3mZRCuC+3/aXL11zs2CHUhcAkGjwH2vogg==
   dependencies:
-    "@sentry/core" "7.47.0"
-    "@sentry/types" "7.47.0"
-    "@sentry/utils" "7.47.0"
+    "@sentry/core" "7.48.0"
+    "@sentry/types" "7.48.0"
+    "@sentry/utils" "7.48.0"
     tslib "^1.9.3"
 
-"@sentry-internal/typescript@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.47.0.tgz#0802f89f32a754f436dece09c948f3bf200014a6"
-  integrity sha512-Q0YkLuoFZrnspYfInr+bSWHYzO/g3qRZpXh9GdtRG2AZrlVY2XIDsBa9oS5AhlgWWuuwxS1vBTYxNfGFbQ2b5g==
+"@sentry-internal/typescript@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.48.0.tgz#27ba755a1414b3518f820086e447eba8ecdeb794"
+  integrity sha512-kD+ZsvuZw0r7LnwS4naWQj0pbUcBhy2WUSu1gpWtW6YsVCbOTEmGEyv/WinzmVQeO14QsG9bROQABAmRxsV7NQ==
 
-"@sentry/browser@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.47.0.tgz#c0d10f348d1fb9336c3ef8fa2f6638f26d4c17a8"
-  integrity sha512-L0t07kS/G1UGVZ9fpD6HLuaX8vVBqAGWgu+1uweXthYozu/N7ZAsakjU/Ozu6FSXj1mO3NOJZhOn/goIZLSj5A==
+"@sentry/browser@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.48.0.tgz#03f39bec6949ff48e343c5862c5d54dfd4a2f9ff"
+  integrity sha512-tdx/2nhuiykncmXFlV4Dpp+Hxgt/v31LiyXE79IcM560wc+QmWKtzoW9azBWQ0xt5KOO3ERMib9qPE4/ql1/EQ==
   dependencies:
-    "@sentry-internal/tracing" "7.47.0"
-    "@sentry/core" "7.47.0"
-    "@sentry/replay" "7.47.0"
-    "@sentry/types" "7.47.0"
-    "@sentry/utils" "7.47.0"
+    "@sentry-internal/tracing" "7.48.0"
+    "@sentry/core" "7.48.0"
+    "@sentry/replay" "7.48.0"
+    "@sentry/types" "7.48.0"
+    "@sentry/utils" "7.48.0"
     tslib "^1.9.3"
 
 "@sentry/cli@2.17.1":
@@ -1766,59 +1766,59 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/core@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.47.0.tgz#6a723d96f64009a9c1b9bc44e259956b7eca0a3f"
-  integrity sha512-EFhZhKdMu7wKmWYZwbgTi8FNZ7Fq+HdlXiZWNz51Bqe3pHmfAkdHtAEs0Buo0v623MKA0CA4EjXIazGUM34XTg==
+"@sentry/core@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.48.0.tgz#1a5ec347ab7212d73a99583c2e64989e34e3263a"
+  integrity sha512-8FYuJTMpyuxRZvlen3gQ3rpOtVInSDmSyXqWEhCLuG/w34AtWoTiW7G516rsAAh6Hy1TP91GooMWbonP3XQNTQ==
   dependencies:
-    "@sentry/types" "7.47.0"
-    "@sentry/utils" "7.47.0"
+    "@sentry/types" "7.48.0"
+    "@sentry/utils" "7.48.0"
     tslib "^1.9.3"
 
-"@sentry/hub@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.47.0.tgz#6a213f89db82e994a783d1c551ae7da1afbe0d78"
-  integrity sha512-pPu1SkUqCJjFuW3a73RADy/B51nzd5brTIrBE4zVL1FYm4JVzkzbtItSGtR6tosB1Ftkr3E2eLryEzeEsuppsw==
+"@sentry/hub@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.48.0.tgz#89b0ed9083e9a2a83e511d111f684c041aa531b7"
+  integrity sha512-yCgcNpdbwy4bQr8LIrDzcP7otDNGYyFubcOohhB6XFKPh4dTI0GJyBkvWy0qtbgQUxL5he618gC3wOLV3/TFXw==
   dependencies:
-    "@sentry/core" "7.47.0"
-    "@sentry/types" "7.47.0"
-    "@sentry/utils" "7.47.0"
+    "@sentry/core" "7.48.0"
+    "@sentry/types" "7.48.0"
+    "@sentry/utils" "7.48.0"
     tslib "^1.9.3"
 
-"@sentry/integrations@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.47.0.tgz#b952cc910e92e9235f42151f7260471b55b10cdf"
-  integrity sha512-PUSeBYI3fCOswn+K+PLjtl2epr8/ceqebWqVcxHclczSY3EOZE+osznDFgZmeVgrHavsgfE4oFVqJeFvDJwCog==
+"@sentry/integrations@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.48.0.tgz#1f1c3fd0735b3c40944a42fb45e3e0ca40f77d6d"
+  integrity sha512-yzbJopVu1UHFXRDv236o5hSEUtqeP45T9uSVbAhKnH5meKWunK7MKvhFvQjhcfvlUVibYrewoVztQP2hrpxgfw==
   dependencies:
-    "@sentry/types" "7.47.0"
-    "@sentry/utils" "7.47.0"
+    "@sentry/types" "7.48.0"
+    "@sentry/utils" "7.48.0"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/react@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.47.0.tgz#9b0b937465a4e7fc6c3bde90ef9d0be2ef708b78"
-  integrity sha512-Qy6OnlE8FivKOLo0YE7tkr+G5fLmEOkpPxj179wbY/N8kp/ALkqbVdcOrZW7AL6HCc0lphhj+0SB+tpwoPEsiQ==
+"@sentry/react@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.48.0.tgz#3c160d7dcccc7581b57c430fccfe482c912c3f0d"
+  integrity sha512-E2HF0njufOI/BWktXfIiPNIh0dh7la9uQmDlYiFAK8MnlW4OOjw4rRJV2qkxKQCYdO9WB+T460DVw102Z/MyUA==
   dependencies:
-    "@sentry/browser" "7.47.0"
-    "@sentry/types" "7.47.0"
-    "@sentry/utils" "7.47.0"
+    "@sentry/browser" "7.48.0"
+    "@sentry/types" "7.48.0"
+    "@sentry/utils" "7.48.0"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/replay@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.47.0.tgz#d2fc8fd3be2360950497426035d1ba0bd8a97b8f"
-  integrity sha512-BFpVZVmwlezZ83y0L43TCTJY142Fxh+z+qZSwTag5HlhmIpBKw/WKg06ajOhrYJbCBkhHmeOvyKkxX0jnc39ZA==
+"@sentry/replay@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.48.0.tgz#ca8f1543bad4717dcd65739bf1256a1933bba757"
+  integrity sha512-8fRHMGJ0NJeIZi6UucxUTvfDPaBa7+jU1kCTLjCcuH3X/UVz5PtGLMtFSO5U8HP+mUDlPs97MP1uoDvMa4S2Ng==
   dependencies:
-    "@sentry/core" "7.47.0"
-    "@sentry/types" "7.47.0"
-    "@sentry/utils" "7.47.0"
+    "@sentry/core" "7.48.0"
+    "@sentry/types" "7.48.0"
+    "@sentry/utils" "7.48.0"
 
-"@sentry/types@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.47.0.tgz#fd07dbec11a26ae861532a9abe75bd31663ca09b"
-  integrity sha512-GxXocplN0j1+uczovHrfkykl9wvkamDtWxlPUQgyGlbLGZn+UH1Y79D4D58COaFWGEZdSNKr62gZAjfEYu9nQA==
+"@sentry/types@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.48.0.tgz#57f3c9cf331a5621e82dda04eefcf8c19ee42bc9"
+  integrity sha512-kkAszZwQ5/v4n7Yyw/DPNRWx7h724mVNRGZIJa9ggUMvTgMe7UKCZZ5wfQmYiKVlGbwd9pxXAcP8Oq15EbByFQ==
 
 "@sentry/typescript@^5.20.1":
   version "5.20.1"
@@ -1828,12 +1828,12 @@
     tslint-config-prettier "^1.18.0"
     tslint-consistent-codestyle "^1.15.1"
 
-"@sentry/utils@7.47.0":
-  version "7.47.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.47.0.tgz#e62fdede15e45387b40c9fa135feba48f0960826"
-  integrity sha512-A89SaOLp6XeZfByeYo2C8Ecye/YAtk/gENuyOUhQEdMulI6mZdjqtHAp7pTMVgkBc/YNARVuoa+kR/IdRrTPkQ==
+"@sentry/utils@7.48.0":
+  version "7.48.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.48.0.tgz#2866975ea8899aba35b083dd0558cbbe29ee8de1"
+  integrity sha512-d977sghkFVMfld0LrEyyY2gYrfayLPdDEpUDT+hg5y79r7zZDCFyHtdB86699E5K89MwDZahW7Erk+a1nk4x5w==
   dependencies:
-    "@sentry/types" "7.47.0"
+    "@sentry/types" "7.48.0"
     tslib "^1.9.3"
 
 "@sentry/wizard@2.6.1":


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

JS SDK update, for some reason the updater was failing on the `@sentry-internal/tracing` package, but that one is not necessary in 7.48.0.

https://github.com/getsentry/sentry-react-native/actions/runs/4716993448/jobs/8365203595
