### PR TITLE
Bump android SDK to 1.19.0 & set native SDK name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Bump JavaScript SDK from v7.52.0 to v7.52.1 ([#3071](https://github.com/getsentry/sentry-react-native/pull/3071))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7521)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.52.0...7.52.1)
+- Bump Android SDK from v6.18.1 to v6.19.0 ([#????](https://github.com/getsentry/sentry-react-native/pull/????))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6190)
+  - [diff](https://github.com/getsentry/sentry-java/compare/6.18.1...6.19.0)
 
 ## 5.5.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:6.18.1'
+    api 'io.sentry:sentry-android:6.19.0'
 }

--- a/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -113,6 +113,7 @@ public class RNSentryModuleImpl {
             }
 
             options.setSentryClientName(sdkVersion.getName() + "/" + sdkVersion.getVersion());
+            options.setNativeSdkName("sentry.native.android.react-native");
             options.setSdkVersion(sdkVersion);
 
             if (rnOptions.hasKey("debug") && rnOptions.getBoolean("debug")) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
- Bumps Android SDK in order to add the feature for renaming the Native SDK.
Since this change for setting the native SDK name is not listed is not listed on the changelog I believe it should also be ignored here, but if needed feel free to request the change.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

- Apps build and validated with a release build.
- Validated on Sentry UI if the desired SDK name was set:
https://sentry-sdks.sentry.io/discover/sentry-react-native:334ce9d183a34da1c9f1e61822e13fe6/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=5428561&query=&sort=-timestamp&statsPeriod=7d&yAxis=count%28%29

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

Close #2960
#skip-changelog