### PR TITLE
chore(wrap): Warn users if root component mounts before `Sentry.init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- `Sentry.init` must be called before `Sentry.wrap`([#3227](https://github.com/getsentry/sentry-react-native/pull/3227))
+  - The SDK now shows warning if incorrect order is detected
+
 ## 5.8.1
 
 ### Dependencies

--- a/src/js/tracing/reactnativeprofiler.tsx
+++ b/src/js/tracing/reactnativeprofiler.tsx
@@ -20,7 +20,7 @@ export class ReactNativeProfiler extends Profiler {
     if (!client) {
       // We can't use logger here because this will be logged before the `Sentry.init`.
       // eslint-disable-next-line no-console
-      console.warn('App Start Span could not be finished. `Sentry.wrap` was called before `Sentry.init`.');
+      __DEV__ && console.warn('App Start Span could not be finished. `Sentry.wrap` was called before `Sentry.init`.');
     } else {
       const tracingIntegration = getCurrentHub().getIntegration(
         ReactNativeTracing

--- a/src/js/tracing/reactnativeprofiler.tsx
+++ b/src/js/tracing/reactnativeprofiler.tsx
@@ -14,23 +14,23 @@ export class ReactNativeProfiler extends Profiler {
    */
   public componentDidMount(): void {
     super.componentDidMount();
-    const client = getCurrentHub().getClient();
-    client && client.addIntegration && client.addIntegration(createIntegration(this.name));
+    const hub = getCurrentHub();
+    const client = hub.getClient();
 
     if (!client) {
       // We can't use logger here because this will be logged before the `Sentry.init`.
       // eslint-disable-next-line no-console
       __DEV__ && console.warn('App Start Span could not be finished. `Sentry.wrap` was called before `Sentry.init`.');
-    } else {
-      const tracingIntegration = getCurrentHub().getIntegration(
-        ReactNativeTracing
-      );
-
-      tracingIntegration
-        && this._mountSpan
-        && typeof this._mountSpan.endTimestamp !== 'undefined'
-        // The first root component mount is the app start finish.
-        && tracingIntegration.onAppStartFinish(this._mountSpan.endTimestamp);
+      return;
     }
+
+    client.addIntegration && client.addIntegration(createIntegration(this.name));
+
+    const tracingIntegration = hub.getIntegration(ReactNativeTracing);
+    tracingIntegration
+      && this._mountSpan
+      && typeof this._mountSpan.endTimestamp !== 'undefined'
+      // The first root component mount is the app start finish.
+      && tracingIntegration.onAppStartFinish(this._mountSpan.endTimestamp);
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->

Switching the order causes issues with the App Start tracking. 

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
