### PR TITLE
Update `CONTRIBUTING.md` to show `allprojects` in the Android guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,9 +152,11 @@ cd sentry-react-native/sample
 Add local maven to `sample/android/build.gradle`.
 
 ```diff
-allprojects {
-    repositories {
-+        mavenLocal()
++ allprojects {
++     repositories {
++         mavenLocal()
++     }
++ }
 ```
 
 Update `sentry-android` version, to the one locally published, in `android/build.gradle`.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
We removed the old `sample` and `sample-new-architecture` doesn't have the `allprojects` section in `build.gradle`, so it should be added to the contribution guide.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keeping the contributing guide up to date.

## :green_heart: How did you test it?
Building `sentry-java` and the sample localy.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 