### PR TITLE
feat(expo): Add `npx sentry-expo-upload-sourcemaps` command

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,7 @@
 !scripts/sentry-xcode.sh
 !scripts/sentry-xcode-debug-files.sh
 !scripts/sentry_utils.rb
+!scripts/expo-upload-sourcemaps.js
 
 # Metro
 !/metro.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@ This release is compatible with `expo@50.0.0-preview.6` and newer.
   const config = getSentryExpoConfig(config);
   ```
 
-- Add `scripts/expo-upload-sourcemaps.js` for simple EAS Update (expo export) source maps upload to Sentry ([#3491](https://github.com/getsentry/sentry-react-native/pull/3491))
+- Add `npx sentry-expo-upload-sourcemaps` for simple EAS Update (expo export) source maps upload to Sentry ([#3491](https://github.com/getsentry/sentry-react-native/pull/3491), [#3510](https://github.com/getsentry/sentry-react-native/pull/3510))
 
   ```bash
   SENTRY_PROJECT=project-slug \
   SENTRY_ORG=org-slug \
   SENTRY_AUTH_TOKEN=super-secret-token \
-  node node_modules/@sentry/react-native/scripts/expo-upload-sourcemaps.js dist
+  npx sentry-expo-upload-sourcemaps dist
   ```
 
 - Sentry CLI binary path in `scripts/expo-upload-sourcemaps.js` is resolved dynamically ([#3507](https://github.com/getsentry/sentry-react-native/pull/3507))

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "run-android": "cd samples/react-native && yarn react-native run-android",
     "yalc:add:sentry-javascript": "yalc add @sentry/browser @sentry/core @sentry/hub @sentry/integrations @sentry/react @sentry/types @sentry/utils"
   },
+  "bin": {
+    "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+  },
   "keywords": [
     "react-native",
     "sentry",

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes the missing script file in the published package. And adds `npx` command for simple execution of the upload script.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
