### PR TITLE
chore(sample): Update CPP Turbo Module crash to use runtime exception

### DIFF
--- a/sample-new-architecture/tm/NativeSampleModule.cpp
+++ b/sample-new-architecture/tm/NativeSampleModule.cpp
@@ -8,7 +8,7 @@ namespace facebook::react
 
   void NativeSampleModule::crash(jsi::Runtime &rt)
   {
-    throw "Error from native cxx module";
+    throw std::runtime_error("Error from native cxx module");
   }
 
 } // namespace facebook::react


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement

Using string is not recommended in CPP, runtime exceptions `what` will get correctly assigned to js error message.

#skip-changelog 