### PR TITLE
feat(sdk): Add Hermes Debug Info flag to React Native Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Add Hermes Debug Info flag to React Native Context ([#3290](https://github.com/getsentry/sentry-react-native/pull/3290))
+  - This flag equals `true` when Hermes Bundle contains Debug Info (Hermes Source Map was not emitted)
+
 ### Fixes
 
 - Create profiles for start up transactions ([#3281](https://github.com/getsentry/sentry-react-native/pull/3281))

--- a/test/integrations/reactnativeinfo.test.ts
+++ b/test/integrations/reactnativeinfo.test.ts
@@ -148,6 +148,91 @@ describe('React Native Info', () => {
       test: 'context',
     });
   });
+
+  it('add hermes_debug_info to react_native_context based on exception frames', async () => {
+    mockedIsHermesEnabled = jest.fn().mockReturnValue(true);
+
+    const mockedEvent: Event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  platform: 'java',
+                  lineno: 2,
+                },
+                {
+                  lineno: 1,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const actualEvent = await executeIntegrationFor(mockedEvent, {});
+
+    expectMocksToBeCalledOnce();
+    expect(actualEvent?.contexts?.react_native_context?.hermes_debug_info).toEqual(true);
+  });
+
+  it('add hermes_debug_info to react_native_context based on threads frames', async () => {
+    mockedIsHermesEnabled = jest.fn().mockReturnValue(true);
+
+    const mockedEvent: Event = {
+      threads: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  platform: 'java',
+                  lineno: 2,
+                },
+                {
+                  lineno: 1,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const actualEvent = await executeIntegrationFor(mockedEvent, {});
+
+    expectMocksToBeCalledOnce();
+    expect(actualEvent?.contexts?.react_native_context?.hermes_debug_info).toEqual(true);
+  });
+
+
+  it('does not add hermes_debug_info to react_native_context (no hermes bytecode frames)', async () => {
+    mockedIsHermesEnabled = jest.fn().mockReturnValue(true);
+
+    const mockedEvent: Event = {
+      threads: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  platform: 'java',
+                  lineno: 2,
+                },
+                {
+                  lineno: 2,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const actualEvent = await executeIntegrationFor(mockedEvent, {});
+
+    expectMocksToBeCalledOnce();
+    expect(actualEvent?.contexts?.react_native_context?.hermes_debug_info).toEqual(undefined);
+  });
 });
 
 function expectMocksToBeCalledOnce() {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature

## :scroll: Description
<!--- Describe your changes in detail -->
Knowing if the Hermes bundle was built with debug info helps us to guide users towards what debug files we need to symbolicate their stack traces.

## :green_heart: How did you test it?
sample app, ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
