### PR TITLE
feat(android): Add `enableNdk` to rn options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add Hermes Debug Info flag to React Native Context ([#3290](https://github.com/getsentry/sentry-react-native/pull/3290))
   - This flag equals `true` when Hermes Bundle contains Debug Info (Hermes Source Map was not emitted)
+- Add `enableNdk` property to ReactNativeOptions for Android. ([#3304](https://github.com/getsentry/sentry-react-native/pull/3304))
 
 ## 5.9.2
 

--- a/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -185,6 +185,9 @@ public class RNSentryModuleImpl {
             if (rnOptions.hasKey("maxQueueSize")) {
                 options.setMaxQueueSize(rnOptions.getInt("maxQueueSize"));
             }
+            if (rnOptions.hasKey("enableNdk")) {
+                options.setEnableNdk(rnOptions.getBoolean("enableNdk"));
+            }
 
             options.setBeforeSend((event, hint) -> {
                 // React native internally throws a JavascriptException

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -44,6 +44,12 @@ export interface BaseReactNativeOptions {
   /** Enable scope sync from Java to NDK on Android */
   enableNdkScopeSync?: boolean;
 
+  /** Enable NDK on Android
+   *
+   * @default true
+  */
+  enableNdk?: boolean;
+
   /** When enabled, all the threads are automatically attached to all logged events on Android */
   attachThreads?: boolean;
 

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -47,7 +47,7 @@ export interface BaseReactNativeOptions {
   /** Enable NDK on Android
    *
    * @default true
-  */
+   */
   enableNdk?: boolean;
 
   /** When enabled, all the threads are automatically attached to all logged events on Android */

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -49,7 +49,7 @@ export interface BaseReactNativeOptions {
 
   /** Enable scope sync from Java to NDK on Android
    * Only has an effect if `enableNdk` is `true`.
-  */
+   */
   enableNdkScopeSync?: boolean;
 
   /** When enabled, all the threads are automatically attached to all logged events on Android */

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -41,14 +41,16 @@ export interface BaseReactNativeOptions {
   /** The interval to end a session if the App goes to the background. */
   sessionTrackingIntervalMillis?: number;
 
-  /** Enable scope sync from Java to NDK on Android */
-  enableNdkScopeSync?: boolean;
-
   /** Enable NDK on Android
    *
    * @default true
    */
   enableNdk?: boolean;
+
+  /** Enable scope sync from Java to NDK on Android
+   * Only has an effect if `enableNdk` is `true`.
+  */
+  enableNdkScopeSync?: boolean;
 
   /** When enabled, all the threads are automatically attached to all logged events on Android */
   attachThreads?: boolean;

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -55,6 +55,7 @@ const DEFAULT_OPTIONS: ReactNativeOptions = {
   maxQueueSize: DEFAULT_BUFFER_SIZE,
   attachStacktrace: true,
   enableCaptureFailedRequests: false,
+  enableNdk: true,
 };
 
 /**


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature

## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds an option to disable/enable the sentry native on Android. This should help users experiencing https://issuetracker.google.com/issues/300840851 until resolved.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- https://github.com/facebook/react-native/issues/39505
- https://getsentry.atlassian.net/browse/INC-517
- https://issuetracker.google.com/issues/300840851

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
