### PR TITLE
fix(metro): Conditionally use Set or CountingSet in Sentry Metro plugin

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,6 +228,10 @@ jobs:
         working-directory: test/e2e
         run: yarn build
 
+      # This prevents modules resolution from outside of the RN Test App projects
+      - name: Clean SDK node_modules
+        run: rm -rf node_modules
+
       - name: Package SDK
         run: yalc publish
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -228,10 +228,6 @@ jobs:
         working-directory: test/e2e
         run: yarn build
 
-      # This prevents modules resolution from outside of the RN Test App projects
-      - name: Clean SDK node_modules
-        run: rm -rf node_modules
-
       - name: Package SDK
         run: yalc publish
 
@@ -282,6 +278,11 @@ jobs:
           ../../../rn.patch.xcode.js \
             --project ios/RnDiffApp.xcodeproj/project.pbxproj \
             --rn-version '${{ matrix.rn-version }}'
+
+      # This prevents modules resolution from outside of the RN Test App projects
+      # during the native app build
+      - name: Clean SDK node_modules
+        run: rm -rf node_modules
 
       - name: Build Android App
         if: ${{ matrix.platform == 'android' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Add iOS profiles to React Native Profiling ([#3349](https://github.com/getsentry/sentry-react-native/pull/3349))
 
+### Fixes
+
+- Conditionally use Set or CountingSet in Sentry Metro plugin ([#3409](https://github.com/getsentry/sentry-react-native/pull/3409))
+  - This makes sentryMetroSerializer compatible with Metro 0.66.2 and newer
+
 ## 5.13.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@sentry/typescript": "^5.20.1",
     "@sentry/wizard": "3.16.3",
     "@types/jest": "^29.5.3",
+    "@types/node": "^20.9.3",
     "@types/react": "^18.2.14",
     "@types/uglify-js": "^3.17.2",
     "@types/uuid": "^9.0.4",

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -1,10 +1,9 @@
 import * as crypto from 'crypto';
 import type { MixedOutput, Module } from 'metro';
-import CountingSet from 'metro/src/lib/CountingSet';
 import * as countLines from 'metro/src/lib/countLines';
 
 import type { Bundle, MetroSerializer, MetroSerializerOutput, SerializedBundle, VirtualJSOutput } from './utils';
-import { createDebugIdSnippet, determineDebugIdFromBundleSource, stringToUUID } from './utils';
+import { createDebugIdSnippet, createSet, determineDebugIdFromBundleSource, stringToUUID } from './utils';
 import { createDefaultMetroSerializer } from './vendor/metro/utils';
 
 type SourceMap = Record<string, unknown>;
@@ -139,7 +138,7 @@ function createDebugIdModule(debugId: string): Module<VirtualJSOutput> & { setSo
     },
     dependencies: new Map(),
     getSource: () => Buffer.from(debugIdCode),
-    inverseDependencies: new CountingSet(),
+    inverseDependencies: createSet(),
     path: DEBUG_ID_MODULE_PATH,
     output: [
       {

--- a/src/js/tools/utils.ts
+++ b/src/js/tools/utils.ts
@@ -77,7 +77,9 @@ export function determineDebugIdFromBundleSource(code: string): string | undefin
 }
 
 /**
- * CountingSet was added in Metro 0.71.0 before that NodeJS Set was used.
+ * CountingSet was added in Metro 0.72.0 before that NodeJS Set was used.
+ *
+ * https://github.com/facebook/metro/blob/fc29a1177f883144674cf85a813b58567f69d545/packages/metro/src/lib/CountingSet.js
  */
 function resolveSetCreator(): () => CountingSet<string> {
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2293,6 +2293,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.1.tgz#56af902ad157e763f9ba63d671c39cda3193c835"
   integrity sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw==
 
+"@types/node@^20.9.3":
+  version "20.9.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.9.3.tgz#e089e1634436f676ff299596c9531bd2b59fffc6"
+  integrity sha512-nk5wXLAXGBKfrhLB0cyHGbSqopS+nz0BUgZkUQqSHSSgdee0kssp1IAqlQOu333bW+gMNs2QREx7iynm19Abxw==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
@@ -8410,6 +8417,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR checks if `CountingSet` exists, if not NodeJS Set is used as a fallback.

CountingSet was added in Metro 0.72.0 before NodeJS Set was used.

This PR also fixed the tests so that the parent dir node modules are not used during the build of the test Apps. As due to that the e2e tests were OK although they should not.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- fixes: https://github.com/getsentry/sentry-react-native/issues/3406

## :green_heart: How did you test it?
e2e tests, locally run 0.65.3 build

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
