### PR TITLE
Add support for AGP8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,13 @@ android {
         namespace = "io.sentry.react"
     }
 
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 8) {
+        buildFeatures {
+            buildConfig = true
+        }
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 31)


### PR DESCRIPTION
by enabling buildConfig since it's using custom buildConfig field
So that consumer projects don't have to globally enable this themselves leading to performance impact

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ x ] Enhancement
- [ ] Refactoring

## :scroll: Description
Since AGP8 this flag is disabled by default. Consumer projects have to enable this flag in them globally if the library doesn't do this correctly itself, but uses custom buildConfig fields.


## :bulb: Motivation and Context
No errors and better build performance than the workaround in consuming projects would be.

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
