### PR TITLE
fix(sample): Add contentType to attachments to enabled preview in Sentry

### DIFF
--- a/sample-new-architecture/src/Screens/HomeScreen.tsx
+++ b/sample-new-architecture/src/Screens/HomeScreen.tsx
@@ -147,9 +147,14 @@ const HomeScreen = (props: Props) => {
               scope.addAttachment({
                 data: 'Attachment content',
                 filename: 'attachment.txt',
+                contentType: 'text/plain',
               });
               if (data) {
-                scope.addAttachment({ data, filename: 'logo.png' });
+                scope.addAttachment({
+                  data,
+                  filename: 'logo.png',
+                  contentType: 'image/png',
+                });
               }
               console.log('Sentry attachment added.');
             });


### PR DESCRIPTION
without content type the preview button is disabled in Sentry UI

this PR only updated the sample app

#skip-changelog
