### PR TITLE
chore: update sentry-js to 7.68.0 and fix types 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   Bump Cocoa SDK from v8.10.0 to v8.11.0 ([#3245](https://github.com/getsentry/sentry-react-native/pull/3245))
     [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8110)
     [diff](https://github.com/getsentry/sentry-cocoa/compare/8.10.0...8.11.0)
+  Bump JavaScript SDK from v7.63.0 to v7.68.0 ([#3247](https://github.com/getsentry/sentry-react-native/pull/3247))
+    [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7680)
+    [diff](https://github.com/getsentry/sentry-javascript/compare/7.63.0...7.68.0)
 ## 5.9.1
 
 - Bump Cocoa SDK from v8.9.4 to v8.10.0 ([#3250](https://github.com/getsentry/sentry-react-native/pull/3250))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Bump Cocoa SDK from v8.10.0 to v8.11.0 ([#3245](https://github.com/getsentry/sentry-react-native/pull/3245))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8110)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.10.0...8.11.0)
-- Bump JavaScript SDK from v7.63.0 to v7.68.0 ([#3247](https://github.com/getsentry/sentry-react-native/pull/3277))
+- Bump JavaScript SDK from v7.63.0 to v7.68.0 ([#3277](https://github.com/getsentry/sentry-react-native/pull/3277))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7680)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.63.0...7.68.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@
 
 ### Dependencies
 
-  Bump CLI from v2.20.5 to v2.20.6 ([#3265](https://github.com/getsentry/sentry-react-native/pull/3265))
-    [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2206)
-    [diff](https://github.com/getsentry/sentry-cli/compare/2.20.5...2.20.6)
-  Bump Cocoa SDK from v8.10.0 to v8.11.0 ([#3245](https://github.com/getsentry/sentry-react-native/pull/3245))
-    [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8110)
-    [diff](https://github.com/getsentry/sentry-cocoa/compare/8.10.0...8.11.0)
-  Bump JavaScript SDK from v7.63.0 to v7.68.0 ([#3247](https://github.com/getsentry/sentry-react-native/pull/3277))
-    [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7680)
-    [diff](https://github.com/getsentry/sentry-javascript/compare/7.63.0...7.68.0)
+- Bump CLI from v2.20.5 to v2.20.6 ([#3265](https://github.com/getsentry/sentry-react-native/pull/3265))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2206)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.20.5...2.20.6)
+- Bump Cocoa SDK from v8.10.0 to v8.11.0 ([#3245](https://github.com/getsentry/sentry-react-native/pull/3245))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8110)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.10.0...8.11.0)
+- Bump JavaScript SDK from v7.63.0 to v7.68.0 ([#3247](https://github.com/getsentry/sentry-react-native/pull/3277))
+  - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7680)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.63.0...7.68.0)
+
 ## 5.9.1
 
 - Bump Cocoa SDK from v8.9.4 to v8.10.0 ([#3250](https://github.com/getsentry/sentry-react-native/pull/3250))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   Bump Cocoa SDK from v8.10.0 to v8.11.0 ([#3245](https://github.com/getsentry/sentry-react-native/pull/3245))
     [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8110)
     [diff](https://github.com/getsentry/sentry-cocoa/compare/8.10.0...8.11.0)
-  Bump JavaScript SDK from v7.63.0 to v7.68.0 ([#3247](https://github.com/getsentry/sentry-react-native/pull/3247))
+  Bump JavaScript SDK from v7.63.0 to v7.68.0 ([#3247](https://github.com/getsentry/sentry-react-native/pull/3277))
     [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7680)
     [diff](https://github.com/getsentry/sentry-javascript/compare/7.63.0...7.68.0)
 ## 5.9.1

--- a/package.json
+++ b/package.json
@@ -56,18 +56,18 @@
     "react-native": ">=0.65.0"
   },
   "dependencies": {
-    "@sentry/browser": "7.63.0",
+    "@sentry/browser": "7.68.0",
     "@sentry/cli": "2.20.6",
-    "@sentry/core": "7.63.0",
-    "@sentry/hub": "7.63.0",
-    "@sentry/integrations": "7.63.0",
-    "@sentry/react": "7.63.0",
-    "@sentry/types": "7.63.0",
-    "@sentry/utils": "7.63.0"
+    "@sentry/core": "7.68.0",
+    "@sentry/hub": "7.68.0",
+    "@sentry/integrations": "7.68.0",
+    "@sentry/react": "7.68.0",
+    "@sentry/types": "7.68.0",
+    "@sentry/utils": "7.68.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "7.63.0",
-    "@sentry-internal/eslint-plugin-sdk": "7.63.0",
+    "@sentry-internal/eslint-config-sdk": "7.68.0",
+    "@sentry-internal/eslint-plugin-sdk": "7.68.0",
     "@sentry/typescript": "^5.20.1",
     "@sentry/wizard": "3.9.1",
     "@types/jest": "^29.5.3",

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -1,7 +1,6 @@
 import type { BrowserTransportOptions } from '@sentry/browser/types/transports/types';
 import type { ProfilerProps } from '@sentry/react/types/profiler';
-import type { ClientOptions, Options } from '@sentry/types';
-import type { CaptureContext } from '@sentry/types/types/scope';
+import type { CaptureContext, ClientOptions, Options } from '@sentry/types';
 
 import type { TouchEventBoundaryProps } from './touchevents';
 

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -177,6 +177,7 @@ export class ReactNativeTracing implements Integration {
       tracingOrigins,
       // @ts-ignore TODO
       shouldCreateSpanForRequest,
+      // eslint-disable-next-line deprecation/deprecation
       tracePropagationTargets: thisOptionsTracePropagationTargets,
       routingInstrumentation,
       enableAppStartTracking,

--- a/src/js/tracing/transaction.ts
+++ b/src/js/tracing/transaction.ts
@@ -1,5 +1,5 @@
 import type { IdleTransaction } from '@sentry/core';
-import type { BeforeFinishCallback } from '@sentry/core/types/tracing/idletransaction';
+import type { BeforeFinishCallback } from '@sentry/core/types-ts3.8/tracing/idletransaction';
 import { logger } from '@sentry/utils';
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1939,13 +1939,13 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
-"@sentry-internal/eslint-config-sdk@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.63.0.tgz#b8f80ccf13051f3770347a507069a01ec407c4c7"
-  integrity sha512-H8VfcRu/Z8omSf5LeixeUiwfEYm4SQ6UlyjRAzzITWfgExySHxbD97V58q7AhoYOxsQ18B0UyR+m9piC9xkthA==
+"@sentry-internal/eslint-config-sdk@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.68.0.tgz#6154af30c5b1125419fb3192c97d96a8ddb98310"
+  integrity sha512-24TdQxg/sneTbPV3gBr9wE5hjhTGSQ4b6H8f069DwdJ8BUKmPXMWkX7/3NmgfOqieccLrgsxIMfbkvLveeVBTA==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.63.0"
-    "@sentry-internal/typescript" "7.63.0"
+    "@sentry-internal/eslint-plugin-sdk" "7.68.0"
+    "@sentry-internal/typescript" "7.68.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -1955,10 +1955,10 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.63.0.tgz#1ff0beb3866b124c072c50880fdabd8783b313cc"
-  integrity sha512-tDvNksUhvmh7bJSvocs0PNXffiM0aJ4TGlKl4jXUG2qLPbUALM2QxMhNs3CeXXf+qAvWidy0+nYz2jM0jQ6zQg==
+"@sentry-internal/eslint-plugin-sdk@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.68.0.tgz#41691a39fa10e66869bbe0418121d8051258433f"
+  integrity sha512-XYv33e+9KiB+uEghilBoGlve3UhbrXGGVnnhVppoeAQQek/RxnjHSwwZWo98UqxzYLLW4G9XofUUIxNI2AISCg==
   dependencies:
     requireindex "~1.1.0"
 
@@ -1972,31 +1972,31 @@
     "@sentry/utils" "7.61.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry-internal/tracing@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.63.0.tgz#58903b2205456034611cc5bc1b5b2479275f89c7"
-  integrity sha512-Fxpc53p6NGvLSURg3iRvZA0k10K9yfeVhtczvJnpX30POBuV41wxpkLHkb68fjksirjEma1K3Ut1iLOEEDpPQg==
+"@sentry-internal/tracing@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.68.0.tgz#cb83a797baa671702cf43caf2280868850a0ef04"
+  integrity sha512-nNKS/q21+Iqzxs2K7T/l3dZi8Z9s/uxsAazpk2AYhFzx9mFnPj1Xfe3dgbFoygNifE+IrpUuldr6D5HQamTDPQ==
   dependencies:
-    "@sentry/core" "7.63.0"
-    "@sentry/types" "7.63.0"
-    "@sentry/utils" "7.63.0"
+    "@sentry/core" "7.68.0"
+    "@sentry/types" "7.68.0"
+    "@sentry/utils" "7.68.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry-internal/typescript@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.63.0.tgz#534413543109a68e692f3b4ad17481817c33b934"
-  integrity sha512-df3TIs6ZwinG5vJB/+DU243aj18x5rN+7XcjUFcebHomC/CM0ZewsX/7tqSU6nyEApDBi/w9rYjAB3gBio5MNQ==
+"@sentry-internal/typescript@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.68.0.tgz#8b38e213b0d6ec98617ab6c9bc42ca529fe93bc4"
+  integrity sha512-9jE/pYmSJndyKZ1y/95rVzwwDN3CGR1Fm30fvgdKdVcf4cIaLQMk50XVCHPhB5D7omXOeChOIwShJq21C1/KfA==
 
-"@sentry/browser@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.63.0.tgz#d7eee4be7bfff015f050bca83cafb111dc13d40d"
-  integrity sha512-P1Iw/2281C/7CUCRsN4jgXvjMNKnrwKqxRg7JqN8eVeCDPMpOeEPHNJ6YatEXdVLTKVn0JB7L63Q1prhFr8+SQ==
+"@sentry/browser@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.68.0.tgz#b94be6385f3b1450e928bacf64479d06c452ff42"
+  integrity sha512-1RIPLzKcBeUeG8CQc4OIRfQ6F1zmGKku1am7P9QTz0bz//Mu7bEjm75DM69LBoUlP/Ab9cQQA3fZFUvrH0j1Tg==
   dependencies:
-    "@sentry-internal/tracing" "7.63.0"
-    "@sentry/core" "7.63.0"
-    "@sentry/replay" "7.63.0"
-    "@sentry/types" "7.63.0"
-    "@sentry/utils" "7.63.0"
+    "@sentry-internal/tracing" "7.68.0"
+    "@sentry/core" "7.68.0"
+    "@sentry/replay" "7.68.0"
+    "@sentry/types" "7.68.0"
+    "@sentry/utils" "7.68.0"
     tslib "^2.4.1 || ^1.9.3"
 
 "@sentry/cli@2.20.6":
@@ -2032,32 +2032,32 @@
     "@sentry/utils" "7.61.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/core@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.63.0.tgz#8c38da6ef3a1de6e364463a09bc703b196ecbba4"
-  integrity sha512-13Ljiq8hv6ieCkO+Am99/PljYJO5ynKT/hRQrWgGy9IIEgUr8sV3fW+1W6K4/3MCeOJou0HsiGBjOD1mASItVg==
+"@sentry/core@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.68.0.tgz#323817afea06b1fc22db37620bf74f3f8a46dbcf"
+  integrity sha512-mT3ObBWgvAky/QF3dZy4KBoXbRXbNsD6evn+mYi9UEeIZQ5NpnQYDEp78mapiEjI/TAHZIhTIuaBhj1Jk0qUUA==
   dependencies:
-    "@sentry/types" "7.63.0"
-    "@sentry/utils" "7.63.0"
+    "@sentry/types" "7.68.0"
+    "@sentry/utils" "7.68.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/hub@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.63.0.tgz#7bf9bbb5930c96d6c91f002029b4b64e66fcd42a"
-  integrity sha512-IDgNcoa+YiBbPrDwrZuzSP+vN9wvlQjLEL3OVn0OFaA6Q3X/Zs40JjRz4bTdKb9SjXbyeJ2boFr+4EFvGQoJ1Q==
+"@sentry/hub@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.68.0.tgz#f317877a1d2819e9426696bfc0ba0c7cbe608e29"
+  integrity sha512-MfXGFR1idRnVMnRvuGzrIFmY3DLjytje4gZJ1pT29gTArpMth68ujJ+61Ptj9QZBSJH7vBlVSdF4UuNBJEI6Dg==
   dependencies:
-    "@sentry/core" "7.63.0"
-    "@sentry/types" "7.63.0"
-    "@sentry/utils" "7.63.0"
+    "@sentry/core" "7.68.0"
+    "@sentry/types" "7.68.0"
+    "@sentry/utils" "7.68.0"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/integrations@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.63.0.tgz#bf4268b524670fdbc290dc489de0069143b499c6"
-  integrity sha512-+P8GNqFZNH/yS/KPbvUfUDERneoRNUrqp9ayvvp8aq4cTtrBdM72CYgI21oG6cti42SSM1VDLYZomTV3ElPzSg==
+"@sentry/integrations@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.68.0.tgz#37e8a0967271c6a36e4ce4b1f34a04fab47cf297"
+  integrity sha512-kCY+rD2QD9YAatx9rFT7ndxCTigP10lWTX1qZHNKZBZqr38SvsaD3tyVpbXVPjaFR1tnpuH0osWAjY/gyjFhlw==
   dependencies:
-    "@sentry/types" "7.63.0"
-    "@sentry/utils" "7.63.0"
+    "@sentry/types" "7.68.0"
+    "@sentry/utils" "7.68.0"
     localforage "^1.8.1"
     tslib "^2.4.1 || ^1.9.3"
 
@@ -2075,35 +2075,35 @@
     lru_map "^0.3.3"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/react@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.63.0.tgz#6d318191e13ccf7ebba4897d7258b4ea3bcf6c51"
-  integrity sha512-KFRjgADVE4aMI7gJmGnoSz65ZErQlz9xRB3vETWSyNOLprWXuQLPPtcDEn39BROtsDG4pLyYFaSDiD7o0+DyjQ==
+"@sentry/react@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.68.0.tgz#c4b182b600a78c36397b4db88ff31c1697bd8bd1"
+  integrity sha512-/WLa21GKfaAlHxLZHMsYgfBac3d18UB7wB90E6zvZ+4uh7+0WQY5E1SVPpHYaQ2IEhqLbB69kVxRN+7L+A96hQ==
   dependencies:
-    "@sentry/browser" "7.63.0"
-    "@sentry/types" "7.63.0"
-    "@sentry/utils" "7.63.0"
+    "@sentry/browser" "7.68.0"
+    "@sentry/types" "7.68.0"
+    "@sentry/utils" "7.68.0"
     hoist-non-react-statics "^3.3.2"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/replay@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.63.0.tgz#989ae32ea028a5eca323786cc07294fedb1f0d45"
-  integrity sha512-ikeFVojuP9oDF103blZcj0Vvb4S50dV54BESMrMW2lYBoMMjvOd7AdL+iDHjn1OL05/mv1C6Oc8MovmvdjILVA==
+"@sentry/replay@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.68.0.tgz#ad6e91586c2c6ac81a42705e846eb74f4d068e76"
+  integrity sha512-be8QT2pxcLOTuX6HBRkK0mCVwM97dU5ZLCeofI+xJEWcRnoJdbx00nFwvBXvvoCizbtf4YIMCGwaT2k5LrVxsQ==
   dependencies:
-    "@sentry/core" "7.63.0"
-    "@sentry/types" "7.63.0"
-    "@sentry/utils" "7.63.0"
+    "@sentry/core" "7.68.0"
+    "@sentry/types" "7.68.0"
+    "@sentry/utils" "7.68.0"
 
 "@sentry/types@7.61.1":
   version "7.61.1"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.61.1.tgz#225912689459c92e62f0b6e3ff145f6dbf72ff0e"
   integrity sha512-CpPKL+OfwYOduRX9AT3p+Ie1fftgcCPd5WofTVVq7xeWRuerOOf2iJd0v+8yHQ25omgres1YOttDkCcvQRn4Jw==
 
-"@sentry/types@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.63.0.tgz#8032029fee6f70e04b667646626a674b03e2f79b"
-  integrity sha512-pZNwJVW7RqNLGuTUAhoygt0c9zmc0js10eANAz0MstygJRhQI1tqPDuiELVdujPrbeL+IFKF+7NvRDAydR2Niw==
+"@sentry/types@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.68.0.tgz#6134511106eed90bf033dc2ce76955f61582b48f"
+  integrity sha512-5J2pH1Pjx/029zTm3CNY9MaE8Aui81nG7JCtlMp7uEfQ//9Ja4d4Sliz/kV4ARbkIKUZerSgaRAm3xCy5XOXLg==
 
 "@sentry/typescript@^5.20.1":
   version "5.20.1"
@@ -2121,12 +2121,12 @@
     "@sentry/types" "7.61.1"
     tslib "^2.4.1 || ^1.9.3"
 
-"@sentry/utils@7.63.0":
-  version "7.63.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.63.0.tgz#7c598553b4dbb6e3740dc96bc7f112ec32edbe69"
-  integrity sha512-7FQv1RYAwnuTuarruP+1+Jd6YQuN7i/Y7KltwPMVEwU7j5mzYQaexLr/Jz1XIdR2KYVdkbXQyP8jj8BmA6u9Jw==
+"@sentry/utils@7.68.0":
+  version "7.68.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.68.0.tgz#e9fd33f4e856cf6ef3843ae11af3c836d88cbb88"
+  integrity sha512-NecnQegvKARyeFmBx7mYmbI17mTvjARWs1nfzY5jhPyNc3Zk4M3bQsgIdnJ1t+jo93UYudlNND7hxhDzjcBAVg==
   dependencies:
-    "@sentry/types" "7.63.0"
+    "@sentry/types" "7.68.0"
     tslib "^2.4.1 || ^1.9.3"
 
 "@sentry/wizard@3.9.1":


### PR DESCRIPTION
- supersedes https://github.com/getsentry/sentry-react-native/pull/3247
