### PR TITLE
fix(promise):  Warn users about multiple versions of `promise` package which can cause unexpected behaviore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Use `android.namespace` for AGP 8 and RN 0.73 ([#3133](https://github.com/getsentry/sentry-react-native/pull/3133))
 
+### Fixes
+
+- Warn users about multiple versions of `promise` package which can cause unexpected behavior like undefined `Promise.allSettled` ([#3162](https://github.com/getsentry/sentry-react-native/pull/3162))
+
 ### Dependencies
 
 - Bump JavaScript SDK from v7.54.0 to v7.57.0 ([#3119](https://github.com/getsentry/sentry-react-native/pull/3119), [#3153](https://github.com/getsentry/sentry-react-native/pull/3153))

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -157,9 +157,9 @@ export class ReactNativeErrorHandlers implements Integration {
       if (ReactNativePromise !== PromisePackagePromise) {
         logger.warn(
           'You appear to have multiple versions of the "promise" package installed. ' +
-          'This may cause unexpected behavior like undefined `Promise.allSettled`. ' +
-          'Please install the `promise` package manually using the exact version as the React Native package. ' +
-          'See https://docs.sentry.io/platforms/react-native/troubleshooting/ for more details.',
+            'This may cause unexpected behavior like undefined `Promise.allSettled`. ' +
+            'Please install the `promise` package manually using the exact version as the React Native package. ' +
+            'See https://docs.sentry.io/platforms/react-native/troubleshooting/ for more details.',
         );
       }
 
@@ -167,7 +167,7 @@ export class ReactNativeErrorHandlers implements Integration {
       if (UsedPromisePolyfill !== RN_GLOBAL_OBJ.Promise) {
         logger.warn(
           'Unhandled promise rejections will not be caught by Sentry. ' +
-          'See https://docs.sentry.io/platforms/react-native/troubleshooting/ for more details.',
+            'See https://docs.sentry.io/platforms/react-native/troubleshooting/ for more details.',
         );
       } else {
         logger.log('Unhandled promise rejections will be caught by Sentry.');
@@ -176,7 +176,7 @@ export class ReactNativeErrorHandlers implements Integration {
       // Do Nothing
       logger.warn(
         'Unhandled promise rejections will not be caught by Sentry. ' +
-        'See https://docs.sentry.io/platforms/react-native/troubleshooting/ for more details.',
+          'See https://docs.sentry.io/platforms/react-native/troubleshooting/ for more details.',
       );
     }
   }

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -87,7 +87,7 @@ export class ReactNativeErrorHandlers implements Integration {
   }
 
   /**
-   * Singe source of truth for the Promise implementation we want to use.
+   * Single source of truth for the Promise implementation we want to use.
    * This is important for verifying that the rejected promise tracing will work as expected.
    */
   private _getPromisePolyfill(): unknown {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
We are patching the global promise which might be an unexpected side effect, but we decided to do this to ensure rejected promise tracking is working 100%. Since the `promise` package is not our dependency but `react-native` it can happen that some other package or the user installs a different version of the package. We can't fix which version will be used in our integration unless we will change from mode 100% tracking working to 100% using the `react-native` version but it might cause the tracking not to work.

Therefore I've added checks and guidance for users that run into this issue. As the solution is simply to install the exact same version as RN uses as direct dep to the app.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes https://github.com/getsentry/sentry-react-native/issues/2851
- relates to one of the issues in https://github.com/getsentry/sentry-react-native/issues/3160

## :green_heart: How did you test it?

Repro from https://github.com/getsentry/sentry-react-native/issues/3160
Sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
