### PR TITLE
fix(ios): build error when using 'use_frameworks!' in Podfile

### DIFF
--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -5,6 +5,7 @@ folly_flags = ' -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
 folly_compiler_flags = folly_flags + ' ' + '-Wno-comma -Wno-shorten-64-to-32'
 
 is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
+is_using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 new_arch_enabled_flag = (is_new_arch_enabled ? folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED" : "")
 other_cflags = "$(inherited)" + new_arch_enabled_flag
 
@@ -42,5 +43,10 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
+  end
+
+  if is_using_hermes then
+    s.dependency 'React-hermes'
+    s.dependency 'hermes-engine'
   end
 end


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-react-native/issues/3275

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
When using 'use_frameworks!' in the Podfile, the build will fail ([report](https://github.com/getsentry/sentry-react-native/issues/3275)).
This issue can be solved by defining an explicit dependency on Hermes in the pod specification.
A [similar fix](https://github.com/software-mansion/react-native-reanimated/pull/4504) was merged into `react-native-reanimated` some time ago.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [X] No breaking changes
