### PR TITLE
fix(ios): Define SentryCurrentDateProvider in RNSentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- fix(ios): Define SentryCurrentDateProvider in RNSentry ([#3418](https://github.com/getsentry/sentry-react-native/pull/3418))
+
 ## 5.14.0
 
 ### Features

--- a/ios/RNSentry.h
+++ b/ios/RNSentry.h
@@ -32,3 +32,15 @@ SentrySDK (Private)
                                        symbolicate: (SymbolicateCallbackType) symbolicate;
 
 @end
+
+@interface SentryCurrentDateProvider : NSObject
+
+- (NSDate *)date;
+
+- (dispatch_time_t)dispatchTimeNow;
+
+- (NSInteger)timezoneOffset;
+
+- (uint64_t)systemTime;
+
+@end

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -22,7 +22,6 @@
 #import <Sentry/SentryBinaryImageCache.h>
 #import <Sentry/SentryDependencyContainer.h>
 #import <Sentry/SentryFormatter.h>
-#import <Sentry/SentryCurrentDateProvider.h>
 
 // This guard prevents importing Hermes in JSC apps
 #if SENTRY_PROFILING_ENABLED


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
`Sentry/SentryCurrentDateProvider.h` is missing in the `HybridPublic` in `sentry-cocoa`. This PR redeclares the interface in `RNSentry` to fix use_frameworks. builds.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes https://github.com/getsentry/sentry-react-native/issues/3414
- related https://github.com/getsentry/sentry-react-native/pull/3416

## :green_heart: How did you test it?
sample app, ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
