### PR TITLE
fix(expo): Use `@sentry/react-native/expo` as plugin name in expo upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use `@sentry/react-native/expo` as plugin name in `expo-upload-sourcemaps.js` ([#3515](https://github.com/getsentry/sentry-react-native/pull/3515))
+
 ## 5.16.0-alpha.3
 
 This release is compatible with `expo@50.0.0-preview.6` and newer.

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -27,7 +27,7 @@ function getSentryPluginPropertiesFromExpoConfig() {
         return false;
       }
       const [pluginName] = plugin;
-      return pluginName === '@sentry/react-native';
+      return pluginName === '@sentry/react-native/expo';
     });
 
     if (!sentryPlugin) {


### PR DESCRIPTION
Although the previous option also works,
we promote in all docs and previous messages/changelogs the `/expo` export, so we should use it here too.