### PR TITLE
chore(internal): Use new DSN after leaked token

### DIFF
--- a/samples/react-native/src/dsn.ts
+++ b/samples/react-native/src/dsn.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react-native';
 
 export const SENTRY_INTERNAL_DSN =
-  'https://d870ad989e7046a8b9715a57f59b23b5@o447951.ingest.sentry.io/5428561';
+  'https://1df17bd4e543fdb31351dee1768bb679@o447951.ingest.sentry.io/5428561';
 
 export const getCurrentDsn = () => {
   return Sentry.getCurrentHub().getClient()?.getOptions().dsn;

--- a/test/perf/TestAppSentry/App.js
+++ b/test/perf/TestAppSentry/App.js
@@ -29,7 +29,7 @@ import {
 import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
-  dsn: 'https://d870ad989e7046a8b9715a57f59b23b5@o447951.ingest.sentry.io/5428561',
+  dsn: 'https://1df17bd4e543fdb31351dee1768bb679@o447951.ingest.sentry.io/5428561',
 });
 
 const Section = ({children, title}): Node => {

--- a/test/react-native/rn.patch.app.js
+++ b/test/react-native/rn.patch.app.js
@@ -25,7 +25,7 @@ import { EndToEndTestsScreen } from 'sentry-react-native-e2e-tests';
 Sentry.init({
   release: '${SENTRY_RELEASE}',
   dist: '${SENTRY_DIST}',
-  dsn: 'https://d870ad989e7046a8b9715a57f59b23b5@o447951.ingest.sentry.io/5428561',
+  dsn: 'https://1df17bd4e543fdb31351dee1768bb679@o447951.ingest.sentry.io/5428561',
 });
 `;
 const e2eComponentPatch = '<EndToEndTestsScreen />';


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The previous DSN was disabled due to a leaked access token.

## :green_heart: How did you test it?
ci/sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 