### PR TITLE
chore(internal): Add meaning full release name and dist to e2e tests builds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -245,6 +245,8 @@ jobs:
     name: Build RN ${{ matrix.rn-version }} ${{ matrix.rn-architecture }} ${{ matrix.platform }} ${{ matrix.build-type }}
     runs-on: macos-latest
     env:
+      SENTRY_RELEASE: ${{ github.workflow }}/${{ github.ref }}
+      SENTRY_DIST: ${{ matrix.rn-architecture }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ github.sha }}
       RN_SENTRY_POD_NAME: RNSentry
       RN_DIFF_REPOSITORY: https://github.com/react-native-community/rn-diff-purge.git
     strategy:
@@ -303,7 +305,10 @@ jobs:
 
       - name: Build E2E Tests Library
         working-directory: test/e2e
-        run: yarn build
+        run: |
+          perl -i -pe"s/<sentry_release>/$SENTRY_RELEASE/g" src/EndToEndTests.tsx
+          perl -i -pe"s/<sentry_dist>/$SENTRY_DIST/g" src/EndToEndTests.tsx
+          yarn build
 
       - name: Package SDK
         run: yalc publish

--- a/test/e2e/src/EndToEndTests.tsx
+++ b/test/e2e/src/EndToEndTests.tsx
@@ -18,8 +18,10 @@ const EndToEndTestsScreen = (): JSX.Element => {
   // We only do this to render the eventId onto the UI for end to end tests.
   React.useEffect(() => {
     Sentry.init({
+      release: '<sentry_release>',
+      dist: '<sentry_dist>',
       dsn: SENTRY_INTERNAL_DSN,
-      beforeSend: (e) => {
+      beforeSend: (e: Sentry.Event) => {
         setEventId(e.event_id || null);
         return e;
       },

--- a/test/react-native/rn.patch.app.js
+++ b/test/react-native/rn.patch.app.js
@@ -2,11 +2,14 @@
 
 const fs = require('fs');
 const path = require('path');
-const { argv } = require('process');
+const { argv, env } = require('process');
 
 const parseArgs = require('minimist');
 const { logger } = require('@sentry/utils');
 logger.enable();
+
+const SENTRY_RELEASE = env.SENTRY_RELEASE;
+const SENTRY_DIST = env.SENTRY_DIST;
 
 const args = parseArgs(argv.slice(2));
 if (!args.app) {
@@ -20,6 +23,8 @@ import * as Sentry from '@sentry/react-native';
 import { EndToEndTestsScreen } from 'sentry-react-native-e2e-tests';
 
 Sentry.init({
+  release: '${SENTRY_RELEASE}',
+  dist: '${SENTRY_DIST}',
   dsn: 'https://d870ad989e7046a8b9715a57f59b23b5@o447951.ingest.sentry.io/5428561',
 });
 `;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
At the moment e2e builds are not symbolicated correctly.

The reason why is that all the builds are using the same name and release and run in parallel.
Therefore sentry can't assign correct source maps.

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 