### PR TITLE
fix(ios): Store envelopes immediately during a fatal crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Store envelopes immediately during a fatal crash on iOS
+
 ## 5.4.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Store envelopes immediately during a fatal crash on iOS
+- Store envelopes immediately during a fatal crash on iOS ([#3031](https://github.com/getsentry/sentry-react-native/pull/3031))
 
 ## 5.4.0
 

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -317,7 +317,7 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSArray * _Nonnull)bytes
     #if DEBUG
         [PrivateSentrySDKOnly captureEnvelope:envelope];
     #else
-        if (options[@'store']) {
+        if (options[@"store"]) {
             // Storing to disk happens asynchronously with captureEnvelope
             [PrivateSentrySDKOnly storeEnvelope:envelope];
         } else {


### PR DESCRIPTION
## :scroll: Description

This typo doesn't break the build, but it cause the envelope never to be stored directly which can cause issues when taking screenshots or taking view hierarchy.

The same as https://github.com/getsentry/sentry-react-native/pull/3030 but for the current SDK version.