### PR TITLE
fix(xcode): node can't be overwritten in `sentry-xcode-debug-files.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ see [the Expo guide](https://docs.sentry.io/platforms/react-native/manual-setup/
 - Remove Native Modules warning from platform where the absence is expected ([#3466](https://github.com/getsentry/sentry-react-native/pull/3466))
 - Add Expo Context information using Expo Native Modules ([#3466](https://github.com/getsentry/sentry-react-native/pull/3466))
 - Errors from InternalBytecode.js are no longer marked as in_app ([#3518](https://github.com/getsentry/sentry-react-native/pull/3518))
+- Fix system node can't be overwritten in `sentry-xcode-debug-files.sh` ([#3523](https://github.com/getsentry/sentry-react-native/pull/3523))
 
 ## 5.16.0-alpha.4
 

--- a/scripts/sentry-xcode-debug-files.sh
+++ b/scripts/sentry-xcode-debug-files.sh
@@ -5,13 +5,13 @@
 # print commands before executing them and stop on first error
 set -x -e
 
-LOCAL_NODE_BINARY=${NODE_BINARY:-node}
-
 # load envs if loader file exists (since rn 0.68)
 WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 if [ -f "$WITH_ENVIRONMENT" ]; then
     . "$WITH_ENVIRONMENT"
 fi
+
+LOCAL_NODE_BINARY=${NODE_BINARY:-node}
 
 [ -z "$SENTRY_PROPERTIES" ] && export SENTRY_PROPERTIES=sentry.properties
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Before this PR the `$NODE_BINARY` could not be overwritten from the `with_enviroment` script. But only by explicitly setting the `$NODE_BINARY` env before the build. In new RN versions setting it with in the env script is common.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
