### PR TITLE
fix(tracing): Ignore defaults when warning about duplicate definition of trace propagation targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ### Fixes
 
 - Change log output to show what paths are considered when collecting modules ([#3316](https://github.com/getsentry/sentry-react-native/pull/3316))
+- Ignore defaults when warning about duplicate definition of trace propagation targets ([#3327](https://github.com/getsentry/sentry-react-native/pull/3327))
 
 ### Dependencies
 

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -136,8 +136,19 @@ export class ReactNativeTracing implements Integration {
   private _awaitingAppStartData?: NativeAppStartResponse;
   private _appStartFinishTimestamp?: number;
   private _currentRoute?: string;
+  private _hasSetTracePropagationTargets: boolean;
 
   public constructor(options: Partial<ReactNativeTracingOptions> = {}) {
+    this._hasSetTracePropagationTargets = false;
+
+    if (__DEV__) {
+      this._hasSetTracePropagationTargets = !!(
+        options &&
+        // eslint-disable-next-line deprecation/deprecation
+        (options.tracePropagationTargets || options.tracingOrigins)
+      );
+    }
+
     this.options = {
       ...defaultReactNativeTracingOptions,
       ...options,
@@ -193,7 +204,7 @@ export class ReactNativeTracing implements Integration {
     //
     // If both 1 and either one of 2 or 3 are set (from above), we log out a warning.
     const tracePropagationTargets = clientOptionsTracePropagationTargets || thisOptionsTracePropagationTargets;
-    if (__DEV__ && (thisOptionsTracePropagationTargets || tracingOrigins) && clientOptionsTracePropagationTargets) {
+    if (__DEV__ && this._hasSetTracePropagationTargets && clientOptionsTracePropagationTargets) {
       logger.warn(
         '[ReactNativeTracing] The `tracePropagationTargets` option was set in the ReactNativeTracing integration and top level `Sentry.init`. The top level `Sentry.init` value is being used.',
       );


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The warning was showing always when `tracePropagationTargets` on the client was used.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
