### PR TITLE
chore(sample): Disable SAGP autoInstallation

### DIFF
--- a/sample-new-architecture/android/app/build.gradle
+++ b/sample-new-architecture/android/app/build.gradle
@@ -17,9 +17,11 @@ sentry {
     // Default is disabled.
     includeNativeSources = true
 
+    // `@sentry/react-native` ships with compatible `sentry-android`
+    // This option would install the latest version that ships with the SDK or SAGP (Sentry Android Gradle Plugin)
+    // which might be incompatible with the React Native SDK
     // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
     // Default is enabled.
-    // Only available v3.1.0 and above.
     autoInstallation {
       enabled = false
     }

--- a/sample-new-architecture/android/app/build.gradle
+++ b/sample-new-architecture/android/app/build.gradle
@@ -16,6 +16,13 @@ sentry {
     // you don't need to do it manually.
     // Default is disabled.
     includeNativeSources = true
+
+    // Enable auto-installation of Sentry components (sentry-android SDK and okhttp, timber and fragment integrations).
+    // Default is enabled.
+    // Only available v3.1.0 and above.
+    autoInstallation {
+      enabled = false
+    }
 }
 
 react {


### PR DESCRIPTION
The Sentry Android Gradle Plugin auto installation can potentially break the RN SDK by installing a newer version of the Android SDK which can be potentially incompatible. RN SDK shipped with a comparable version of `sentry-android`.

#skip-changelog 