### PR TITLE
fix(modules-collector): Fix info output log to show from where modules are collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Change log output to show what paths are considered when collecting modules ([#3316](https://github.com/getsentry/sentry-react-native/pull/3316))
+
 ## 5.10.0
 
 ### Features

--- a/src/js/tools/ModulesCollector.ts
+++ b/src/js/tools/ModulesCollector.ts
@@ -104,7 +104,7 @@ export default class ModulesCollector {
 
     logger.info('Reading source map from', sourceMapPath);
     logger.info('Saving modules to', outputModulesPath);
-    logger.info('Resolving modules from paths', modulesPaths);
+    logger.info('Resolving modules from paths', modulesPaths.join(', '));
 
     if (!existsSync(sourceMapPath)) {
       logger.error(`Source map file does not exist at ${sourceMapPath}`);

--- a/src/js/tools/ModulesCollector.ts
+++ b/src/js/tools/ModulesCollector.ts
@@ -104,7 +104,7 @@ export default class ModulesCollector {
 
     logger.info('Reading source map from', sourceMapPath);
     logger.info('Saving modules to', outputModulesPath);
-    logger.info('Resolving modules from paths', outputModulesPath);
+    logger.info('Resolving modules from paths', modulesPaths);
 
     if (!existsSync(sourceMapPath)) {
       logger.error(`Source map file does not exist at ${sourceMapPath}`);


### PR DESCRIPTION
Fixes log output which should show what paths are considered when collecting modules.

closes: https://github.com/getsentry/sentry-react-native/issues/3308