### PR TITLE
feat(expo): Add support to inject debug module before serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:sdk": "tsc -p tsconfig.build.json",
     "build:sdk:watch": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "build:tools": "tsc -p tsconfig.build.tools.json",
+    "build:tools:watch": "tsc -p tsconfig.build.tools.json -w --preserveWatchOutput",
     "build:plugin": "EXPO_NONINTERACTIVE=true expo-module build plugin",
     "downlevel": "downlevel-dts dist ts3.8/dist --to=3.8",
     "clean": "rimraf dist coverage && yarn clean:plugin",

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -21,14 +21,20 @@ const DEBUG_ID_COMMENT = '//# debugId=';
  */
 export function getSentryExpoConfig(projectRoot: string): MetroConfig {
   const { getDefaultConfig } = loadExpoMetroConfigModule();
-  return getDefaultConfig(projectRoot, {unstable_beforeAssetSerializationPlugins: [unstable_beforeAssetSerializationPlugin]});
+  return getDefaultConfig(projectRoot, {
+    unstable_beforeAssetSerializationPlugins: [unstable_beforeAssetSerializationPlugin],
+  });
 }
 
-function unstable_beforeAssetSerializationPlugin({graph, premodules, debugId}: {
+function unstable_beforeAssetSerializationPlugin({
+  graph,
+  premodules,
+  debugId,
+}: {
   graph: ReadOnlyGraph<MixedOutput>;
   premodules: Module[];
   debugId?: string;
-}) : Module[] {
+}): Module[] {
   if (graph.transformOptions.hot || !debugId) {
     return premodules;
   }
@@ -52,16 +58,15 @@ function loadExpoMetroConfigModule(): {
         graph: ReadOnlyGraph<MixedOutput>;
         premodules: Module[];
         debugId?: string;
-    }) => Module[])[];}
+      }) => Module[])[];
+    },
   ) => MetroConfig;
 } {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require('expo/metro-config');
   } catch (e) {
-    throw new Error(
-      'Unable to load `expo/metro-config`. Make sure you have Expo installed.',
-    );
+    throw new Error('Unable to load `expo/metro-config`. Make sure you have Expo installed.');
   }
 }
 

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -56,9 +56,8 @@ function loadExpoMetroConfigModule(): {
   ) => MetroConfig;
 } {
   try {
-    // TODO: switch this back!
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('/Users/quin/Documents/expo/packages/@expo/metro-config/build/ExpoMetroConfig');
+    return require('@expo/metro-config');
   } catch (e) {
     throw new Error(
       'Unable to load `withExpoSerializers` from `@expo/metro-config`. Make sure you have Expo installed.',

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -60,7 +60,7 @@ function loadExpoMetroConfigModule(): {
     return require('expo/metro-config');
   } catch (e) {
     throw new Error(
-      'Unable to load `withExpoSerializers` from `@expo/metro-config`. Make sure you have Expo installed.',
+      'Unable to load `expo/metro-config`. Make sure you have Expo installed.',
     );
   }
 }

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -1,6 +1,5 @@
 import * as crypto from 'crypto';
-import type { MetroConfig, MixedOutput, Module } from 'metro';
-import { mergeConfig } from 'metro';
+import type { MetroConfig, MixedOutput, Module, ReadOnlyGraph } from 'metro';
 import * as countLines from 'metro/src/lib/countLines';
 
 import type { Bundle, MetroSerializer, MetroSerializerOutput, SerializedBundle, VirtualJSOutput } from './utils';
@@ -16,29 +15,50 @@ const SOURCE_MAP_COMMENT = '//# sourceMappingURL=';
 const DEBUG_ID_COMMENT = '//# debugId=';
 
 /**
- * This function will overwrite any existing custom serializer with default Expo and Sentry serializers.
+ * This config will overwrite any existing custom serializer with default Expo and Sentry serializers.
  *
  * To use custom serializers, use `createSentryMetroSerializer(customSerializer)` instead.
  */
-export function withSentryExpoSerializers(config: MetroConfig): MetroConfig {
-  const { withExpoSerializers } = loadExpoSerializersModule();
-
-  const sentryConfig = {
-    serializer: {
-      customSerializer: createSentryMetroSerializer(),
-    },
-  } as MetroConfig;
-
-  const finalConfig = mergeConfig(config, sentryConfig);
-  return withExpoSerializers(finalConfig);
+export function getSentryExpoConfig(projectRoot: string): MetroConfig {
+  const { getDefaultConfig } = loadExpoMetroConfigModule();
+  return getDefaultConfig(projectRoot, {unstable_beforeAssetSerializationPlugins: [unstable_beforeAssetSerializationPlugin]});
 }
 
-function loadExpoSerializersModule(): {
-  withExpoSerializers: (config: MetroConfig) => MetroConfig;
+function unstable_beforeAssetSerializationPlugin({graph, premodules, debugId}: {
+  graph: ReadOnlyGraph<MixedOutput>;
+  premodules: Module[];
+  debugId?: string;
+}) : Module[] {
+  if (graph.transformOptions.hot || !debugId) {
+    return premodules;
+  }
+
+  const debugIdModuleExists = premodules.findIndex(module => module.path === DEBUG_ID_MODULE_PATH) != -1;
+  if (debugIdModuleExists) {
+    // eslint-disable-next-line no-console
+    console.warn('Debug ID module found. Skipping Sentry Debug ID module...');
+    return premodules;
+  }
+
+  const debugIdModule = createDebugIdModule(debugId);
+  return [...addDebugIdModule(premodules, debugIdModule)];
+}
+
+function loadExpoMetroConfigModule(): {
+  getDefaultConfig: (
+    projectRoot: string,
+    options: {
+      unstable_beforeAssetSerializationPlugins?: ((serializationInput: {
+        graph: ReadOnlyGraph<MixedOutput>;
+        premodules: Module[];
+        debugId?: string;
+    }) => Module[])[];}
+  ) => MetroConfig;
 } {
   try {
+    // TODO: switch this back!
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('@expo/metro-config/build/serializer/withExpoSerializers');
+    return require('/Users/quin/Documents/expo/packages/@expo/metro-config/build/ExpoMetroConfig');
   } catch (e) {
     throw new Error(
       'Unable to load `withExpoSerializers` from `@expo/metro-config`. Make sure you have Expo installed.',

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -15,9 +15,7 @@ const SOURCE_MAP_COMMENT = '//# sourceMappingURL=';
 const DEBUG_ID_COMMENT = '//# debugId=';
 
 /**
- * This config will overwrite any existing custom serializer with default Expo and Sentry serializers.
- *
- * To use custom serializers, use `createSentryMetroSerializer(customSerializer)` instead.
+ * This function returns Default Expo configuration with Sentry plugins.
  */
 export function getSentryExpoConfig(projectRoot: string): MetroConfig {
   const { getDefaultConfig } = loadExpoMetroConfigModule();

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -57,7 +57,7 @@ function loadExpoMetroConfigModule(): {
 } {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('@expo/metro-config');
+    return require('expo/metro-config');
   } catch (e) {
     throw new Error(
       'Unable to load `withExpoSerializers` from `@expo/metro-config`. Make sure you have Expo installed.',


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This PR adds support to inject a debug module before serialization for Expo projects, since expo has a custom serialization process. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In order to provide a good user experience, people can declare their `metro.config.js` like so:
``` js
// metro.config.js
const {
  getSentryExpoConfig,
} = require("/Users/quin/Documents/sentry-react-native/dist/js/tools/sentryMetroSerializer");

const config = getSentryExpoConfig(__dirname);
module.exports = config;
```


## :green_heart: How did you test it?
- Changed all the `requires` to point to the working directories of `sentry-react-native` with this change and `@expo/metro-config` with the changes of https://github.com/expo/expo/pull/25859
- Manually changed the `@expo/metro-config` source code to dump the `js` bundle to disk
- Ran `expo export --output-dir dist --dump-sourcemap`
- Confirm the sentry module is added to the `js` bundle with the passed `debugId`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
