### PR TITLE
Dont use static path to react native in xcode debug files script.

### DIFF
--- a/scripts/sentry-xcode-debug-files.sh
+++ b/scripts/sentry-xcode-debug-files.sh
@@ -6,7 +6,12 @@
 set -x -e
 
 # load envs if loader file exists (since rn 0.68)
-WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+nodePath="node"
+if [[ -n "$NODE_BINARY" ]]; then
+  nodePath="$NODE_BINARY"
+fi
+[ -z "$WITH_ENVIRONMENT" ] && REACT_NATIVE_PACKAGE_PATH=$("$nodePath" --print "require.resolve('react-native/package.json')")
+[ -z "$WITH_ENVIRONMENT" ] && WITH_ENVIRONMENT="${REACT_NATIVE_PACKAGE_PATH}/scripts/xcode/with-environment.sh"
 if [ -f "$WITH_ENVIRONMENT" ]; then
     . "$WITH_ENVIRONMENT"
 fi


### PR DESCRIPTION

## :loudspeaker: Type of change
- [x] Bugfix


## :scroll: Description
Issue: https://github.com/getsentry/sentry-react-native/issues/3490 
The script `sentry-xcode-debug-files.sh` refers to `WITH_ENVIRONMENT` with a static path. (unsure if static is the correct word here)
So in a monorepo for example, the path is not correct.
All other environment variables I have needed to change are configurable or dynamic. 

So update this one also to be dynamic, with a lookup like is done some other places in this respository and with help from issue comment!

## :green_heart: How did you test it?
* Tested in own monorepo. 

## :pencil: Checklist
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes (I think so)
