### PR TITLE
Filter beforeSendTransaction from the Native SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+- Filter beforeSendTransaction from the Native SDK ([#3140](https://github.com/getsentry/sentry-react-native/pull/3140))
+
+
 ### Dependencies
 
 - Bump JavaScript SDK from v7.54.0 to v7.56.0 ([#3119](https://github.com/getsentry/sentry-react-native/pull/3119))

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -198,7 +198,7 @@ export const NATIVE: SentryNativeWrapper = {
 
     // filter out all the options that would crash native.
     /* eslint-disable @typescript-eslint/unbound-method,@typescript-eslint/no-unused-vars */
-    const { beforeSend, beforeBreadcrumb, integrations, ...filteredOptions } = options;
+    const { beforeSend, beforeBreadcrumb, beforeSendTransaction, integrations, ...filteredOptions } = options;
     /* eslint-enable @typescript-eslint/unbound-method,@typescript-eslint/no-unused-vars */
     const nativeIsReady = await RNSentry.initNativeSdk(filteredOptions);
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -145,36 +145,6 @@ describe('Tests Native Wrapper', () => {
       expect(NATIVE.enableNative).toBe(true);
     });
 
-    test('filter beforeSend when initializing Native SDK', async () => {
-      await NATIVE.initNativeSdk({
-        dsn: 'test',
-        enableNative: true,
-        autoInitializeNativeSdk: true,
-        beforeSend: jest.fn(),
-      });
-
-      expect(RNSentry.initNativeSdk).toBeCalled();
-      // @ts-ignore mock value
-      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
-      expect(initParameter).not.toHaveProperty('beforeSend');
-      expect(NATIVE.enableNative).toBe(true);
-    });
-
-    test('filter beforeSend when initializing Native SDK', async () => {
-      await NATIVE.initNativeSdk({
-        dsn: 'test',
-        enableNative: true,
-        autoInitializeNativeSdk: true,
-        beforeSend: jest.fn(),
-      });
-
-      expect(RNSentry.initNativeSdk).toBeCalled();
-      // @ts-ignore mock value
-      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
-      expect(initParameter).not.toHaveProperty('beforeSend');
-      expect(NATIVE.enableNative).toBe(true);
-    });
-
     test('filter beforeBreadcrumb when initializing Native SDK', async () => {
       await NATIVE.initNativeSdk({
         dsn: 'test',
@@ -186,7 +156,37 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.initNativeSdk).toBeCalled();
       // @ts-ignore mock value
       const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).not.toHaveProperty('beforeBreadcrumb');
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
+    test('filter beforeSendTransaction when initializing Native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        beforeSendTransaction: jest.fn(),
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalled();
+      // @ts-ignore mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
       expect(initParameter).not.toHaveProperty('beforeSendTransaction');
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
+    test('filter integrations when initializing Native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        integrations: [],
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalled();
+      // @ts-ignore mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).not.toHaveProperty('beintegrationsforeSendTransaction');
       expect(NATIVE.enableNative).toBe(true);
     });
 

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -130,6 +130,66 @@ describe('Tests Native Wrapper', () => {
       expect(logger.warn).toHaveBeenLastCalledWith('Note: Native Sentry SDK is disabled.');
     });
 
+    test('filter beforeSend when initializing Native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        beforeSend: jest.fn()
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalled();
+      // @ts-ignore mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).not.toHaveProperty('beforeSend');
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
+    test('filter beforeSend when initializing Native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        beforeSend: jest.fn()
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalled();
+      // @ts-ignore mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).not.toHaveProperty('beforeSend');
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
+    test('filter beforeSend when initializing Native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        beforeSend: jest.fn()
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalled();
+      // @ts-ignore mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).not.toHaveProperty('beforeSend');
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
+    test('filter beforeBreadcrumb when initializing Native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: 'test',
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        beforeBreadcrumb: jest.fn()
+      });
+
+      expect(RNSentry.initNativeSdk).toBeCalled();
+      // @ts-ignore mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).not.toHaveProperty('beforeSendTransaction');
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
     test('does not initialize with autoInitializeNativeSdk: false', async () => {
       NATIVE.enableNative = false;
       logger.warn = jest.fn();
@@ -215,8 +275,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":87}\n' +
-            '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
+          '{"type":"event","content_type":"application/json","length":87}\n' +
+          '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
         ),
         { store: false },
       );
@@ -245,8 +305,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":93}\n' +
-            '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
+          '{"type":"event","content_type":"application/json","length":93}\n' +
+          '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
         ),
         { store: false },
       );
@@ -280,8 +340,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":50}\n' +
-            '{"event_id":"event0","message":{"message":"test"}}\n',
+          '{"type":"event","content_type":"application/json","length":50}\n' +
+          '{"event_id":"event0","message":{"message":"test"}}\n',
         ),
         { store: false },
       );
@@ -317,8 +377,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":104}\n' +
-            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
+          '{"type":"event","content_type":"application/json","length":104}\n' +
+          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -344,8 +404,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":38}\n' +
-            '{"event_id":"event0","breadcrumbs":[]}\n',
+          '{"type":"event","content_type":"application/json","length":38}\n' +
+          '{"event_id":"event0","breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -381,8 +441,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":125}\n' +
-            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
+          '{"type":"event","content_type":"application/json","length":125}\n' +
+          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
         ),
         { store: true },
       );

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -275,8 +275,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":87}\n' +
-          '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
+            '{"type":"event","content_type":"application/json","length":87}\n' +
+            '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
         ),
         { store: false },
       );
@@ -305,8 +305,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":93}\n' +
-          '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
+            '{"type":"event","content_type":"application/json","length":93}\n' +
+            '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
         ),
         { store: false },
       );
