### PR TITLE
fix(gradle): add resolved sentry package for monorepos

### DIFF
--- a/sentry.gradle
+++ b/sentry.gradle
@@ -163,9 +163,15 @@ gradle.projectsEvaluated {
 
               workingDir reactRoot
 
+              def resolvedSentryPath = null
+              try {
+                  resolvedSentryPath = new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile();
+              } catch (Throwable ignored) {}
+              def sentryPackage = resolvedSentryPath != null && resolvedSentryPath.exists() ? resolvedSentryPath.getAbsolutePath() : "$reactRoot/node_modules/@sentry/react-native"
+
               def collectModulesScript = config.collectModulesScript
                   ? file(config.collectModulesScript).getAbsolutePath()
-                  : "$reactRoot/node_modules/@sentry/react-native/dist/js/tools/collectModules.js"
+                  : "$sentryPackage/dist/js/tools/collectModules.js"
               def modulesPaths = config.modulesPaths
                   ? config.modulesPaths.join(',')
                   : "$reactRoot/node_modules"


### PR DESCRIPTION
fix #2740

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Dynamically resolve the sentry package dir so that it works with monorepos 


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using Sentry on monorepos we need to manually set the collectModulesScript path

## :green_heart: How did you test it?
I did not :/ 
Any ideas how can I test it? 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
