### PR TITLE
fix: allow to pass any type for wrap component props

### DIFF
--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -138,6 +138,7 @@ export function init(passedOptions: ReactNativeOptions): void {
 /**
  * Inits the Sentry React Native SDK with automatic instrumentation and wrapped features.
  */
+// eslint-disable-next-line @typescript-eslint/ban-types
 export function wrap<P = {}>(
   RootComponent: React.ComponentType<P>,
   options?: ReactNativeWrapperOptions

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -138,7 +138,7 @@ export function init(passedOptions: ReactNativeOptions): void {
 /**
  * Inits the Sentry React Native SDK with automatic instrumentation and wrapped features.
  */
-export function wrap<P extends JSX.IntrinsicAttributes>(
+export function wrap<P = {}>(
   RootComponent: React.ComponentType<P>,
   options?: ReactNativeWrapperOptions
 ): React.ComponentType<P> {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Allow passing any type to `wrap`. Right now props type could only extend `JSX.IntrinsicAttributes`

## :green_heart: How did you test it?
Tested locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
