### PR TITLE
Make 'collect modules' more monorepo friendly on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Use `android.namespace` for AGP 8 and RN 0.73 ([#3133](https://github.com/getsentry/sentry-react-native/pull/3133))
+- Make 'collect modules' more monorepo friendly on Android ([#3159](https://github.com/getsentry/sentry-react-native/pull/3159))
 
 ### Dependencies
 

--- a/sample-new-architecture/android/app/build.gradle
+++ b/sample-new-architecture/android/app/build.gradle
@@ -62,7 +62,7 @@ project.ext.sentryCli = [
     collectModulesScript: "../../../dist/js/tools/collectModules.js",
     modulesPaths: [
       "node_modules",
-      "../..",
+      "../node_modules",
     ],
     skipCollectModules: false,
 ]

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -44,7 +44,7 @@ gradle.projectsEvaluated {
         if (reactRoot == null) {
             reactRoot = props.get("root").get() // RN 0.71 and above
         }
-        def modulesOutput = "$reactRoot/android/app/src/main/assets/modules.json"
+        def modulesOutput = "$projectDir/src/main/assets/modules.json"
         def modulesTask = null
 
         (shouldCleanUp, bundleOutput, sourcemapOutput) = forceSourceMapOutputFromBundleTask(bundleTask)


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix (?)
- [x] Enhancement

## :scroll: Description
Change Android's 'collect modules' gradle task to use a `$projectDir` rather than `$reactRoot` for locating where it should put the `modules.json` output file.

This _should_ more consistently put it in the correct place automatically for a monorepo. `$reactRoot` can be the app directory (like with `sample-new-architecture`) but, depending on monorepo setup, it can also be the root of the monorepo (as it is for us). This change allows it to work for both cases (and shouldn't affect non-monorepo projects).

Additionally, while I was testing this, it seemed like the `modulesPaths` for the sample app was set incorrectly (it was going above the top directory of the repo) so I've altered it.

## :bulb: Motivation and Context
In our monorepo setup the `modules.json` was being put in the wrong place, and thus didn't become part of the produced apk.

## :green_heart: How did you test it?

Manually tested in our monorepo directly by running `./gradlew assemsbleRelease` from the `android` directory of one of our apps.

Manually tested via `sample-new-architecture` in the `@sentry/react-native` repo to check I got the same APK output before and after my changes (bar the changes present inside `modules.json` due to fixing the `modulesPaths`).

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
