### PR TITLE
fix(ci): bump-version.js logs out modified files paths

### DIFF
--- a/scripts/version-bump.js
+++ b/scripts/version-bump.js
@@ -7,9 +7,15 @@ replace({
   from: /\d+\.\d+.\d+(?:-\w+(?:\.\w+)?)?/g,
   to: pjson.version,
 })
-  .then((changedFiles) => {
-    console.log('Modified files:', changedFiles.join(', '));
+  .then(matchedFiles => {
+    console.log(
+      'Modified files:',
+      matchedFiles
+        .filter(file => file.hasChanged)
+        .map(file => file.file)
+        .join(', ') || 'none',
+    );
   })
-  .catch((error) => {
+  .catch(error => {
     console.error('Error occurred:', error);
   });

--- a/scripts/version-bump.js
+++ b/scripts/version-bump.js
@@ -8,13 +8,12 @@ replace({
   to: pjson.version,
 })
   .then(matchedFiles => {
-    console.log(
-      'Modified files:',
+    const modifiedFiles =
       matchedFiles
         .filter(file => file.hasChanged)
         .map(file => file.file)
-        .join(', ') || 'none',
-    );
+        .join(', ') || 'none';
+    console.log('Modified files:', modifiedFiles);
   })
   .catch(error => {
     console.error('Error occurred:', error);


### PR DESCRIPTION
This fixes a small bug I've found when checking https://github.com/getsentry/sentry-react-native/pull/3156

The bump-version.js doesn't print modified files paths

```bash
Modified files: [object Object], [object Object]
```

After the cahnge:

```bash
Modified files: none
OR
Modified files: src/js/version.ts, other/js/version.ts
```

#skip-changelog 