### PR TITLE
fix(ci): Use node action yarn cache instead of node modules

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -42,6 +42,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            samples/react-native/yarn.lock
+
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'ios' }}
         with:
@@ -61,26 +69,15 @@ jobs:
         if: ${{ matrix.platform == 'ios' }}
         run: brew install xcbeautify
 
-      - name: NPM cache
-        uses: actions/cache@v3
-        id: deps-cache
-        with:
-          path: |
-            node_modules
-            samples/react-native/node_modules
-          key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-npm-${{ hashFiles('yarn.lock', 'samples/react-native/yarn.lock') }}
-
       - name: Install SDK Dependencies
-        if: ${{ steps.deps-cache.outputs['cache-hit'] != 'true' }}
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Build SDK
         run: yarn build
 
       - name: Install Sample Dependencies
-        if: ${{ steps.deps-cache.outputs['cache-hit'] != 'true' }}
         working-directory: samples/react-native
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Install App Pods
         if: ${{ matrix.platform == 'ios' }}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The cached `node_modules` caused the new architecture builds to fail.

This PR uses the node setup action cache instead.

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 