### PR TITLE
fix(profiling): Create profiles for start up transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Create profiles for start up transactions ([#3281](https://github.com/getsentry/sentry-react-native/pull/3281))
+
 ### Dependencies
 
 - Bump CLI from v2.20.5 to v2.20.7 ([#3265](https://github.com/getsentry/sentry-react-native/pull/3265), [#3273](https://github.com/getsentry/sentry-react-native/pull/3273))

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -121,6 +121,9 @@ export function init(passedOptions: ReactNativeOptions): void {
     if (options.enableNative) {
       defaultIntegrations.push(new DeviceContext());
     }
+    if (options._experiments && typeof options._experiments.profilesSampleRate === 'number') {
+      defaultIntegrations.push(new HermesProfiling());
+    }
     if (hasTracingEnabled(options) && options.enableAutoPerformanceTracing) {
       defaultIntegrations.push(new ReactNativeTracing());
     }
@@ -132,9 +135,6 @@ export function init(passedOptions: ReactNativeOptions): void {
     }
     if (options.enableCaptureFailedRequests) {
       defaultIntegrations.push(new HttpClient());
-    }
-    if (options._experiments && typeof options._experiments.profilesSampleRate === 'number') {
-      defaultIntegrations.push(new HermesProfiling());
     }
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently start-up transactions don't have profiles attached. 

## :green_heart: How did you test it?
sample app, ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
