### PR TITLE
Fix node version for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -179,8 +179,14 @@ jobs:
           echo "SENTRY_DIST=$SENTRY_DIST"
 
       - uses: actions/setup-node@v3
+        if: ${{ matrix.rn-version == '0.65.3' }}
         with:
           node-version: 16
+
+      - uses: actions/setup-node@v3
+        if: ${{ matrix.rn-version != '0.65.3' }}
+        with:
+          node-version: 18
 
       - uses: actions/setup-java@v3
         with:
@@ -381,8 +387,14 @@ jobs:
         run: tar -xvf *.tar
 
       - uses: actions/setup-node@v3
+        if: ${{ matrix.rn-version == '0.65.3' }}
         with:
           node-version: 16
+
+      - uses: actions/setup-node@v3
+        if: ${{ matrix.rn-version != '0.65.3' }}
+        with:
+          node-version: 18
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -178,6 +178,10 @@ jobs:
           echo "SENTRY_RELEASE=$SENTRY_RELEASE"
           echo "SENTRY_DIST=$SENTRY_DIST"
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - uses: actions/setup-java@v3
         with:
           java-version: '11'
@@ -375,6 +379,10 @@ jobs:
       - name: Extract App Package
         working-directory: test/e2e
         run: tar -xvf *.tar
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
We have to fix the major version of Node.JS for RN E2E tests, as RN 0.65.3 won't build with the newer node versions due to unsupported OSSL. 

https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported


And at the same time, we have to fix the major version for the newer RN releases as they support only Node.JS 18 and above.

https://github.com/facebook/react-native/blob/main/packages/react-native/package.json#L24

#skip-changelog 