### PR TITLE
fix(tracing): Use deprecated tracing origins option if set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ### Fixes
 
 - Change log output to show what paths are considered when collecting modules ([#3316](https://github.com/getsentry/sentry-react-native/pull/3316))
+- Ignore defaults when warning about duplicate definition of trace propagation targets ([#3327](https://github.com/getsentry/sentry-react-native/pull/3327))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 
 - Change log output to show what paths are considered when collecting modules ([#3316](https://github.com/getsentry/sentry-react-native/pull/3316))
 - Ignore defaults when warning about duplicate definition of trace propagation targets ([#3327](https://github.com/getsentry/sentry-react-native/pull/3327))
+- Use deprecated `ReactNativeTracingOptions.tracingOrigins` if set in the options ([#3331](https://github.com/getsentry/sentry-react-native/pull/3331))
 
 ### Dependencies
 

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -136,8 +136,19 @@ export class ReactNativeTracing implements Integration {
   private _awaitingAppStartData?: NativeAppStartResponse;
   private _appStartFinishTimestamp?: number;
   private _currentRoute?: string;
+  private _hasSetTracePropagationTargets: boolean;
 
   public constructor(options: Partial<ReactNativeTracingOptions> = {}) {
+    this._hasSetTracePropagationTargets = false;
+
+    if (__DEV__) {
+      this._hasSetTracePropagationTargets = !!(
+        options &&
+        // eslint-disable-next-line deprecation/deprecation
+        (options.tracePropagationTargets || options.tracingOrigins)
+      );
+    }
+
     this.options = {
       ...defaultReactNativeTracingOptions,
       ...options,
@@ -193,7 +204,7 @@ export class ReactNativeTracing implements Integration {
     //
     // If both 1 and either one of 2 or 3 are set (from above), we log out a warning.
     const tracePropagationTargets = clientOptionsTracePropagationTargets || thisOptionsTracePropagationTargets;
-    if (__DEV__ && (thisOptionsTracePropagationTargets || tracingOrigins) && clientOptionsTracePropagationTargets) {
+    if (__DEV__ && this._hasSetTracePropagationTargets && clientOptionsTracePropagationTargets) {
       logger.warn(
         '[ReactNativeTracing] The `tracePropagationTargets` option was set in the ReactNativeTracing integration and top level `Sentry.init`. The top level `Sentry.init` value is being used.',
       );

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -209,6 +209,56 @@ describe('ReactNativeTracing', () => {
         }),
       );
     });
+
+    it('client tracePropagationTargets takes priority over integration options', () => {
+      const instrumentOutgoingRequests = jest.spyOn(SentryBrowser, 'instrumentOutgoingRequests');
+      const mockedHub = {
+        getClient: () => ({
+          getOptions: () => ({
+            tracePropagationTargets: ['test1', 'test2'],
+          }),
+        }),
+      };
+
+      const integration = new ReactNativeTracing({
+        tracePropagationTargets: ['test3', 'test4'],
+        tracingOrigins: ['test5', 'test6'],
+      });
+      integration.setupOnce(
+        () => {},
+        () => mockedHub as unknown as Hub,
+      );
+
+      expect(instrumentOutgoingRequests).toBeCalledWith(
+        expect.objectContaining({
+          tracePropagationTargets: ['test1', 'test2'],
+        }),
+      );
+    });
+
+    it('integration tracePropagationTargets takes priority over tracingOrigins', () => {
+      const instrumentOutgoingRequests = jest.spyOn(SentryBrowser, 'instrumentOutgoingRequests');
+      const mockedHub = {
+        getClient: () => ({
+          getOptions: () => ({}),
+        }),
+      };
+
+      const integration = new ReactNativeTracing({
+        tracePropagationTargets: ['test3', 'test4'],
+        tracingOrigins: ['test5', 'test6'],
+      });
+      integration.setupOnce(
+        () => {},
+        () => mockedHub as unknown as Hub,
+      );
+
+      expect(instrumentOutgoingRequests).toBeCalledWith(
+        expect.objectContaining({
+          tracePropagationTargets: ['test3', 'test4'],
+        }),
+      );
+    });
   });
 
   describe('App Start', () => {

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { SpanStatusType, User } from '@sentry/browser';
-import { BrowserClient } from '@sentry/browser';
+import * as SentryBrowser from '@sentry/browser';
 import type { IdleTransaction } from '@sentry/core';
 import { addGlobalEventProcessor, Hub, Transaction } from '@sentry/core';
 
 import type { NativeAppStartResponse } from '../../src/js/NativeRNSentry';
 import { RoutingInstrumentation } from '../../src/js/tracing/routingInstrumentation';
+
+const BrowserClient = SentryBrowser.BrowserClient;
 
 jest.mock('../../src/js/wrapper', () => {
   return {
@@ -115,6 +117,98 @@ describe('ReactNativeTracing', () => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
     jest.clearAllMocks();
+  });
+
+  describe('trace propagation targets', () => {
+    it('uses tracingOrigins', () => {
+      const instrumentOutgoingRequests = jest.spyOn(SentryBrowser, 'instrumentOutgoingRequests');
+      const mockedHub = {
+        getClient: () => ({
+          getOptions: () => ({}),
+        }),
+      };
+
+      const integration = new ReactNativeTracing({
+        tracingOrigins: ['test1', 'test2'],
+      });
+      integration.setupOnce(
+        () => {},
+        () => mockedHub as unknown as Hub,
+      );
+
+      expect(instrumentOutgoingRequests).toBeCalledWith(
+        expect.objectContaining({
+          tracePropagationTargets: ['test1', 'test2'],
+        }),
+      );
+    });
+
+    it('uses tracePropagationTargets', () => {
+      const instrumentOutgoingRequests = jest.spyOn(SentryBrowser, 'instrumentOutgoingRequests');
+      const mockedHub = {
+        getClient: () => ({
+          getOptions: () => ({}),
+        }),
+      };
+
+      const integration = new ReactNativeTracing({
+        tracePropagationTargets: ['test1', 'test2'],
+      });
+      integration.setupOnce(
+        () => {},
+        () => mockedHub as unknown as Hub,
+      );
+
+      expect(instrumentOutgoingRequests).toBeCalledWith(
+        expect.objectContaining({
+          tracePropagationTargets: ['test1', 'test2'],
+        }),
+      );
+    });
+
+    it('uses tracePropagationTargets from client options', () => {
+      const instrumentOutgoingRequests = jest.spyOn(SentryBrowser, 'instrumentOutgoingRequests');
+      const mockedHub = {
+        getClient: () => ({
+          getOptions: () => ({
+            tracePropagationTargets: ['test1', 'test2'],
+          }),
+        }),
+      };
+
+      const integration = new ReactNativeTracing({});
+      integration.setupOnce(
+        () => {},
+        () => mockedHub as unknown as Hub,
+      );
+
+      expect(instrumentOutgoingRequests).toBeCalledWith(
+        expect.objectContaining({
+          tracePropagationTargets: ['test1', 'test2'],
+        }),
+      );
+    });
+
+    it('uses defaults', () => {
+      const instrumentOutgoingRequests = jest.spyOn(SentryBrowser, 'instrumentOutgoingRequests');
+      const mockedHub = {
+        getClient: () => ({
+          getOptions: () => ({}),
+        }),
+      };
+
+      const integration = new ReactNativeTracing({});
+      integration.setupOnce(
+        () => {},
+        () => mockedHub as unknown as Hub,
+      );
+
+      expect(instrumentOutgoingRequests).toBeCalledWith(
+        expect.objectContaining({
+          tracePropagationTargets: ['localhost', /^\/(?!\/)/],
+        }),
+      );
+    });
   });
 
   describe('App Start', () => {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix


## :scroll: Description
<!--- Describe your changes in detail -->
Until the next major version, where we can remove the deprecated options, there are 3 ways to set trace propagation targets. The oldest `tracingOrigins` option was not working as the default value of the newer option always overwrote it.

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
