### PR TITLE
chore(ci): Temporarily disable new arch E2E test on ios

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -410,6 +410,10 @@ jobs:
             engine: 'hermes'
           - rn-version: '0.72.4'
             engine: 'jsc'
+          # E2E timeout due to a race condition https://github.com/facebook/react-native/issues/42123#issuecomment-1881203719
+          - rn-version: '0.73.2'
+            platform: 'ios'
+            rn-architecture: 'new'
     env:
       PLATFORM: ${{ matrix.platform }}
       DEVICE: ${{ matrix.device }}


### PR DESCRIPTION
E2E on RN 0.73.0,1,2 New Architecture on iOS timeout due to race condition in the RN framework.

- More details https://github.com/facebook/react-native/issues/42123#issuecomment-1881203719

This PR disables the tests.

#skip-changelog 