### PR TITLE
Update react typings fix deprecated JSX global imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@sentry/typescript": "^5.20.1",
     "@sentry/wizard": "3.2.3",
     "@types/jest": "^29.2.5",
-    "@types/react": "^18.0.25",
+    "@types/react": "^18.2.14",
     "babel-jest": "^29.3.1",
     "downlevel-dts": "^0.11.0",
     "eslint": "^7.6.0",

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -141,6 +141,8 @@ export function init(passedOptions: ReactNativeOptions): void {
 /**
  * Inits the Sentry React Native SDK with automatic instrumentation and wrapped features.
  */
+// Deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f1b25591890978a92c610ce575ea2ba2bbde6a89
+// eslint-disable-next-line deprecation/deprecation
 export function wrap<P extends JSX.IntrinsicAttributes>(
   RootComponent: React.ComponentType<P>,
   options?: ReactNativeWrapperOptions

--- a/test/e2e/src/EndToEndTests.tsx
+++ b/test/e2e/src/EndToEndTests.tsx
@@ -10,7 +10,9 @@ export { getTestProps };
  * This screen is for internal end-to-end testing purposes only. Do not use.
  * Not visible through the UI (no button to load it).
  */
-const EndToEndTestsScreen = (): React.JSX.Element => {
+// Deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f1b25591890978a92c610ce575ea2ba2bbde6a89
+// eslint-disable-next-line deprecation/deprecation
+const EndToEndTestsScreen = (): JSX.Element => {
   const [eventId, setEventId] = React.useState<string | null | undefined>();
 
   // !!! WARNING: This is only for testing purposes.

--- a/test/e2e/src/EndToEndTests.tsx
+++ b/test/e2e/src/EndToEndTests.tsx
@@ -10,7 +10,7 @@ export { getTestProps };
  * This screen is for internal end-to-end testing purposes only. Do not use.
  * Not visible through the UI (no button to load it).
  */
-const EndToEndTestsScreen = (): JSX.Element => {
+const EndToEndTestsScreen = (): React.JSX.Element => {
   const [eventId, setEventId] = React.useState<string | null | undefined>();
 
   // !!! WARNING: This is only for testing purposes.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,10 +2186,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react@^18.0.25":
-  version "18.0.28"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.28.tgz#accaeb8b86f4908057ad629a26635fe641480065"
-  integrity sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==
+"@types/react@^18.2.14":
+  version "18.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.14.tgz#fa7a6fecf1ce35ca94e74874f70c56ce88f7a127"
+  integrity sha512-A0zjq+QN/O0Kpe30hA1GidzyFjatVvrpIvWLxD+xv67Vt91TWWgco9IvrJBkeyHm1trGaFS/FSGqPlhyeZRm0g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
We should not switch to the new scoped `React.JSX` yet, because it could break projects with older typings.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 