### PR TITLE
fix: errors from InternalBytecode.js are no longer marked as in_app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Errors from InternalBytecode.js are no longer marked as in_app ([#3518](https://github.com/getsentry/sentry-react-native/pull/3518))
+
 ## 5.15.2
 
 ### Fixes

--- a/src/js/integrations/rewriteframes.ts
+++ b/src/js/integrations/rewriteframes.ts
@@ -60,7 +60,8 @@ export function createReactNativeRewriteFrames(): RewriteFrames {
       // https://github.com/getsentry/sentry-react-native/issues/3348
       if (frame.filename === '/InternalBytecode.js') {
         frame.in_app = false;
-      }      // We always want to have a triple slash
+      }
+      // We always want to have a triple slash
       frame.filename =
         frame.filename.indexOf('/') === 0 ? `${appPrefix}${frame.filename}` : `${appPrefix}/${frame.filename}`;
       return frame;

--- a/src/js/integrations/rewriteframes.ts
+++ b/src/js/integrations/rewriteframes.ts
@@ -57,7 +57,10 @@ export function createReactNativeRewriteFrames(): RewriteFrames {
       }
 
       const appPrefix = 'app://';
-      // We always want to have a triple slash
+      // https://github.com/getsentry/sentry-react-native/issues/3348
+      if (frame.filename === '/InternalBytecode.js') {
+        frame.in_app = false;
+      }      // We always want to have a triple slash
       frame.filename =
         frame.filename.indexOf('/') === 0 ? `${appPrefix}${frame.filename}` : `${appPrefix}/${frame.filename}`;
       return frame;

--- a/test/integrations/rewriteframes.test.ts
+++ b/test/integrations/rewriteframes.test.ts
@@ -863,14 +863,14 @@ describe('RewriteFrames', () => {
   it('InternalBytecode should be flaged as not InApp', async () => {
     mockFunction(isHermesEnabled).mockReturnValue(true);
 
-    const ANDROID_REACT_NATIVE_HERMES = {
+    const IOS_REACT_NATIVE_HERMES = {
       message: 'Error: lets throw!',
       name: 'Error',
       stack:
         'at anonymous (/Users/username/react-native/sdks/hermes/build_iphonesimulator/lib/InternalBytecode/InternalBytecode.js:139:27)',
     };
 
-    const exception = await exceptionFromError(ANDROID_REACT_NATIVE_HERMES);
+    const exception = await exceptionFromError(IOS_REACT_NATIVE_HERMES);
 
     expect(exception).toEqual({
       value: 'Error: lets throw!',

--- a/test/integrations/rewriteframes.test.ts
+++ b/test/integrations/rewriteframes.test.ts
@@ -859,4 +859,37 @@ describe('RewriteFrames', () => {
       },
     });
   });
+
+  it('InternalBytecode should be flaged as not InApp', async () => {
+    mockFunction(isHermesEnabled).mockReturnValue(true);
+
+    const ANDROID_REACT_NATIVE_HERMES = {
+      message: 'Error: lets throw!',
+      name: 'Error',
+      stack:
+        'at anonymous (/Users/username/react-native/sdks/hermes/build_iphonesimulator/lib/InternalBytecode/InternalBytecode.js:139:27)'
+    };
+
+    const exception = await exceptionFromError(ANDROID_REACT_NATIVE_HERMES);
+
+    expect(exception).toEqual({
+      value: 'Error: lets throw!',
+      type: 'Error',
+      mechanism: {
+        handled: true,
+        type: 'generic',
+      },
+      stacktrace: {
+        frames: [
+          {
+            filename: 'app:///InternalBytecode.js',
+            function: 'anonymous',
+            lineno: 139,
+            colno: 27,
+            in_app: false,
+          },
+        ],
+      },
+    });
+  });
 });

--- a/test/integrations/rewriteframes.test.ts
+++ b/test/integrations/rewriteframes.test.ts
@@ -867,7 +867,7 @@ describe('RewriteFrames', () => {
       message: 'Error: lets throw!',
       name: 'Error',
       stack:
-        'at anonymous (/Users/username/react-native/sdks/hermes/build_iphonesimulator/lib/InternalBytecode/InternalBytecode.js:139:27)'
+        'at anonymous (/Users/username/react-native/sdks/hermes/build_iphonesimulator/lib/InternalBytecode/InternalBytecode.js:139:27)',
     };
 
     const exception = await exceptionFromError(ANDROID_REACT_NATIVE_HERMES);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

By default InternalBytecode is marked as inApp but in reality it's an generated file outside of the user code so it should be flagged as  false.

closes #3348

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

I haven't found in time an error that could be reproduced so instead, I retrieved from the internet the raw Stack Trace with users that had errors with the `InternalBytecode`, made a test with it and then I fixed the `rewriteStackFrame` in order to pass the test. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
