### PR TITLE
chore(ci): Don't add changelog entry for sentry-wizard updates

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -43,6 +43,7 @@ jobs:
       path: scripts/update-wizard.sh
       name: Wizard
       pr-strategy: update
+      changelog-entry: false
     secrets:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
`sentry-wizard` is a dev dependency and doesn't make sense to inform users about its' version.

users should be always using the latest version regardless of what we have as a dev dep in the repository.

#skip-changelog 