### PR TITLE
fix(ios): Store envelopes immediately during a fatal crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Store envelopes immediately during a fatal crash on iOS
+
 ## 4.15.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Store envelopes immediately during a fatal crash on iOS
+- Store envelopes immediately during a fatal crash on iOS ([#3030](https://github.com/getsentry/sentry-react-native/pull/3030))
 
 ## 4.15.0
 

--- a/ios/RNSentry.m
+++ b/ios/RNSentry.m
@@ -292,7 +292,7 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSArray * _Nonnull)bytes
     #if DEBUG
         [PrivateSentrySDKOnly captureEnvelope:envelope];
     #else
-        if (options[@'store']) {
+        if (options[@"store"]) {
             // Storing to disk happens asynchronously with captureEnvelope
             [PrivateSentrySDKOnly storeEnvelope:envelope];
         } else {


### PR DESCRIPTION
## :scroll: Description

### This is a bug fix for v4 version of the SDK

This typo doesn't break the build, but it cause the envelope never to be stored directly which can cause issues when taking screenshots or taking view hierarchy.

introduced in https://github.com/getsentry/sentry-react-native/pull/2463/files#diff-add4c17f9e3987271b5ca99f9a87cff1cd9adf9ffa5a599987d0ab3980990b25R293