### PR TITLE
fix(expo): Fix expo upload source maps script lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,7 @@ module.exports = {
       // Scripts
       files: ['scripts/*'],
       parserOptions: {
-        ecmaVersion: 2015,
+        ecmaVersion: 2018,
       },
       rules: {
         'no-console': 'off',

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const { stderr } = require('process');
+const process = require('process');
 
 const SENTRY_PROJECT = 'SENTRY_PROJECT';
 // The sentry org is inferred from the auth token
@@ -113,7 +113,7 @@ if (!sentryProject) {
   }
   if (!pluginConfig.project) {
     console.error(
-      "Could not resolve sentry project, set it in the environment variable SENTRY_PROJECT or in the '@sentry/react-native' plugin properties in your expo config.",
+      `Could not resolve sentry project, set it in the environment variable ${SENTRY_PROJECT} or in the '@sentry/react-native' plugin properties in your expo config.`,
     );
     process.exit(1);
   }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The lint parsing was failing due to use newer ecmascript features.

I checked https://node.green/#ES2018 we can safely bump to 2018 in the scripts as the oldest node version used is 16, which is required for RN 0.65, which is the currently oldest supported version by the Sentry RN SDK.

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 