### PR TITLE
fix(integrations): No screenshots when the SDK is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 ### Fixes
 
 - Change log output to show what paths are considered when collecting modules ([#3316](https://github.com/getsentry/sentry-react-native/pull/3316))
+- Screenshots are not taken when the SDK is disabled ([#3333](https://github.com/getsentry/sentry-react-native/pull/3333))
 
 ### Dependencies
 

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -16,7 +16,6 @@ import { dateTimestampInSeconds, logger, SentryError } from '@sentry/utils';
 import { Alert } from 'react-native';
 
 import { createIntegration } from './integrations/factory';
-import { Screenshot } from './integrations/screenshot';
 import { defaultSdkInfo } from './integrations/sdkinfo';
 import type { ReactNativeClientOptions } from './options';
 import { ReactNativeTracing } from './tracing';
@@ -52,9 +51,7 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
    * @inheritDoc
    */
   public eventFromException(exception: unknown, hint: EventHint = {}): PromiseLike<Event> {
-    return Screenshot.attachScreenshotToEventHint(hint, this._options).then(hintWithScreenshot =>
-      eventFromException(this._options.stackParser, exception, hintWithScreenshot, this._options.attachStacktrace),
-    );
+    return eventFromException(this._options.stackParser, exception, hint, this._options.attachStacktrace);
   }
 
   /**


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR removes hardcoded screenshots from the RN Client and hooks into the global event processor like any other integration.

This may result in slightly delayed screenshots compared to the original method but prevents unexpected behavior due to non-standard integration behavior. 

It also deprecated `attachScreenshotToEventHint` which can be removed in the next major of the SDK.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes: https://github.com/getsentry/sentry-react-native/pull/3328
closes: https://github.com/getsentry/sentry-react-native/issues/3317

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
