### PR TITLE
fix(debug): Remove `platform: node` from Debug Builds Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
   Read more at https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7690
 
+### Fixes
+
+- Remove `platform: node` from Debug Builds Events ([#3377](https://github.com/getsentry/sentry-react-native/pull/3377))
+
 ## 5.12.0
 
 ### Features

--- a/src/js/integrations/debugsymbolicator.ts
+++ b/src/js/integrations/debugsymbolicator.ts
@@ -66,8 +66,6 @@ export class DebugSymbolicator implements Integration {
 
       await self._symbolicate(event, stack);
 
-      event.platform = 'node'; // Setting platform node makes sure we do not show source maps errors
-
       return event;
     });
   }
@@ -120,8 +118,6 @@ export class DebugSymbolicator implements Integration {
     } catch (_oO) {
       // We can't load devserver URL
     }
-    // Below you will find lines marked with :HACK to prevent showing errors in the sentry ui
-    // But since this is a debug only feature: This is Fine (TM)
     return Promise.all(
       frames.map(async (frame: ReactNativeFrame): Promise<StackFrame> => {
         let inApp = !!frame.column && !!frame.lineNumber;
@@ -132,12 +128,11 @@ export class DebugSymbolicator implements Integration {
           !frame.file.includes('native code');
 
         const newFrame: StackFrame = {
+          lineno: frame.lineNumber,
           colno: frame.column,
           filename: frame.file,
           function: frame.methodName,
           in_app: inApp,
-          lineno: inApp ? frame.lineNumber : undefined, // :HACK
-          platform: inApp ? 'javascript' : 'node', // :HACK
         };
 
         // The upstream `react-native@0.61` delegates parsing of stacks to `stacktrace-parser`, which is buggy and


### PR DESCRIPTION
The hack is not necessary anymore, Sentry doesn't show symbolication errors

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR removes the hack that was used to hide source maps symbolication errors. Sentry doesn't show the errors anymore.

Example event after this PR.

https://sentry-sdks.sentry.io/issues/4609867578/events/5c7a02ee966c4566bbb5a565124a9c58/

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The platform node caused UI issues. 

https://discord.com/channels/621778831602221064/1024798907496140820/1171452965538762752

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
