### PR TITLE
fix(sample): All Expo native scripts paths are relative to the repo root

### DIFF
--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "sentry-react-native-expo-sample",
     "slug": "sentry-react-native-expo-sample",
+    "jsEngine": "hermes",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -15,19 +16,32 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "io.sentry.expo.sample"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "io.sentry.expo.sample"
     },
     "web": {
       "favicon": "./assets/favicon.png"
     },
     "experiments": {
       "tsconfigPaths": true
-    }
+    },
+    "plugins": [
+      [
+        "../../expo",
+        {
+          "url": "https://sentry.io/",
+          "project": "sentry-react-native",
+          "organization": "sentry-sdks"
+        }
+      ],
+      "./withSampleSentry.js"
+    ]
   }
 }

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -18,6 +18,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.72.6",
     "react-native-web": "~0.19.6",
+    "ts-node": "^10.9.2",
     "typescript": "^5.3.2"
   },
   "devDependencies": {

--- a/samples/expo/withSampleSentry.js
+++ b/samples/expo/withSampleSentry.js
@@ -1,0 +1,2 @@
+require('ts-node/register');
+module.exports = require('./withSampleSentry.ts');

--- a/samples/expo/withSampleSentry.ts
+++ b/samples/expo/withSampleSentry.ts
@@ -1,0 +1,153 @@
+import fs from 'fs';
+import type { ConfigPlugin, XcodeProject } from 'expo/config-plugins';
+import { withAppBuildGradle, withDangerousMod, withXcodeProject } from 'expo/config-plugins';
+
+const SENTRY_GRADLE_LOCAL_OVERWRITE = `../../../../sentry.gradle`;
+
+const withLocalSentry: ConfigPlugin = originalConfig => {
+  let config = originalConfig;
+  config = withAppBuildGradle(config, overwriteSentryGradlePath);
+  config = withAppBuildGradle(config, addLocalSentryScriptsPaths);
+  config = withXcodeProject(config, overwriteSentryXcodePath);
+  config = withDangerousMod(config, ['ios', appendSentryScriptsPathsToXcodeEnvLocal]);
+  return config;
+};
+
+const overwriteSentryXcodePath: Parameters<typeof withXcodeProject>[1] = config => {
+  const xcodeProject: XcodeProject = config.modResults;
+
+  const bundleReactNativePhase = xcodeProject.pbxItemByComment(
+    'Bundle React Native code and images',
+    'PBXShellScriptBuildPhase',
+  );
+  if (!bundleReactNativePhase) {
+    throw new Error('Could not find `Bundle React Native code and images` build phase to patch xcode-sentry.sh!');
+  }
+
+  const includesSentry = bundleReactNativePhase.shellScript.includes('sentry-xcode.sh');
+
+  let code = JSON.parse(bundleReactNativePhase.shellScript);
+  if (includesSentry) {
+    console.log('Overwriting sentry-xcode.sh path...');
+    code = code.replace(
+      `\`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\``,
+      '../../../scripts/sentry-xcode.sh',
+    );
+  } else {
+    console.log('Adding sentry-xcode.sh path...');
+    code = code.replace(
+      /^.*?(packager|scripts)\/react-native-xcode\.sh\s*(\\'\\\\")?/m,
+      (match: string) => `/bin/sh ../../../scripts/sentry-xcode.sh ${match}`,
+    );
+  }
+
+  bundleReactNativePhase.shellScript = JSON.stringify(code);
+  return config;
+};
+
+const appendSentryScriptsPathsToXcodeEnvLocal: Parameters<typeof withDangerousMod>[1][1] = config => {
+  const xcodeEnvLocalPath = `${config.modRequest.projectRoot}/ios/.xcode.env.local`;
+  const xcodeEnvLocalExists = fs.existsSync(xcodeEnvLocalPath);
+  const xcodeEnvLocalContents = (xcodeEnvLocalExists && fs.readFileSync(xcodeEnvLocalPath, 'utf8')) || '';
+  const newSentryScriptsPaths = `${xcodeEnvLocalContents}
+
+export EXTRA_COMPILER_ARGS="-w"
+
+export SENTRY_RN_PACKAGE_PATH="../../.."
+export SENTRY_CLI_EXECUTABLE="../../../node_modules/@sentry/cli/bin/sentry-cli"
+export SENTRY_CLI_EXTRA_ARGS="--force-foreground"
+export SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS=""
+export SENTRY_CLI_RN_XCODE_EXTRA_ARGS=""
+export MODULES_PATHS="$PWD/../node_modules,$PWD/../../.."
+export SENTRY_COLLECT_MODULES="../../scripts/collect-modules.sh"
+`;
+
+  console.log('Adding Sentry Scripts Paths to .xcode.env.local...');
+  fs.writeFileSync(xcodeEnvLocalPath, newSentryScriptsPaths, 'utf8');
+  return config;
+};
+
+const overwriteSentryGradlePath: Parameters<typeof withAppBuildGradle>[1] = config => {
+  if (config.modResults.language !== 'groovy') {
+    throw new Error("Can't overwrite sentry.gradle path because the `app/build.gradle` is not groovy!");
+  }
+
+  const appGradleContentsOriginal = config.modResults.contents;
+  const includesSentry = appGradleContentsOriginal.includes('sentry.gradle');
+  const includesOverwrittenSentry = appGradleContentsOriginal.includes(SENTRY_GRADLE_LOCAL_OVERWRITE);
+
+  if (includesOverwrittenSentry) {
+    console.log('sentry.gradle path is already overwritten!');
+    return config;
+  }
+
+  const newSentryGradlePath = `apply from: "${SENTRY_GRADLE_LOCAL_OVERWRITE}";`;
+  let newAppGradleContents = appGradleContentsOriginal;
+  if (includesSentry) {
+    console.log('Overwriting existing sentry.gradle path...');
+    newAppGradleContents = appGradleContentsOriginal.replace(
+      /^.*sentry.gradle.*$/gm,
+      newSentryGradlePath,
+    );
+  } else {
+    console.log('Adding sentry.gradle local overwrite path...');
+    newAppGradleContents = appGradleContentsOriginal.replace(
+      /^android {/m,
+      match => `${newSentryGradlePath}\n\n${match}`);
+  }
+
+  if (newAppGradleContents === appGradleContentsOriginal) {
+    throw new Error('Failed to overwrite sentry.gradle path!');
+  }
+
+  config.modResults.contents = newAppGradleContents;
+  return config;
+};
+
+const addLocalSentryScriptsPaths: Parameters<typeof withAppBuildGradle>[1] = config => {
+  if (config.modResults.language !== 'groovy') {
+    throw new Error("Can't add local sentry scripts paths because the `app/build.gradle` is not groovy!");
+  }
+
+  const appGradleContentsOriginal = config.modResults.contents;
+  const includesSentry = appGradleContentsOriginal.includes('sentry.gradle');
+  const includesSentryOptions = appGradleContentsOriginal.includes('project.ext.sentryCli');
+
+  if (includesSentryOptions) {
+    throw new Error("Can't overwrite Sentry Options are already defined in app/build.gradle!");
+  }
+
+  const newSentryOptions = `project.ext.sentryCli = [
+  collectModulesScript: "../../../../dist/js/tools/collectModules.js",
+  modulesPaths: [
+    "node_modules",
+    "../../..",
+  ],
+  skipCollectModules: false,
+  copyDebugIdScript: "../../../../scripts/copy-debugid.js",
+  hasSourceMapDebugIdScript: "../../../../scripts/has-sourcemap-debugid.js",
+]`;
+
+  let newAppGradleContents = appGradleContentsOriginal;
+
+  if (includesSentry) {
+    console.log('Adding Sentry Options before sentry.gradle...');
+    newAppGradleContents = appGradleContentsOriginal.replace(
+      /^.*sentry.gradle.*$/gm,
+      match => `${newSentryOptions}\n\n${match}`);
+  } else {
+    console.log('Adding Sentry Options before android {...');
+    newAppGradleContents = appGradleContentsOriginal.replace(
+      /^android {/m,
+      match => `${newSentryOptions}\n\n${match}`);
+  }
+
+  if (newAppGradleContents === appGradleContentsOriginal) {
+    throw new Error('Failed to add Sentry Options!');
+  }
+
+  config.modResults.contents = newAppGradleContents;
+  return config;
+}
+
+export default withLocalSentry;

--- a/samples/expo/yarn.lock
+++ b/samples/expo/yarn.lock
@@ -1171,6 +1171,13 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@expo/bunyan@4.0.0", "@expo/bunyan@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@expo/bunyan/-/bunyan-4.0.0.tgz#be0c1de943c7987a9fbd309ea0b1acd605890c7b"
@@ -1638,7 +1645,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
@@ -1660,6 +1667,14 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.20"
@@ -1971,6 +1986,26 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/body-parser@*":
   version "1.19.5"
@@ -2414,7 +2449,12 @@ acorn-import-assertions@^1.9.0:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
 
-acorn@^8.7.1, acorn@^8.8.2:
+acorn-walk@^8.1.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.1.tgz#2f10f5b69329d90ae18c58bf1fa8fccd8b959a43"
+  integrity sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==
+
+acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.2:
   version "8.11.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
   integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
@@ -2555,6 +2595,11 @@ arg@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
   integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -3378,6 +3423,11 @@ cosmiconfig@^5.0.5, cosmiconfig@^5.1.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@^3.1.5:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
@@ -3700,6 +3750,11 @@ detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -5493,6 +5548,11 @@ make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -8033,6 +8093,25 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
@@ -8240,6 +8319,11 @@ uuid@^8.0.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 valid-url@~1.0.9:
   version "1.0.9"
@@ -8608,6 +8692,11 @@ yargs@^17.6.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/samples/react-native/ios/.xcode.env
+++ b/samples/react-native/ios/.xcode.env
@@ -12,9 +12,10 @@ export NODE_BINARY=$(command -v node)
 
 export EXTRA_COMPILER_ARGS="-w"
 
+export SENTRY_RN_PACKAGE_PATH="../../.."
 export SENTRY_CLI_EXECUTABLE="../../../node_modules/@sentry/cli/bin/sentry-cli"
 export SENTRY_CLI_EXTRA_ARGS="--force-foreground"
 export SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS=""
 export SENTRY_CLI_RN_XCODE_EXTRA_ARGS=""
 export MODULES_PATHS="$PWD/../node_modules,$PWD/../../.."
-export SENTRY_COLLECT_MODULES="../../scripts/collect-modules.sh"
+export SENTRY_COLLECT_MODULES="../../../scripts/collect-modules.sh"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The Expo sample native builds didn't work due to incorrect paths.

## :green_heart: How did you test it?

build locally

e2e test will be added in a follow-up PR.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 