### PR TITLE
fix(sdk): `Sentry.wrap` doesn't enforce any keys on the wrapped component props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ### Fixes
 
 - Change log output to show what paths are considered when collecting modules ([#3316](https://github.com/getsentry/sentry-react-native/pull/3316))
+- `Sentry.wrap` doesn't enforce any keys on the wrapped component props ([#3332](https://github.com/getsentry/sentry-react-native/pull/3332))
 
 ### Dependencies
 

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -149,9 +149,7 @@ export function init(passedOptions: ReactNativeOptions): void {
 /**
  * Inits the Sentry React Native SDK with automatic instrumentation and wrapped features.
  */
-// Deprecated in https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f1b25591890978a92c610ce575ea2ba2bbde6a89
-// eslint-disable-next-line deprecation/deprecation
-export function wrap<P extends JSX.IntrinsicAttributes>(
+export function wrap<P extends Record<string, unknown>>(
   RootComponent: React.ComponentType<P>,
   options?: ReactNativeWrapperOptions
 ): React.ComponentType<P> {

--- a/test/wrap.test.tsx
+++ b/test/wrap.test.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import { wrap } from '../src/js/sdk';
+
+describe('Sentry.wrap', () => {
+  it('should not enforce any keys on the wrapped component', () => {
+    const Mock: React.FC<{ test: 23 }> = () => <></>;
+    const ActualWrapped = wrap(Mock);
+
+    expect(typeof ActualWrapped.defaultProps).toBe(typeof Mock.defaultProps);
+  });
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
closes: https://github.com/getsentry/sentry-react-native/issues/3311
adds test to prevent this regression in the future

## :green_heart: How did you test it?
unit test, sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
