### PR TITLE
chore(ci): Use ubuntu-latest runners everywhere possible

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           java-version: '17'
           distribution: "adopt"
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
       - uses: actions/cache@v3
         id: cache
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -427,17 +427,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup KVM
-        shell: bash
-        run: |
-          # check if virtualization is supported...
-          sudo apt install -y --no-install-recommends cpu-checker coreutils && echo "CPUs=$(nproc --all)" && kvm-ok
-          # allow access to KVM to run the emulator
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
       - name: Setup Global Xcode Tools
         if: ${{ matrix.platform == 'ios' }}
         run: brew install xcbeautify
@@ -467,6 +456,18 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+
+      - name: Setup KVM
+        if: ${{ matrix.platform == 'android' }}
+        shell: bash
+        run: |
+          # check if virtualization is supported...
+          sudo apt install -y --no-install-recommends cpu-checker coreutils && echo "CPUs=$(nproc --all)" && kvm-ok
+          # allow access to KVM to run the emulator
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: NPM cache E2E Tests Library
         uses: actions/cache@v3
@@ -517,10 +518,15 @@ jobs:
         uses: reactivecircus/android-emulator-runner@50986b1464923454c95e261820bc626f38490ec0 # pin@v2
         with:
           working-directory: test/e2e
-          api-level: 29
+          api-level: 30
+          force-avd-creation: false
+          disable-animations: true
+          disable-spellchecker: true
+          target: 'aosp_atd'
+          channel: canary # Necessary for ATDs
           emulator-options: >
-            -accel on
-            -no-snapshot
+            -no-window
+            -no-snapshot-save
             -gpu swiftshader_indirect
             -noaudio
             -no-boot-anim

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,7 +153,7 @@ jobs:
         rn-version: ['0.65.3', '0.73.2']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
-        build-type: ['dev', 'production']
+        build-type: ['production']
         ios-use-frameworks: ['no', 'static', 'dynamic']
         engine: ['hermes', 'jsc']
         include:
@@ -165,7 +165,7 @@ jobs:
             runs-on: ubuntu-latest
         exclude:
           # exclude JSC for new RN versions (keeping the matrix manageable)
-          - rn-version: '0.72.4'
+          - rn-version: '0.73.2'
             engine: 'jsc'
           # exclude all rn versions lower than 0.70.0 for new architecture
           - rn-version: '0.65.3'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -223,7 +223,10 @@ jobs:
       - name: Setup Global Tools
         run: |
           yarn global add yalc semver
-          brew install xcbeautify
+
+      - name: Setup Global Xcode Tools
+        if: ${{ matrix.platform == 'ios' }}
+        run: brew install xcbeautify
 
       - name: NPM cache SDK
         uses: actions/cache@v3
@@ -435,7 +438,8 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Setup Global Tools
+      - name: Setup Global Xcode Tools
+        if: ${{ matrix.platform == 'ios' }}
         run: brew install xcbeautify
 
       - name: Download App Package

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -419,7 +419,7 @@ jobs:
           # e2e test only the default combinations
           - rn-version: '0.65.3'
             engine: 'hermes'
-          - rn-version: '0.72.4'
+          - rn-version: '0.73.2'
             engine: 'jsc'
     env:
       PLATFORM: ${{ matrix.platform }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
           access_token: ${{ github.token }}
 
   metrics:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       # we want that the matrix keeps running, default is to cancel them if it fails.
       fail-fast: false
@@ -31,9 +31,11 @@ jobs:
         platform: ["ios", "android"]
         include:
           - platform: ios
+            runs-on: macos-latest
             name: iOS
             appPlain: test/perf/test-app-plain.ipa
           - platform: android
+            runs-on: ubuntu-latest
             name: Android
             appPlain: test/perf/TestAppPlain/android/app/build/outputs/apk/release/app-release.apk
     steps:
@@ -141,7 +143,7 @@ jobs:
 
   react-native-build:
     name: Build RN ${{ matrix.rn-version }} ${{ matrix.rn-architecture }} ${{ matrix.engine }} ${{ matrix.platform }} ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
     env:
       RN_SENTRY_POD_NAME: RNSentry
       RN_DIFF_REPOSITORY: https://github.com/react-native-community/rn-diff-purge.git
@@ -156,8 +158,11 @@ jobs:
         engine: ['hermes', 'jsc']
         include:
           - platform: ios
+            runs-on: macos-latest
             runtime: 'latest'
             device: 'iPhone 14'
+          - platform: android
+            runs-on: ubuntu-latest
         exclude:
           # exclude JSC for new RN versions (keeping the matrix manageable)
           - rn-version: '0.72.4'
@@ -387,7 +392,7 @@ jobs:
   react-native-test:
     name: Test RN ${{ matrix.rn-version }} ${{ matrix.rn-architecture }} ${{ matrix.engine }} ${{ matrix.platform }} ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }}
     needs: react-native-build
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
@@ -399,8 +404,11 @@ jobs:
         engine: ['hermes', 'jsc']
         include:
           - platform: ios
+            runs-on: macos-latest
             runtime: 'latest'
             device: 'iPhone 14'
