### PR TITLE
fix(sdk): Do not overwrite `_metadata` option by default `sdkInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Store envelopes immediately during a fatal crash on iOS ([#3031](https://github.com/getsentry/sentry-react-native/pull/3031))
+- Do not overwrite `_metadata` option by default `sdkInfo` ([#3036](https://github.com/getsentry/sentry-react-native/pull/3036))
 
 ## 5.4.0
 

--- a/test/integrations/sdkinfo.test.ts
+++ b/test/integrations/sdkinfo.test.ts
@@ -2,6 +2,7 @@ import type { Event, EventHint, Package } from '@sentry/types';
 
 import { SdkInfo } from '../../src/js/integrations';
 import { NATIVE } from '../../src/js/wrapper';
+import { SDK_NAME, SDK_VERSION } from '../../src/js';
 
 let mockedFetchNativeSdkInfo: jest.Mock<PromiseLike<Package | null>, []>;
 
@@ -56,6 +57,29 @@ describe('Sdk Info', () => {
     expect(processedEvent?.sdk?.packages).toEqual([]);
     expect(processedEvent?.platform === 'javascript');
     expect(mockedFetchNativeSdkInfo).toBeCalledTimes(1);
+  });
+
+  it('Does not overwrite existing sdk name and version', async () => {
+    mockedFetchNativeSdkInfo = jest.fn().mockResolvedValue(null);
+    const mockEvent: Event = {
+      sdk: {
+        name: 'test-sdk',
+        version: '1.0.0',
+      },
+    };
+    const processedEvent = await executeIntegrationFor(mockEvent);
+
+    expect(processedEvent?.sdk?.name).toEqual('test-sdk');
+    expect(processedEvent?.sdk?.version).toEqual('1.0.0');
+  });
+
+  it('Does use default sdk name and version', async () => {
+    mockedFetchNativeSdkInfo = jest.fn().mockResolvedValue(null);
+    const mockEvent: Event = {};
+    const processedEvent = await executeIntegrationFor(mockEvent);
+
+    expect(processedEvent?.sdk?.name).toEqual(SDK_NAME);
+    expect(processedEvent?.sdk?.version).toEqual(SDK_VERSION);
   });
 });
 

--- a/test/integrations/sdkinfo.test.ts
+++ b/test/integrations/sdkinfo.test.ts
@@ -1,8 +1,8 @@
 import type { Event, EventHint, Package } from '@sentry/types';
 
+import { SDK_NAME, SDK_VERSION } from '../../src/js';
 import { SdkInfo } from '../../src/js/integrations';
 import { NATIVE } from '../../src/js/wrapper';
-import { SDK_NAME, SDK_VERSION } from '../../src/js';
 
 let mockedFetchNativeSdkInfo: jest.Mock<PromiseLike<Package | null>, []>;
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
When SDK like `sentry-expo` is built on top of `sentry-react-native` it should be able to supply its own metadata,

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
