### PR TITLE
feat(expo): Add support for Expo hash named bundles in RewriteFrames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Overwrite Expo bundle names in stack frames ([#3115])(https://github.com/getsentry/sentry-react-native/pull/3115)
+  - This enables source maps to resolve correctly without using `sentry-expo` package
+
 ### Fixes
 
 - Dynamically resolve `collectModulesScript` path to support monorepos ([#3092])(https://github.com/getsentry/sentry-react-native/pull/3092)

--- a/src/js/integrations/rewriteframes.ts
+++ b/src/js/integrations/rewriteframes.ts
@@ -1,28 +1,42 @@
 import { RewriteFrames } from '@sentry/integrations';
 import type { StackFrame } from '@sentry/types';
+import { Platform } from 'react-native';
+
+import { isExpo } from '../utils/environment';
 
 /**
  * Creates React Native default rewrite frames integration
  * which appends app:// to the beginning of the filename
- * and removes file://, 'address at' prefixes and CodePush postfix.
+ * and removes file://, 'address at' prefixes, CodePush postfix,
+ * and Expo bundle postfix.
  */
 export function createReactNativeRewriteFrames(): RewriteFrames {
   return new RewriteFrames({
     iteratee: (frame: StackFrame) => {
-      if (frame.filename) {
-        frame.filename = frame.filename
-          .replace(/^file:\/\//, '')
-          .replace(/^address at /, '')
-          .replace(/^.*\/[^.]+(\.app|CodePush|.*(?=\/))/, '');
-
-        if (frame.filename !== '[native code]' && frame.filename !== 'native') {
-          const appPrefix = 'app://';
-          // We always want to have a triple slash
-          frame.filename =
-            frame.filename.indexOf('/') === 0 ? `${appPrefix}${frame.filename}` : `${appPrefix}/${frame.filename}`;
-        }
-        delete frame.abs_path;
+      if (!frame.filename) {
+        return frame;
       }
+      delete frame.abs_path;
+
+      frame.filename = frame.filename
+        .replace(/^file:\/\//, '')
+        .replace(/^address at /, '')
+        .replace(/^.*\/[^.]+(\.app|CodePush|.*(?=\/))/, '');
+
+      if (frame.filename === '[native code]' || frame.filename === 'native') {
+        return frame;
+      }
+
+      // Expo adds hash to the end of bundle names
+      if (isExpo()) {
+        frame.filename = Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
+        return frame;
+      }
+
+      const appPrefix = 'app://';
+      // We always want to have a triple slash
+      frame.filename =
+        frame.filename.indexOf('/') === 0 ? `${appPrefix}${frame.filename}` : `${appPrefix}/${frame.filename}`;
       return frame;
     },
   });

--- a/src/js/integrations/rewriteframes.ts
+++ b/src/js/integrations/rewriteframes.ts
@@ -4,6 +4,9 @@ import { Platform } from 'react-native';
 
 import { isExpo } from '../utils/environment';
 
+const ANDROID_DEFAULT_BUNDLE_NAME = 'app:///index.android.bundle';
+const IOS_DEFAULT_BUNDLE_NAME = 'app:///main.jsbundle';
+
 /**
  * Creates React Native default rewrite frames integration
  * which appends app:// to the beginning of the filename
@@ -28,8 +31,13 @@ export function createReactNativeRewriteFrames(): RewriteFrames {
       }
 
       // Expo adds hash to the end of bundle names
-      if (isExpo()) {
-        frame.filename = Platform.OS === 'android' ? 'app:///index.android.bundle' : 'app:///main.jsbundle';
+      if (isExpo() && Platform.OS === 'android') {
+        frame.filename = ANDROID_DEFAULT_BUNDLE_NAME;
+        return frame;
+      }
+
+      if (isExpo() && Platform.OS === 'ios') {
+        frame.filename = IOS_DEFAULT_BUNDLE_NAME;
         return frame;
       }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement
- [x] Refactoring

## :scroll: Description
<!--- Describe your changes in detail -->
This code was part of `sentry-expo` package by moving it into `sentry-react-native` users using this package directly will have working source maps out of the box without changing the rewriteframes integration themself. 

Technically this could be a breaking change as before we kept the hash bundle name, but since then source maps are not working it will only add more for new users and will not affect current non-expo users and expo users with their own rewriteframes.    

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes: https://github.com/getsentry/sentry-react-native/issues/3081

## :green_heart: How did you test it?
unit tests, expo app

https://github.com/getsentry/sentry-react-native/issues/3078#issuecomment-1554208985

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
