### PR TITLE
Fix windows sample build

### DIFF
--- a/sample-new-architecture/metro.config.js
+++ b/sample-new-architecture/metro.config.js
@@ -20,6 +20,7 @@ const config = {
   resolver: {
     blacklistRE: blacklist([
       new RegExp(`${parentDir}/node_modules/react-native/.*`),
+      new RegExp(`.*\\android\\.*`), // Required for Windows in order to run the Sample.
     ]),
     extraNodeModules: new Proxy(
       {


### PR DESCRIPTION
without the additional blacklist rule, The React Native CLI always crashes/closes when running the sample on Windows with the following Error message:
```
Error: EPERM: operation not permitted, lstat 'c:\...\sentry-react-native\sample-new-architecture\android\app\build\intermediates\cxx\Debug\6h4e2b82\obj\arm64-v8a\libreact_codegen_rngesturehandler_codegen.so.tmpa7af62e'
Emitted 'error' event on NodeWatcher instance at:
    at c:\...\sentry-react-native\sample-new-architecture\node_modules\metro-file-map\src\watchers\NodeWatcher.js:231:14 {
  errno: -4048,
  code: 'EPERM',
  syscall: 'lstat',
  path: 'c:\\...\\sentry-react-native\\sample-new-architecture\\android\\app\\build\\intermediates\\cxx\\Debug\\6h4e2b82\\obj\\arm64-v8a\\libreact_codegen_rngesturehandler_codegen.so.tmpa7af62e'

```

This error has no error related to folder/file permission, but in reality it's a lock issue, so this block list prevents the lock to happen, and with result, The React Native CLI Does not crash when running the Sample on Windows.

#skip-changelog.