### PR TITLE
fix(gradle): Waif for `has-sourcemap-debugid` process to exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Waif for `has-sourcemap-debugid` process to exit ([#3336](https://github.com/getsentry/sentry-react-native/pull/3336))
+
 ## 5.11.0
 
 ### Features

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -128,8 +128,9 @@ gradle.projectsEvaluated {
 
                   // Add release and dist for backward compatibility if no Debug ID detected in output soruce map
                   def process = ["node", hasSourceMapDebugIdScript, sourcemapOutput].execute(null, new File("$reactRoot"))
+                  def exitValue = process.waitFor()
                   project.logger.lifecycle("Check generated source map for Debug ID: ${process.text}")
-                  def notIncludeRelease = "$bundleCommand" == "bundle" && process.exitValue() == 0
+                  def notIncludeRelease = "$bundleCommand" == "bundle" && exitValue == 0
                   def not = notIncludeRelease ? 'not ' : ''
                   project.logger.lifecycle("Sentry Source Maps upload will ${not}include the release name and dist.")
                   extraArgs.addAll(notIncludeRelease ? [] : [


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Since 5.11.0 `sentry.gradle` exec a js script to check if the generated source map has debug id. This process needs to be awaited.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes: https://github.com/getsentry/sentry-react-native/issues/3334

I could not reproduce the issue in CI or locally. Based on the reported error message we are accessing the exit code before the process exites.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
