### PR TITLE
chore(sample): Change environment to `dev` to ensure 100% sampling

### DIFF
--- a/sample-new-architecture/src/App.tsx
+++ b/sample-new-architecture/src/App.tsx
@@ -30,6 +30,7 @@ Sentry.init({
   // Replace the example DSN below with your own DSN:
   dsn: SENTRY_INTERNAL_DSN,
   debug: true,
+  environment: 'dev',
   beforeSend: (event: Sentry.Event) => {
     console.log('Event beforeSend:', event.event_id);
     return event;


### PR DESCRIPTION
We want to receive all events from the sample for development and debugging purposes.

#skip-changelog 

> Environments that contain "debug", "dev", "local", "qa", and "test" are not sampled on the server.