### PR TITLE
dependabot: configure to use groups for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  ignore:
-    - dependency-name: "@sentry*"
-- package-ecosystem: gradle
-  directory: "/android"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0 # security updates only
+    groups:
+      # The name of the group, it will be used in PR titles and branch
+      babel-dependencies:
+        patterns:
+          - '@babel/*'
+      react-native-deps:
+        patterns:
+          - '@react-native/*'
+      typescript-eslint-deps:
+        patterns:
+          - '@typescript-eslint/*'
+    ignore:
+      - dependency-name: '@sentry*'
+  - package-ecosystem: gradle
+    directory: '/android'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
       interval: weekly


### PR DESCRIPTION
#skip-changelog

Configure Dependabot to:

- Only open security update PRs.
- Group dependencies where necessary to keep versions aligned and reduce Dependabot spam. 
