### PR TITLE
chore(deps): update Android SDK to v6.33.2-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Dependencies
+
+- Bump Android SDK from v6.33.1 to v6.33.2-beta.1 ([#3385](https://github.com/getsentry/sentry-react-native/pull/3385))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6332-beta1)
+  - [diff](https://github.com/getsentry/sentry-java/compare/6.33.1...6.33.2-beta.1)
+
 ### Features
 
 - Current screen is now repoted on the error's app context ([#3339](https://github.com/getsentry/sentry-react-native/pull/3339))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Dependencies
 
 - Bump Android SDK from v6.33.1 to v6.33.2-beta.1 ([#3385](https://github.com/getsentry/sentry-react-native/pull/3385))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6332-beta1)
+  - [changelog](https://github.com/getsentry/sentry-java/blob/6.33.2-beta.1/CHANGELOG.md#6332-beta1)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.33.1...6.33.2-beta.1)
 
 ## 5.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-### Dependencies
+### Fixes
 
-- Bump Android SDK from v6.33.1 to v6.33.2-beta.1 ([#3385](https://github.com/getsentry/sentry-react-native/pull/3385))
+- Fix SIGSEV, SIGABRT and SIGBUS crashes happening after/around the August Google Play System update, see [#2955](https://github.com/getsentry/sentry-java/issues/2955) for more details
+  - Fix provided by Native SDK bump in Android SDK v6.33.2-beta.1 ([#3385](https://github.com/getsentry/sentry-react-native/pull/3385))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6332-beta1)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.33.1...6.33.2-beta.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.13.0
+## Unreleased
 
 ### Fixes
 
@@ -8,6 +8,8 @@
   - Fix provided by Native SDK bump in Android SDK v6.33.2-beta.1 ([#3385](https://github.com/getsentry/sentry-react-native/pull/3385))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6332-beta1)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.33.1...6.33.2-beta.1)
+
+## 5.13.0
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Fixes
 
 - Fix SIGSEV, SIGABRT and SIGBUS crashes happening after/around the August Google Play System update, see [#2955](https://github.com/getsentry/sentry-java/issues/2955) for more details
-  - Fix provided by Native SDK bump in Android SDK v6.33.2-beta.1 ([#3385](https://github.com/getsentry/sentry-react-native/pull/3385))
+
+### Dependencies
+
+- Bump Android SDK from v6.33.1 to v6.33.2-beta.1 ([#3385](https://github.com/getsentry/sentry-react-native/pull/3385))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6332-beta1)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.33.1...6.33.2-beta.1)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:6.33.1'
+    api 'io.sentry:sentry-android:6.33.2-beta.1'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix


## :scroll: Description
<!--- Describe your changes in detail -->
Bumps Android SDK to beta version that includes bump of sentry native that includes fix for the native crashesh.


## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
