### PR TITLE
Fix remove route params, as they may leak PII data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Stop sending navigation route params for auto-generated transactions, as they may contain PII or other sensitive data ([#3487](https://github.com/getsentry/sentry-react-native/pull/3487))
-  - Further details and other strategies to mitigate this issue can be found on our (trouble shooting guide page)[https://docs.sentry.io/platforms/react-native/troubleshooting/#routing-transaction-data-contains-sensitive-information]
+  - Further details and other strategies to mitigate this issue can be found on our [trouble shooting guide page](https://docs.sentry.io/platforms/react-native/troubleshooting/#routing-transaction-data-contains-sensitive-information)
 
 ## 5.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix leaking route params, as they may contain PII data ([#3487](https://github.com/getsentry/sentry-react-native/pull/3487))
+
 ## 5.15.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- Fix leaking route params, as they may contain PII data ([#3487](https://github.com/getsentry/sentry-react-native/pull/3487))
+- Stop sending navigation route params for auto-generated transactions, as they may contain PII or other sensitive data ([#3487](https://github.com/getsentry/sentry-react-native/pull/3487))
+  - Further details and other strategies to mitigate this issue can be found on our (trouble shooting guide page)[https://docs.sentry.io/platforms/react-native/troubleshooting/#routing-transaction-data-contains-sensitive-information]
 
 ## 5.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### Fixes
 
 - Sentry CLI upgrade resolves Xcode Could timeout during source maps upload [#3390](https://github.com/getsentry/sentry-react-native/pull/3390)
-- Fix leaking route params, as they may contain PII data ([#3487](https://github.com/getsentry/sentry-react-native/pull/3487))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Sentry CLI upgrade resolves Xcode Could timeout during source maps upload [#3390](https://github.com/getsentry/sentry-react-native/pull/3390)
+- Fix leaking route params, as they may contain PII data ([#3487](https://github.com/getsentry/sentry-react-native/pull/3487))
 
 ### Dependencies
 

--- a/src/js/tracing/reactnavigation.ts
+++ b/src/js/tracing/reactnavigation.ts
@@ -196,14 +196,16 @@ export class ReactNavigationInstrumentation extends InternalRoutingInstrumentati
             route: {
               name: route.name,
               key: route.key,
-              params: route.params ?? {},
+              // TODO: filter PII params instead of dropping them all
+              params: {},
               hasBeenSeen: routeHasBeenSeen,
             },
             previousRoute: previousRoute
               ? {
                   name: previousRoute.name,
                   key: previousRoute.key,
-                  params: previousRoute.params ?? {},
+                  // TODO: filter PII params instead of dropping them all
+                  params: {},
                 }
               : null,
           };

--- a/src/js/tracing/reactnavigationv4.ts
+++ b/src/js/tracing/reactnavigationv4.ts
@@ -264,14 +264,16 @@ class ReactNavigationV4Instrumentation extends InternalRoutingInstrumentation {
       route: {
         name: route.routeName, // Include name here too for use in `beforeNavigate`
         key: route.key,
-        params: route.params ?? {},
+        // TODO: filter PII params instead of dropping them all
+        params: {},
         hasBeenSeen: this._recentRouteKeys.includes(route.key),
       },
       previousRoute: previousRoute
         ? {
             name: previousRoute.routeName,
             key: previousRoute.key,
-            params: previousRoute.params ?? {},
+            // TODO: filter PII params instead of dropping them all
+            params: {},
           }
         : null,
     };

--- a/test/tracing/reactnavigation.test.ts
+++ b/test/tracing/reactnavigation.test.ts
@@ -123,7 +123,7 @@ describe('ReactNavigationInstrumentation', () => {
           route: {
             name: route.name,
             key: route.key,
-            params: route.params,
+            params: {}, // expect the data to be stripped
             hasBeenSeen: false,
           },
           previousRoute: {

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -119,7 +119,7 @@ describe('ReactNavigationV4Instrumentation', () => {
       route: {
         name: firstRoute.routeName,
         key: firstRoute.key,
-        params: {},
+        params: {}, // expect the data to be stripped
         hasBeenSeen: false,
       },
       previousRoute: null,
@@ -169,13 +169,13 @@ describe('ReactNavigationV4Instrumentation', () => {
         route: {
           name: action.routeName,
           key: action.key,
-          params: {},
+          params: {}, // expect the data to be stripped
           hasBeenSeen: false,
         },
         previousRoute: {
           name: 'Initial Route',
           key: 'route0',
-          params: {},
+          params: {}, // expect the data to be stripped
         },
       },
     });
@@ -228,13 +228,13 @@ describe('ReactNavigationV4Instrumentation', () => {
         route: {
           name: action.routeName,
           key: action.key,
-          params: {},
+          params: {}, // expect the data to be stripped
           hasBeenSeen: false,
         },
         previousRoute: {
           name: 'Initial Route',
           key: 'route0',
-          params: {},
+          params: {}, // expect the data to be stripped
         },
       },
       sampled: false,

--- a/test/tracing/reactnavigationv4.test.ts
+++ b/test/tracing/reactnavigationv4.test.ts
@@ -119,7 +119,7 @@ describe('ReactNavigationV4Instrumentation', () => {
       route: {
         name: firstRoute.routeName,
         key: firstRoute.key,
-        params: firstRoute.params,
+        params: {},
         hasBeenSeen: false,
       },
       previousRoute: null,
@@ -169,15 +169,13 @@ describe('ReactNavigationV4Instrumentation', () => {
         route: {
           name: action.routeName,
           key: action.key,
-          params: action.params,
+          params: {},
           hasBeenSeen: false,
         },
         previousRoute: {
           name: 'Initial Route',
           key: 'route0',
-          params: {
-            hello: true,
-          },
+          params: {},
         },
       },
     });
@@ -230,15 +228,13 @@ describe('ReactNavigationV4Instrumentation', () => {
         route: {
           name: action.routeName,
           key: action.key,
-          params: action.params,
+          params: {},
           hasBeenSeen: false,
         },
         previousRoute: {
           name: 'Initial Route',
           key: 'route0',
-          params: {
-            hello: true,
-          },
+          params: {},
         },
       },
       sampled: false,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
We collect the RN navigation route params in the trace context:
 *  `contexts.trace.data.route.params`
 *  `contexts.trace.data.previousRoute.params`
 
But as the params may contain PII, and the data bag isn't scrubbed server side, sensitive data may leak.
This bugfix PR simply ensures `params` are not collected and an empty map is used instead.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
