### PR TITLE
fix(profiling): Add actual `activeThreadId` to Profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Add actual `activeThreadId` to Profiles ([#3338](https://github.com/getsentry/sentry-react-native/pull/3338))
+
 ## 5.11.1
 
 ### Fixes

--- a/src/js/profiling/convertHermesProfile.ts
+++ b/src/js/profiling/convertHermesProfile.ts
@@ -8,6 +8,7 @@ import { parseHermesStackFrameFunctionName } from './hermes';
 import { MAX_PROFILE_DURATION_MS } from './integration';
 import type { RawThreadCpuProfile } from './types';
 
+const PLACEHOLDER_THREAD_ID_STRING = '0';
 const MS_TO_NS = 1e6;
 const MAX_PROFILE_DURATION_NS = MAX_PROFILE_DURATION_MS * MS_TO_NS;
 const ANONYMOUS_FUNCTION_NAME = 'anonymous';
@@ -61,12 +62,14 @@ export function convertToSentryProfile(hermesProfile: Hermes.Profile): RawThread
       priority: JS_THREAD_PRIORITY,
     };
   }
+  const active_thread_id = Object.keys(thread_metadata)[0] || PLACEHOLDER_THREAD_ID_STRING;
 
   return {
     samples,
     frames,
     stacks,
     thread_metadata,
+    active_thread_id,
   };
 }
 

--- a/src/js/profiling/types.ts
+++ b/src/js/profiling/types.ts
@@ -2,4 +2,5 @@ import type { ThreadCpuProfile } from '@sentry/types';
 
 export interface RawThreadCpuProfile extends ThreadCpuProfile {
   profile_id?: string;
+  active_thread_id: string;
 }

--- a/src/js/profiling/utils.ts
+++ b/src/js/profiling/utils.ts
@@ -3,8 +3,6 @@ import { forEachEnvelopeItem, logger } from '@sentry/utils';
 
 import type { RawThreadCpuProfile } from './types';
 
-const ACTIVE_THREAD_ID_STRING = '0';
-
 /**
  *
  */
@@ -163,7 +161,7 @@ function createProfilePayload(
       name: transaction,
       id: event_id,
       trace_id: trace_id || '',
-      active_thread_id: ACTIVE_THREAD_ID_STRING,
+      active_thread_id: cpuProfile.active_thread_id,
     },
   };
 

--- a/test/profiling/convertHermesProfile.test.ts
+++ b/test/profiling/convertHermesProfile.test.ts
@@ -1,7 +1,8 @@
-import type { ThreadCpuProfile, ThreadCpuSample } from '@sentry/types';
+import type { ThreadCpuSample } from '@sentry/types';
 
 import { convertToSentryProfile, mapSamples } from '../../src/js/profiling/convertHermesProfile';
 import type * as Hermes from '../../src/js/profiling/hermes';
+import type { RawThreadCpuProfile } from '../../src/js/profiling/types';
 
 describe('convert hermes profile to sentry profile', () => {
   it('simple test profile', async () => {
@@ -79,7 +80,7 @@ describe('convert hermes profile to sentry profile', () => {
         },
       },
     };
-    const expectedSentryProfile: ThreadCpuProfile = {
+    const expectedSentryProfile: RawThreadCpuProfile = {
       frames: [
         {
           colno: undefined,
@@ -135,6 +136,7 @@ describe('convert hermes profile to sentry profile', () => {
           priority: 1,
         },
       },
+      active_thread_id: '14509472',
     };
     expect(convertToSentryProfile(hermesProfile)).toStrictEqual(expectedSentryProfile);
   });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
the missing active thread id cause the Sentry backend to not calculate aggregate data, as those are calculated only for the active thread

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
