### PR TITLE
fix(rnna): Allow disabling native on RNNA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Allow disabling native on RNNA
+- Allow disabling native on RNNA ([#2978](https://github.com/getsentry/sentry-react-native/pull/2978))
 
 ## 5.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Allow disabling native on RNNA
+
 ## 5.3.1
 
 ### Fixes

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -27,7 +27,7 @@ import { isTurboModuleEnabled } from './utils/environment';
 import { utf8ToBytes } from './vendor';
 
 const RNSentry: Spec | undefined = isTurboModuleEnabled()
-  ? TurboModuleRegistry.getEnforcing<Spec>('RNSentry')
+  ? TurboModuleRegistry.get<Spec>('RNSentry')
   : NativeModules.RNSentry;
 
 export interface Screenshot {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Enforcing the native module causes an error when RN App is built with the new architecture but doesn't have the sentry native SDKs installed. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A user might want to use sentry only in JS.

## :green_heart: How did you test it?
sample app, rn-tester

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
