### PR TITLE
feat(sdk): Disable sourcemap based on ENV

### DIFF
--- a/sentry.gradle
+++ b/sentry.gradle
@@ -159,7 +159,7 @@ gradle.projectsEvaluated {
 
               enabled true
           }
-
+          cliTask.onlyIf { !System.getenv("DISABLE_UPLOAD_SOURCEMAP_SENTRY") }
           modulesTask = tasks.create(nameModulesTask, Exec) {
               description = "collect javascript modules from bundle source map"
               group = 'sentry.io'


### PR DESCRIPTION
DISABLE_UPLOAD_SOURCEMAP_SENTRY, the name can be discussed

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
disable task in sentry.gradle. This part is only for android, the iOS parts will be made in the sentry-wizard. ill link it here later

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
when building test-builds there is no need to generate source-map for every build. it might be good to save some CI/CD time
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-react-native/issues/1042

## :green_heart: How did you test it?
manual build and verified

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

fix sentry-wizard 