### PR TITLE
Fix: Should not take screenshot when SDK is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ### Fixes
 
 - Change log output to show what paths are considered when collecting modules ([#3316](https://github.com/getsentry/sentry-react-native/pull/3316))
+- Should not take screenshot when SDK is disabled ([#3328](https://github.com/getsentry/sentry-react-native/pull/3328))
 
 ### Dependencies
 

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -65,24 +65,25 @@ export function init(passedOptions: ReactNativeOptions): void {
   const reactNativeHub = new Hub(undefined, new ReactNativeScope());
   makeMain(reactNativeHub);
 
-  const maxQueueSize = passedOptions.maxQueueSize
+  const maxQueueSize =
+    passedOptions.maxQueueSize ??
     // eslint-disable-next-line deprecation/deprecation
-    ?? passedOptions.transportOptions?.bufferSize
-    ?? DEFAULT_OPTIONS.maxQueueSize;
+    passedOptions.transportOptions?.bufferSize ??
+    DEFAULT_OPTIONS.maxQueueSize;
 
-  const enableNative = passedOptions.enableNative === undefined || passedOptions.enableNative
-    ? NATIVE.isNativeAvailable()
-    : false;
+  const enableNative =
+    passedOptions.enableNative === undefined || passedOptions.enableNative ? NATIVE.isNativeAvailable() : false;
   const options: ReactNativeClientOptions = {
     ...DEFAULT_OPTIONS,
     ...passedOptions,
     enableNative,
     // If custom transport factory fails the SDK won't initialize
-    transport: passedOptions.transport
-      || makeNativeTransportFactory({
+    transport:
+      passedOptions.transport ||
+      makeNativeTransportFactory({
         enableNative,
-      })
-      || makeFetchTransport,
+      }) ||
+      makeFetchTransport,
     transportOptions: {
       ...DEFAULT_OPTIONS.transportOptions,
       ...(passedOptions.transportOptions ?? {}),
@@ -91,7 +92,9 @@ export function init(passedOptions: ReactNativeOptions): void {
     maxQueueSize,
     integrations: [],
     stackParser: stackParserFromStackParserOptions(passedOptions.stackParser || defaultStackParser),
-    beforeBreadcrumb: safeFactory(passedOptions.beforeBreadcrumb, { loggerMessage: 'The beforeBreadcrumb threw an error' }),
+    beforeBreadcrumb: safeFactory(passedOptions.beforeBreadcrumb, {
+      loggerMessage: 'The beforeBreadcrumb threw an error',
+    }),
     initialScope: safeFactory(passedOptions.initialScope, { loggerMessage: 'The initialScope threw an error' }),
     tracesSampler: safeTracesSampler(passedOptions.tracesSampler),
   };
@@ -99,15 +102,15 @@ export function init(passedOptions: ReactNativeOptions): void {
   const defaultIntegrations: Integration[] = passedOptions.defaultIntegrations || [];
   if (passedOptions.defaultIntegrations === undefined) {
     defaultIntegrations.push(new ModulesLoader());
-    defaultIntegrations.push(new ReactNativeErrorHandlers({
-      patchGlobalPromise: options.patchGlobalPromise,
-    }));
+    defaultIntegrations.push(
+      new ReactNativeErrorHandlers({
+        patchGlobalPromise: options.patchGlobalPromise,
+      }),
+    );
     defaultIntegrations.push(new Release());
-    defaultIntegrations.push(...[
-      ...reactDefaultIntegrations.filter(
-        (i) => !IGNORED_DEFAULT_INTEGRATIONS.includes(i.name)
-      ),
-    ]);
+    defaultIntegrations.push(
+      ...[...reactDefaultIntegrations.filter(i => !IGNORED_DEFAULT_INTEGRATIONS.includes(i.name))],
+    );
 
     defaultIntegrations.push(new NativeLinkedErrors());
     defaultIntegrations.push(new EventOrigin());
@@ -128,7 +131,7 @@ export function init(passedOptions: ReactNativeOptions): void {
     if (hasTracingEnabled(options) && options.enableAutoPerformanceTracing) {
       defaultIntegrations.push(new ReactNativeTracing());
     }
-    if (options.attachScreenshot) {
+    if (options.attachScreenshot && options.enabled) {
       defaultIntegrations.push(new Screenshot());
     }
     if (options.attachViewHierarchy) {
@@ -153,7 +156,7 @@ export function init(passedOptions: ReactNativeOptions): void {
 // eslint-disable-next-line deprecation/deprecation
 export function wrap<P extends JSX.IntrinsicAttributes>(
   RootComponent: React.ComponentType<P>,
-  options?: ReactNativeWrapperOptions
+  options?: ReactNativeWrapperOptions,
 ): React.ComponentType<P> {
   const tracingIntegration = getCurrentHub().getIntegration(ReactNativeTracing);
   if (tracingIntegration) {
@@ -165,7 +168,7 @@ export function wrap<P extends JSX.IntrinsicAttributes>(
     name: RootComponent.displayName ?? 'Root',
   };
 
-  const RootApp: React.FC<P> = (appProps) => {
+  const RootApp: React.FC<P> = appProps => {
     return (
       <TouchEventBoundary {...(options?.touchEventBoundaryProps ?? {})}>
         <ReactNativeProfiler {...profilerProps}>
@@ -221,7 +224,7 @@ export async function flush(): Promise<boolean> {
       return result;
     }
     // eslint-disable-next-line no-empty
-  } catch (_) { }
+  } catch (_) {}
 
   logger.error('Failed to flush the event queue.');
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -440,12 +440,25 @@ describe('Tests the SDK functionality', () => {
     it('adds screenshot integration', () => {
       init({
         attachScreenshot: true,
+        enabled: true,
       });
 
       const actualOptions = mockedInitAndBind.mock.calls[0][secondArg] as ReactNativeClientOptions;
       const actualIntegrations = actualOptions.integrations;
 
       expect(actualIntegrations).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'Screenshot' })]));
+    });
+
+    it('Should not add screenshot integration when the SDK is disabled', () => {
+      init({
+        attachScreenshot: true,
+        enabled: false,
+      });
+
+      const actualOptions = mockedInitAndBind.mock.calls[0][secondArg] as ReactNativeClientOptions;
+      const actualIntegrations = actualOptions.integrations;
+
+      expect(actualIntegrations).not.toEqual(expect.arrayContaining([expect.objectContaining({ name: 'Screenshot' })]));
     });
 
     it('no view hierarchy integration by default', () => {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR suggests a solution for not taking screenshot when the SDK is diabled.



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
related to this issue : #3317 


## :green_heart: How did you test it?
I wrote a unit test for the case when enabled is false


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
