### PR TITLE
fix(expo): Make `getSentryExpoConfig` options param optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Make `getSentryExpoConfig` options parameter optional ([#3514](https://github.com/getsentry/sentry-react-native/pull/3514))
+
 ## 5.16.0-alpha.3
 
 This release is compatible with `expo@50.0.0-preview.6` and newer.
@@ -12,7 +18,7 @@ This release is compatible with `expo@50.0.0-preview.6` and newer.
 
   ```js
   const { getSentryExpoConfig } = require("@sentry/react-native/metro");
-  const config = getSentryExpoConfig(config);
+  const config = getSentryExpoConfig(config, {});
   ```
 
 - Add `npx sentry-expo-upload-sourcemaps` for simple EAS Update (expo export) source maps upload to Sentry ([#3491](https://github.com/getsentry/sentry-react-native/pull/3491), [#3510](https://github.com/getsentry/sentry-react-native/pull/3510))

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -18,7 +18,7 @@ const DEBUG_ID_COMMENT = '//# debugId=';
 /**
  * This function returns Default Expo configuration with Sentry plugins.
  */
-export function getSentryExpoConfig(projectRoot: string, options: DefaultConfigOptions): MetroConfig {
+export function getSentryExpoConfig(projectRoot: string, options: DefaultConfigOptions = {}): MetroConfig {
   const { getDefaultConfig } = loadExpoMetroConfigModule();
   return getDefaultConfig(projectRoot, {
     ...options,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Options object is optional in the original Expo function.

https://github.com/expo/expo/blob/0060551c471b3c63af68cbd94db7fb3bae3e17e2/packages/%40expo/metro-config/src/ExpoMetroConfig.ts#L106

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
