### PR TITLE
chore(e2e): Use monorepo friendly RN SAGP path resolution

### DIFF
--- a/test/react-native/rn.patch.app.build.gradle.js
+++ b/test/react-native/rn.patch.app.build.gradle.js
@@ -15,8 +15,7 @@ if (!args['app-build-gradle']) {
 logger.info('Patching app/build.gradle', args['app-build-gradle']);
 
 const sentryGradlePatch = `
-apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
-
+apply from: new File(["node", "--print", "require.resolve('@sentry/react-native')"].execute(null, rootDir).text.trim(), "sentry.gradle");
 `;
 const reactNativeGradleRex = /^android {/m;
 

--- a/test/react-native/rn.patch.app.build.gradle.js
+++ b/test/react-native/rn.patch.app.build.gradle.js
@@ -15,7 +15,7 @@ if (!args['app-build-gradle']) {
 logger.info('Patching app/build.gradle', args['app-build-gradle']);
 
 const sentryGradlePatch = `
-apply from: new File(["node", "--print", "require.resolve('@sentry/react-native')"].execute(null, rootDir).text.trim(), "sentry.gradle");
+apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
 `;
 const reactNativeGradleRex = /^android {/m;
 

--- a/test/react-native/rn.patch.app.build.gradle.js
+++ b/test/react-native/rn.patch.app.build.gradle.js
@@ -21,7 +21,7 @@ const reactNativeGradleRex = /^android {/m;
 
 const buildGradle = fs.readFileSync(args['app-build-gradle'], 'utf8');
 
-const isPatched = buildGradle.match(sentryGradlePatch.trim());
+const isPatched = buildGradle.includes(sentryGradlePatch.trim());
 if (!isPatched) {
   const patched = buildGradle.replace(reactNativeGradleRex, m => sentryGradlePatch + m);
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->

Updates the e2e test patch file to use the node resolution to resolve the path to the react native sentry android gradle plugin.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

if the e2e test works, we can make the same change in the sentry-wizard

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

- https://github.com/getsentry/sentry-wizard/pull/352

#skip-changelog 
