### PR TITLE
fix(android): Clean up `modules.json` when building bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Allow disabling native on RNNA ([#2978](https://github.com/getsentry/sentry-react-native/pull/2978))
 - iOS Autolinking for RN 0.68 and older ([#2980](https://github.com/getsentry/sentry-react-native/pull/2980))
+- Clean up `modules.json` when building bundles
 
 ### Dependencies
 

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -215,7 +215,10 @@ gradle.projectsEvaluated {
         // task.name could be packageDev-debugRelease but in that case currentVariants == null
         // because of the regex in `extractCurrentVariants` and this code doesn't run
         def packageTasks = tasks.findAll {
-          task -> "package${variantTaskName}".equalsIgnoreCase(task.name) && task.enabled
+          task -> (
+            "package${variantTaskName}".equalsIgnoreCase(task.name)
+              || "package${variantTaskName}Bundle".equalsIgnoreCase(task.name)
+            ) && task.enabled
         }
         packageTasks.each { packageTask ->
             packageTask.dependsOn modulesTask


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Android can be built as APK or Bundle, the package tasks are named differently based on the build type.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- closes: https://github.com/getsentry/sentry-react-native/issues/2993

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
