### PR TITLE
chore(deps): update JavaScript SDK to v7.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Dependencies
 
-- Bump JavaScript SDK from v7.49.0 to v7.50.0 ([#3018](https://github.com/getsentry/sentry-react-native/pull/3018))
+- Bump JavaScript SDK from v7.49.0 to v7.50.0 ([#3018](https://github.com/getsentry/sentry-react-native/pull/3034))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7500)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.49.0...7.50.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Dependencies
 
-- Bump JavaScript SDK from v7.49.0 to v7.50.0 ([#3018](https://github.com/getsentry/sentry-react-native/pull/3034))
+- Bump JavaScript SDK from v7.49.0 to v7.50.0 ([#3034](https://github.com/getsentry/sentry-react-native/pull/3034))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7500)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.49.0...7.50.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - Store envelopes immediately during a fatal crash on iOS ([#3031](https://github.com/getsentry/sentry-react-native/pull/3031))
 
+### Dependencies
+
+- Bump JavaScript SDK from v7.49.0 to v7.50.0 ([#3018](https://github.com/getsentry/sentry-react-native/pull/3018))
+  - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7500)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.49.0...7.50.0)
+
 ## 5.4.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -55,18 +55,18 @@
     "react-native": ">=0.65.0"
   },
   "dependencies": {
-    "@sentry/browser": "7.49.0",
+    "@sentry/browser": "7.50.0",
     "@sentry/cli": "2.17.4",
-    "@sentry/core": "7.49.0",
-    "@sentry/hub": "7.49.0",
-    "@sentry/integrations": "7.49.0",
-    "@sentry/react": "7.49.0",
-    "@sentry/types": "7.49.0",
-    "@sentry/utils": "7.49.0"
+    "@sentry/core": "7.50.0",
+    "@sentry/hub": "7.50.0",
+    "@sentry/integrations": "7.50.0",
+    "@sentry/react": "7.50.0",
+    "@sentry/types": "7.50.0",
+    "@sentry/utils": "7.50.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.49.0",
-    "@sentry-internal/eslint-plugin-sdk": "7.49.0",
+    "@sentry-internal/eslint-config-sdk": "7.50.0",
+    "@sentry-internal/eslint-plugin-sdk": "7.50.0",
     "@sentry/typescript": "^5.20.1",
     "@sentry/wizard": "3.0.0",
     "@types/jest": "^29.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,13 +1659,13 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-2.0.0.tgz#4c40b74655c83982c8cf47530ee7dc13d957b6aa"
   integrity sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ==
 
-"@sentry-internal/eslint-config-sdk@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.49.0.tgz#61450f76a178e6757c31b6438a498b17dca62314"
-  integrity sha512-5/Mb8mjduNCni1hRQD0gLTAfLIVWL1rfyS/TVhoZg/x3qz6DLO/upOyk/PpbHoJuvXXyiYixobultycm3iO7FQ==
+"@sentry-internal/eslint-config-sdk@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.50.0.tgz#b4210244f1bf69e035cf924f34f8cb8b0e50be31"
+  integrity sha512-jge0KvAH9kUcphiWftLqIYmKM0Wm0/cZUWPBtnc8ApNDGCOZhj0uX8zTEWSAZb2YOXv5AikCEfshPGuftlXYBg==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.49.0"
-    "@sentry-internal/typescript" "7.49.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.50.0"
+    "@sentry-internal/typescript" "7.50.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -1674,38 +1674,38 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.49.0.tgz#936cbb99b972d5ebda45a1fbd7058bb57f3baee1"
-  integrity sha512-mh4wEXk0DIUd2kZe+nhym0K9cAHJSF54gd0p0GF53jPXU1u7/gltW3eEQP+CLtT60IezZxYTO9cvnUmzDSh7uQ==
+"@sentry-internal/eslint-plugin-sdk@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.50.0.tgz#a42a9acad3fc87af5f9d82d5c02adc8bc69c69b6"
+  integrity sha512-DFDqs43Pc6sIYHGysYO9E+Z4hkUs4cbmo9e+vWnRKlsQDfHs/+BirsX6pH07m/sbWxKwwdUbel3I+yOXJF9jxQ==
   dependencies:
     requireindex "~1.1.0"
 
-"@sentry-internal/tracing@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.49.0.tgz#f589de565370884b9a13f82c98463de9b2d25dcd"
-  integrity sha512-ESh3+ZneQk/3HESTUmIPNrW5GVPu/HrRJU+eAJJto74vm+6vP7zDn2YV2gJ1w18O/37nc7W/bVCgZJlhZ3cwew==
+"@sentry-internal/tracing@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.50.0.tgz#74454af99a03d81762993835d2687c881e14f41e"
+  integrity sha512-4TQ4vN0aMBWsUXfJWk2xbe4x7fKfwCXgXKTtHC/ocwwKM+0EefV5Iw9YFG8IrIQN4vMtuRzktqcs9q0/Sbv7tg==
   dependencies:
-    "@sentry/core" "7.49.0"
-    "@sentry/types" "7.49.0"
-    "@sentry/utils" "7.49.0"
+    "@sentry/core" "7.50.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     tslib "^1.9.3"
 
-"@sentry-internal/typescript@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.49.0.tgz#af70ffbf8bb4e70906cb9913a5ff34ed3d9286ce"
-  integrity sha512-u3heGxVyQuty8IkKSTOiH1meNPRzzDcnSFbnMuJE9jGiJ/22WSruMH7BX2JQQnwzu8E1VlSVtPrHnsMJkSU8MA==
+"@sentry-internal/typescript@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.50.0.tgz#31d76a36bba025ca35edefc6d1dae6afac26d4f1"
+  integrity sha512-cCWBqAcKWByS7z9x2oqsFl6/fT4EhFgb6OYShPlsOwP5UYthIJqDDFZJiFb9qSejQeENgSyWE63dIMVMtUI5sQ==
 
-"@sentry/browser@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.49.0.tgz#5ce1cdb8d883c129d9a4e313c08a54c5ada4661b"
-  integrity sha512-x2DekKkQoY7/dhBzE4J25mdQ978NtPBTVQb+uZqlF/t5mp4K44TAszmPqy8lC/CmVHkp7qcpRGSCIzeboUL4KA==
+"@sentry/browser@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.50.0.tgz#16c995c336322c8aec65570f90f50288678004ec"
+  integrity sha512-a+UYbP89+SAvW47/p9wxEi9eWlyp/SkYl52OCdZNXnplQY4kQIOVyiaIs5nnCxIxZgXKrhAX4eo1E9ykleFuNQ==
   dependencies:
-    "@sentry-internal/tracing" "7.49.0"
-    "@sentry/core" "7.49.0"
-    "@sentry/replay" "7.49.0"
-    "@sentry/types" "7.49.0"
-    "@sentry/utils" "7.49.0"
+    "@sentry-internal/tracing" "7.50.0"
+    "@sentry/core" "7.50.0"
+    "@sentry/replay" "7.50.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     tslib "^1.9.3"
 
 "@sentry/cli@2.17.4":
@@ -1732,59 +1732,59 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/core@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.49.0.tgz#340d059f5efeff1a3359fef66d0c8e34e79ac992"
-  integrity sha512-AlSnCYgfEbvK8pkNluUkmdW/cD9UpvOVCa+ERQswXNRkAv5aDGCL6Ihv6fnIajE++BYuwZh0+HwZUBVKTFzoZg==
+"@sentry/core@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.50.0.tgz#88bc9cbfc0cb429a28489ece6f0be7a7006436c4"
+  integrity sha512-6oD1a3fYs4aiNK7tuJSd88LHjYJAetd7ZK/AfJniU7zWKj4jxIYfO8nhm0qdnhEDs81RcweVDmPhWm3Kwrzzsg==
   dependencies:
-    "@sentry/types" "7.49.0"
-    "@sentry/utils" "7.49.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     tslib "^1.9.3"
 
-"@sentry/hub@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.49.0.tgz#1ba2257cef3f51c4b83af7e2107400b1033f57b6"
-  integrity sha512-1gHj9YaVSkKpV3A4BnC+0y2rK7OKEFfh+CXg19lVtU+Hvj04DZOlpSq3dtGJEpr1Qvm4mQO1GoPq8eTboQg0vg==
+"@sentry/hub@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.50.0.tgz#e2568883f9cc777f66a3a8e27448d22d679ee64a"
+  integrity sha512-Zor8U/6NYdYfwW8fTBOvFnPCqdeuPF6v1hzgDNoG4BRqiO/TwDLSerXKdy11Pl+s+tUpRrtZDDct3phNBt20pg==
   dependencies:
-    "@sentry/core" "7.49.0"
-    "@sentry/types" "7.49.0"
-    "@sentry/utils" "7.49.0"
+    "@sentry/core" "7.50.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     tslib "^1.9.3"
 
-"@sentry/integrations@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.49.0.tgz#e123f687e0abe10d3428027e3879ce231503fc2f"
-  integrity sha512-qsEVkcZjw+toFGnzsVo+Cozz+hMK9LugzkfJyOFL+CyiEx9MfkEmsvRpZe1ETEWKe/VZylYU27NQzl6UNuAUjw==
+"@sentry/integrations@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.50.0.tgz#82616f34ddba3c1f3e17b54900dfa7d8e0a0c537"
+  integrity sha512-HUmPN2sHNx37m+lOWIoCILHimILdI0Df9nGmWA13fIhny8mxJ6Dbazyis11AW4/lrZ1a6F1SQ2epLEq7ZesiRw==
   dependencies:
-    "@sentry/types" "7.49.0"
-    "@sentry/utils" "7.49.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/react@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.49.0.tgz#9a31808d4232d3010019e09d7c706b3d4fe54960"
-  integrity sha512-s+ROJr1tP9zVBmoOn94JM+fu2TuoJKxkSXTEUOKoQ9P6P5ROzpDqTzHRGk6u4OjZTy5tftRyEqBGM2Iaf9Y+UA==
+"@sentry/react@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.50.0.tgz#ed85405518539905a34e5cf89baef719569ef4c0"
+  integrity sha512-V/KfIhwLezefnRz0y9pGJn5x0RBL8Q1347LowcOZWoNiDoaaLI9hRBTqJGyvCstG5NNhsLTKMM3UDk0WNXflPg==
   dependencies:
-    "@sentry/browser" "7.49.0"
-    "@sentry/types" "7.49.0"
-    "@sentry/utils" "7.49.0"
+    "@sentry/browser" "7.50.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/replay@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.49.0.tgz#c7f16bc3ca0c5911f641738f8894eb596c5da00d"
-  integrity sha512-UY3bHoBDPOu4Dpq3m3oxNjLrq09NiFVYUfrTN4QOq1Am2SA04XbuCj/YZ+jNVy/NrFtoz9cTovK6oQbNw53jog==
+"@sentry/replay@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.50.0.tgz#dd29f063492d91e708629ff8dd95a59d4b7180f1"
+  integrity sha512-EYRk+DTZ5luwfkiCaDpBC3YBKIEdkReTUNZtWDVUytSVjsCnttkAipx/y6bxy3HN+rSXungMd3XKQT5RNMRUNA==
   dependencies:
-    "@sentry/core" "7.49.0"
-    "@sentry/types" "7.49.0"
-    "@sentry/utils" "7.49.0"
+    "@sentry/core" "7.50.0"
+    "@sentry/types" "7.50.0"
+    "@sentry/utils" "7.50.0"
 
-"@sentry/types@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.49.0.tgz#2c217091e13dc373682f5be2e9b5baed9d2ae695"
-  integrity sha512-9yXXh7iv76+O6h2ONUVx0wsL1auqJFWez62mTjWk4350SgMmWp/zUkBxnVXhmcYqscz/CepC+Loz9vITLXtgxg==
+"@sentry/types@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.50.0.tgz#52a035cad83a80ca26fa53c09eb1241250c3df3e"
+  integrity sha512-Zo9vyI98QNeYT0K0y57Rb4JRWDaPEgmp+QkQ4CRQZFUTWetO5fvPZ4Gb/R7TW16LajuHZlbJBHmvmNj2pkL2kw==
 
 "@sentry/typescript@^5.20.1":
   version "5.20.1"
@@ -1794,12 +1794,12 @@
     tslint-config-prettier "^1.18.0"
     tslint-consistent-codestyle "^1.15.1"
 
-"@sentry/utils@7.49.0":
-  version "7.49.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.49.0.tgz#b1b3a2af52067dd27e660c7c3062a31cdf4b94f9"
-  integrity sha512-JdC9yGnOgev4ISJVwmIoFsk8Zx0psDZJAj2DV7x4wMZsO6QK+YjC7G3mUED/S5D5lsrkBZ/3uvQQhr8DQI4UcQ==
+"@sentry/utils@7.50.0":
+  version "7.50.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.50.0.tgz#2b93a48024651436e95b7c8e2066aee7c2234d57"
+  integrity sha512-iyPwwC6fwJsiPhH27ZbIiSsY5RaccHBqADS2zEjgKYhmP4P9WGgHRDrvLEnkOjqQyKNb6c0yfmv83n0uxYnolw==
   dependencies:
-    "@sentry/types" "7.49.0"
+    "@sentry/types" "7.50.0"
     tslib "^1.9.3"
 
 "@sentry/wizard@3.0.0":


### PR DESCRIPTION

Bumps scripts/update-javascript.sh from 7.49.0 to 7.50.0.

Auto-generated by a [dependency updater](https://github.com/getsentry/github-workflows/blob/main/.github/workflows/updater.yml).
## Changelog
### 7.50.0

#### Important Changes

- **doc(sveltekit): Promote the SDK to beta state ([#7976](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7976))**
  - feat(sveltekit): Convert `sentryHandle` to a factory function ([#7975](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7975))

With this release, the Sveltekit SDK ([sentry/sveltekit](./packages/sveltekit/README.md)) is promoted to Beta.
This means that we do not expect any more breaking changes.

The final breaking change is that `sentryHandle` is now a function.
So in order to update to 7.50.0, you have to update your `hooks.server.js` file:

```js
// hooks.server.js

// Old:
export const handle = sentryHandle;
// New:
export const handle = sentryHandle();
```

- **feat(replay): Allow to configure URLs to capture network bodies/headers ([#7953](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7953))**

You can now capture request/response bodies & headers of network requests in Replay.
You have to define an allowlist of URLs you want to capture additional information for:

```js
new Replay({
  networkDetailAllowUrls: ['https://sentry.io/api'],
});
```

By default, we will capture request/response bodies, as well as the request/response headers `content-type`, `content-length` and `accept`.
You can configure this with some additional configuration:

```js
new Replay({
  networkDetailAllowUrls: ['https://sentry.io/api'],
  // opt-out of capturing bodies
  networkCaptureBodies: false,
  // These headers are captured _in addition to_ the default headers
  networkRequestHeaders: ['X-Custom-Header'],
  networkResponseHeaders: ['X-Custom-Header', 'X-Custom-Header-2']
});
```

Note that bodies will be truncated to a max length of ~150k characters.

**- feat(replay): Changes of sampling behavior & public API**
  - feat(replay): Change the behavior of error-based sampling ([#7768](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7768))
  - feat(replay): Change `flush()` API to record current event buffer ([#7743](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7743))
  - feat(replay): Change `stop()` to flush and remove current session ([#7741](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7741))

We have changed the behavior of error-based sampling, as well as adding & adjusting APIs a bit to be more aligned with expectations.
See [Sampling](./packages/replay/README.md#sampling) for details.

We've also revamped some public APIs in order to be better aligned with expectations. See [Stoping & Starting Replays manually](./packages/replay/README.md#stopping--starting-replays-manually) for details.

- **feat(core): Add multiplexed transport ([#7926](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7926))**

We added a new transport to support multiplexing.
With this, you can configure Sentry to send events to different DSNs, depending on a logic of your choosing:

```js
import { makeMultiplexedTransport } from 'sentry/core';
import { init, captureException, makeFetchTransport } from 'sentry/browser';

function dsnFromFeature({ getEvent }) {
  const event = getEvent();
  switch(event?.tags?.feature) {
    case 'cart':
      return ['__CART_DSN__'];
    case 'gallery':
      return ['__GALLERY_DSN__'];
  }
  return []
}

init({
  dsn: '__FALLBACK_DSN__',
  transport: makeMultiplexedTransport(makeFetchTransport, dsnFromFeature)
});
```

#### Additional Features and Fixes

- feat(nextjs): Add `disableLogger` option that automatically tree shakes logger statements ([#7908](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7908))
- feat(node): Make Undici a default integration. ([#7967](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7967))
- feat(replay): Extend session idle time until expire to 15min ([#7955](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7955))
- feat(tracing): Add `db.system` span data to DB spans ([#7952](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7952))
- fix(core): Avoid crash when Function.prototype is frozen ([#7899](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7899))
- fix(nextjs): Fix inject logic for Next.js 13.3.1 canary ([#7921](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7921))
- fix(replay): Ensure console breadcrumb args are truncated ([#7917](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7917))
- fix(replay): Ensure we do not set replayId on dsc if replay is disabled ([#7939](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7939))
- fix(replay): Ensure we still truncate large bodies if they are failed JSON ([#7923](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7923))
- fix(utils): default normalize() to a max. of 100 levels deep instead of Inifnity ([#7957](https://github-redirect.dependabot.com/getsentry/sentry-javascript/issues/7957))

Work in this release contributed by Jack-Works. Thank you for your contribution!