### PR TITLE
chore: Bump Sentry-Cocoa version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
+### Dependencies
+
+## Unreleased
+
+- Bump Cocoa SDK from v8.9.4 to v8.10.0 ([#3250](https://github.com/getsentry/sentry-react-native/pull/3250))
+  - This will fix an error to compile projects that use cocoapod with `use_frameworks!` option.
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8100)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.9.4...8.10.0)
+
 ## 5.9.0
+
+## Important Note
+
+**Do not use this version** if you use cocoapod with `use_frameworks!` option. It introduces a bug where the project won't compile.
+This has been fixed in [version `5.10.0`](https://github.com/getsentry/sentry-cocoa/releases/tag/5.10.0).
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Unreleased
 
 - Bump Cocoa SDK from v8.9.4 to v8.10.0 ([#3250](https://github.com/getsentry/sentry-react-native/pull/3250))
-  - This will fix an error to compile projects that use cocoapod with `use_frameworks!` option.
+  - This fixes a compile error for projects that use CocoaPods with `use_frameworks!` option.
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8100)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.9.4...8.10.0)
 
@@ -13,7 +13,7 @@
 
 ## Important Note
 
-**Do not use this version** if you use cocoapod with `use_frameworks!` option. It introduces a bug where the project won't compile.
+**Do not use this version** if you use CocoaPods with `use_frameworks!` option. It introduces a bug where the project won't compile.
 This has been fixed in [version `5.10.0`](https://github.com/getsentry/sentry-cocoa/releases/tag/5.10.0).
 
 ### Features

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.dependency 'React-Core'
-  s.dependency 'Sentry/HybridSDK', '8.9.4'
+  s.dependency 'Sentry/HybridSDK', '8.10.0'
 
   s.source_files = 'ios/**/*.{h,mm}'
   s.public_header_files = 'ios/RNSentry.h'


### PR DESCRIPTION
Bump sentry-cocoa version to 8.10.0.

Closes #3240

_#skip-changelog_