### PR TITLE
fix(ios): BinaryImageCache is only available from dependency container

### DIFF
--- a/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentry+initNativeSdk.h
+++ b/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentry+initNativeSdk.h
@@ -22,4 +22,5 @@ SentrySDK (PrivateTests)
 @interface SentryDependencyContainer : NSObject
 + (instancetype)sharedInstance;
 @property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
+@property (nonatomic, strong) SentryBinaryImageCache *binaryImageCache;
 @end

--- a/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentry+initNativeSdk.mm
+++ b/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentry+initNativeSdk.mm
@@ -189,6 +189,9 @@ int sucessfulSymbolicate(const void *, Dl_info *info){
   id sentrySDKMock = OCMClassMock([SentrySDK class]);
   OCMStub([(SentrySDK*) sentrySDKMock options]).andReturn(sentryOptions);
 
+  id sentryDependencyContainerMock = OCMClassMock([SentryDependencyContainer class]);
+  OCMStub(ClassMethod([sentryDependencyContainerMock sharedInstance])).andReturn(sentryDependencyContainerMock);
+  
   id sentryBinaryImageInfoMockOne = OCMClassMock([SentryBinaryImageInfo class]);
   OCMStub([(SentryBinaryImageInfo*) sentryBinaryImageInfoMockOne address]).andReturn([@112233 unsignedLongLongValue]);
   OCMStub([sentryBinaryImageInfoMockOne name]).andReturn(@"testnameone");
@@ -198,7 +201,7 @@ int sucessfulSymbolicate(const void *, Dl_info *info){
   OCMStub([sentryBinaryImageInfoMockTwo name]).andReturn(@"testnametwo");
   
   id sentryBinaryImageCacheMock = OCMClassMock([SentryBinaryImageCache class]);
-  OCMStub(ClassMethod([sentryBinaryImageCacheMock shared])).andReturn(sentryBinaryImageCacheMock);
+  OCMStub([(SentryDependencyContainer*) sentryDependencyContainerMock binaryImageCache]).andReturn(sentryBinaryImageCacheMock);
   OCMStub([sentryBinaryImageCacheMock imageByAddress:[@123 unsignedLongLongValue]]).andReturn(sentryBinaryImageInfoMockOne);
   OCMStub([sentryBinaryImageCacheMock imageByAddress:[@456 unsignedLongLongValue]]).andReturn(sentryBinaryImageInfoMockTwo);
   
@@ -214,8 +217,6 @@ int sucessfulSymbolicate(const void *, Dl_info *info){
   id sentryDebugImageProviderMock = OCMClassMock([SentryDebugImageProvider class]);
   OCMStub([sentryDebugImageProviderMock getDebugImagesForAddresses:[NSSet setWithObject:@"0x000000000001b669"] isCrash:false]).andReturn(@[sentryDebugImageMock]);
 
-  id sentryDependencyContainerMock = OCMClassMock([SentryDependencyContainer class]);
-  OCMStub(ClassMethod([sentryDependencyContainerMock sharedInstance])).andReturn(sentryDependencyContainerMock);
   OCMStub([sentryDependencyContainerMock debugImageProvider]).andReturn(sentryDebugImageProviderMock);
 }
 

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -216,7 +216,7 @@ RCT_EXPORT_METHOD(fetchNativePackageName:(RCTPromiseResolveBlock)resolve
   NSMutableArray<NSDictionary<NSString *, id> *> * _Nonnull serializedFrames = [[NSMutableArray alloc] init];
 
   for (NSNumber *addr in instructionsAddr) {
-    SentryBinaryImageInfo * _Nullable image = [[SentryBinaryImageCache shared] imageByAddress:[addr unsignedLongLongValue]];
+    SentryBinaryImageInfo * _Nullable image = [[[SentryDependencyContainer sharedInstance] binaryImageCache] imageByAddress:[addr unsignedLongLongValue]];
     if (image != nil) {
       NSString * imageAddr = sentry_formatHexAddressUInt64([image address]);
       [imagesAddrToRetrieveDebugMetaImages addObject: imageAddr];


### PR DESCRIPTION
- Fixes oversight from https://github.com/getsentry/sentry-react-native/pull/3245

#skip-changelog 