@@ -340,8 +340,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":50}\n' +
-          '{"event_id":"event0","message":{"message":"test"}}\n',
+            '{"type":"event","content_type":"application/json","length":50}\n' +
+            '{"event_id":"event0","message":{"message":"test"}}\n',
         ),
         { store: false },
       );
@@ -377,8 +377,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":104}\n' +
-          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
+            '{"type":"event","content_type":"application/json","length":104}\n' +
+            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -404,8 +404,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":38}\n' +
-          '{"event_id":"event0","breadcrumbs":[]}\n',
+            '{"type":"event","content_type":"application/json","length":38}\n' +
+            '{"event_id":"event0","breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -441,8 +441,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":125}\n' +
-          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
+            '{"type":"event","content_type":"application/json","length":125}\n' +
+            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
         ),
         { store: true },
       );

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -135,7 +135,7 @@ describe('Tests Native Wrapper', () => {
         dsn: 'test',
         enableNative: true,
         autoInitializeNativeSdk: true,
-        beforeSend: jest.fn()
+        beforeSend: jest.fn(),
       });
 
       expect(RNSentry.initNativeSdk).toBeCalled();
@@ -150,7 +150,7 @@ describe('Tests Native Wrapper', () => {
         dsn: 'test',
         enableNative: true,
         autoInitializeNativeSdk: true,
-        beforeSend: jest.fn()
+        beforeSend: jest.fn(),
       });
 
       expect(RNSentry.initNativeSdk).toBeCalled();
@@ -165,7 +165,7 @@ describe('Tests Native Wrapper', () => {
         dsn: 'test',
         enableNative: true,
         autoInitializeNativeSdk: true,
-        beforeSend: jest.fn()
+        beforeSend: jest.fn(),
       });
 
       expect(RNSentry.initNativeSdk).toBeCalled();
@@ -180,7 +180,7 @@ describe('Tests Native Wrapper', () => {
         dsn: 'test',
         enableNative: true,
         autoInitializeNativeSdk: true,
-        beforeBreadcrumb: jest.fn()
+        beforeBreadcrumb: jest.fn(),
       });
 
       expect(RNSentry.initNativeSdk).toBeCalled();
@@ -275,8 +275,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":87}\n' +
-          '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
+            '{"type":"event","content_type":"application/json","length":87}\n' +
+            '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
         ),
         { store: false },
       );
@@ -305,8 +305,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":93}\n' +
-          '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
+            '{"type":"event","content_type":"application/json","length":93}\n' +
+            '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
         ),
         { store: false },
       );
@@ -340,8 +340,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":50}\n' +
-          '{"event_id":"event0","message":{"message":"test"}}\n',
+            '{"type":"event","content_type":"application/json","length":50}\n' +
+            '{"event_id":"event0","message":{"message":"test"}}\n',
         ),
         { store: false },
       );
@@ -377,8 +377,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":104}\n' +
-          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
+            '{"type":"event","content_type":"application/json","length":104}\n' +
+            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -404,8 +404,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":38}\n' +
-          '{"event_id":"event0","breadcrumbs":[]}\n',
+            '{"type":"event","content_type":"application/json","length":38}\n' +
+            '{"event_id":"event0","breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -441,8 +441,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-          '{"type":"event","content_type":"application/json","length":125}\n' +
-          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
+            '{"type":"event","content_type":"application/json","length":125}\n' +
+            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
         ),
         { store: true },
       );

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -186,7 +186,7 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.initNativeSdk).toBeCalled();
       // @ts-ignore mock value
       const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
-      expect(initParameter).not.toHaveProperty('beintegrationsforeSendTransaction');
+      expect(initParameter).not.toHaveProperty('integrations');
       expect(NATIVE.enableNative).toBe(true);
     });
 
@@ -275,8 +275,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":87}\n' +
-            '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
+          '{"type":"event","content_type":"application/json","length":87}\n' +
+          '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
         ),
         { store: false },
       );
@@ -305,8 +305,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":93}\n' +
-            '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
+          '{"type":"event","content_type":"application/json","length":93}\n' +
+          '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
         ),
         { store: false },
       );
@@ -340,8 +340,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":50}\n' +
-            '{"event_id":"event0","message":{"message":"test"}}\n',
+          '{"type":"event","content_type":"application/json","length":50}\n' +
+          '{"event_id":"event0","message":{"message":"test"}}\n',
         ),
         { store: false },
       );
@@ -377,8 +377,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":104}\n' +
-            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
+          '{"type":"event","content_type":"application/json","length":104}\n' +
+          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -404,8 +404,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":38}\n' +
-            '{"event_id":"event0","breadcrumbs":[]}\n',
+          '{"type":"event","content_type":"application/json","length":38}\n' +
+          '{"event_id":"event0","breadcrumbs":[]}\n',
         ),
         { store: false },
       );
@@ -441,8 +441,8 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.captureEnvelope).toBeCalledWith(
         utf8ToBytes(
           '{"event_id":"event0","sent_at":"123"}\n' +
-            '{"type":"event","content_type":"application/json","length":125}\n' +
-            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
+          '{"type":"event","content_type":"application/json","length":125}\n' +
+          '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
         ),
         { store: true },
       );


### PR DESCRIPTION
Includes `beforeSendTransaction` to the list of filtered items from the Native SDK.
Close #3069

TODO: tests for beforeSendTransaction and also the other cases that were ignored.