+          - platform: android
+            runs-on: ubuntu-latest
         exclude:
           # exclude all rn versions lower than 0.70.0 for new architecture
           - rn-version: '0.65.3'
@@ -415,6 +423,17 @@ jobs:
       DEVICE: ${{ matrix.device }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup KVM
+        shell: bash
+        run: |
+          # check if virtualization is supported...
+          sudo apt install -y --no-install-recommends cpu-checker coreutils && echo "CPUs=$(nproc --all)" && kvm-ok
+          # allow access to KVM to run the emulator
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Setup Global Tools
         run: brew install xcbeautify

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,6 +47,8 @@ jobs:
         with:
           java-version: '17'
           distribution: "adopt"
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
       - name: Install Global Dependencies
         run: yarn global add react-native-cli @sentry/cli yalc
       - uses: actions/cache@v3
@@ -219,6 +221,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
 
       - name: Setup Global Tools
         run: |
@@ -456,6 +461,9 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
 
       - name: Setup KVM
         if: ${{ matrix.platform == 'android' }}

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -62,6 +62,17 @@ jobs:
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
+      - name: Setup KVM
+        shell: bash
+        run: |
+          # check if virtualization is supported...
+          sudo apt install -y --no-install-recommends cpu-checker coreutils && echo "CPUs=$(nproc --all)" && kvm-ok
+          # allow access to KVM to run the emulator
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: AVD cache
         uses: actions/cache@v3
         id: avd-cache
@@ -69,47 +80,48 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-21
+          key: avd-aosp-atd-30
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
         with:
-          api-level: 21
+          api-level: 30
+          force-avd-creation: false
+          disable-animations: true
+          disable-spellchecker: true
+          target: 'aosp_atd'
+          channel: canary # Necessary for ATDs
           emulator-options: >
-            -accel on
             -no-window
+            -no-snapshot-save
             -gpu swiftshader_indirect
             -noaudio
             -no-boot-anim
             -camera-back none
             -camera-front none
             -timezone US/Pacific
-          force-avd-creation: false
-          disable-animations: true
-          arch: x86_64
-          profile: Nexus 6
           script: echo "Generated AVD snapshot for caching."
 
       - name: Run connected tests
         uses: reactivecircus/android-emulator-runner@d94c3fbe4fe6a29e4a5ba47c12fb47677c73656b #pin@v2.28.0
         with:
           working-directory: RNSentryAndroidTester
-          api-level: 21
+          api-level: 30
+          force-avd-creation: false
+          disable-animations: true
+          disable-spellchecker: true
+          target: 'aosp_atd'
+          channel: canary # Necessary for ATDs
           emulator-options: >
-            -no-snapshot-save
-            -accel on
             -no-window
+            -no-snapshot-save
             -gpu swiftshader_indirect
             -noaudio
             -no-boot-anim
             -camera-back none
             -camera-front none
             -timezone US/Pacific
-          force-avd-creation: false
-          disable-animations: true
-          arch: x86_64
-          profile: Nexus 6
           script: |
             ./gradlew uninstallDebug uninstallDebugAndroidTest
             ./gradlew connectedCheck

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -54,6 +54,9 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+
       - name: Setup Global Xcode Tools
         if: ${{ matrix.platform == 'ios' }}
         run: brew install xcbeautify

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -54,7 +54,8 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
 
-      - name: Install Global Dependencies
+      - name: Setup Global Xcode Tools
+        if: ${{ matrix.platform == 'ios' }}
         run: brew install xcbeautify
 
       - name: NPM cache

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -65,7 +65,7 @@ jobs:
           path: |
             node_modules
             samples/react-native/node_modules
-          key: ${{ github.workflow }}-${{ github.job }}-npm-${{ hashFiles('yarn.lock', 'samples/react-native/yarn.lock') }}
+          key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-npm-${{ hashFiles('yarn.lock', 'samples/react-native/yarn.lock') }}
 
       - name: Install SDK Dependencies
         if: ${{ steps.deps-cache.outputs['cache-hit'] != 'true' }}

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -24,8 +24,7 @@ jobs:
 
   build:
     name: Build ${{ matrix.rn-architecture }} ${{ matrix.platform }} ${{ matrix.build-type }}
-    # Android emulator said to perform best with macos HAXM
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       # we want that the matrix keeps running, default is to cancel them if it fails.
       fail-fast: false
@@ -35,8 +34,11 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
+            runs-on: macos-latest
             runtime: 'latest'
             device: 'iPhone 14'
+          - platform: android
+            runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
ONLY CI CHANGES

This PR switches to `ubuntu-latest` runners everywhere possible, all Android and platform-independent jobs.

`macos-latest` runners stay only for ios jobs.

Android builds are ~3x faster from ~11 min to ~4 mins.

All android simulators are using ATD images and KVM -> native test from ~8 mins to ~2.

This PR fixes the extra E2E JSC tests on the latest RN that were enabled by mistake.

This PR removes the E2E development builds to lower the number of jobs so the CI is not blocked by the macos runners' smaller pool.

- part of https://github.com/getsentry/sentry-react-native/issues/3419

#skip-changelog 