### PR TITLE
fix: Auto add release and dist to every artifact upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Sentry CLI 2.25.1 fixes background debug files uploads during Xcode builds ([#3486](https://github.com/getsentry/sentry-react-native/pull/3486))
 - Performance Tracing should be disabled by default ([#3533](https://github.com/getsentry/sentry-react-native/pull/3533))
 - Use `$NODE_BINARY` to execute Sentry CLI in Xcode scripts ([#3493](https://github.com/getsentry/sentry-react-native/pull/3493))
+- Return auto Release and Dist to source maps auto upload ([#3540](https://github.com/getsentry/sentry-react-native/pull/3540))
 
 ### Dependencies
 

--- a/scripts/sentry-xcode.sh
+++ b/scripts/sentry-xcode.sh
@@ -17,7 +17,7 @@ LOCAL_NODE_BINARY=${NODE_BINARY:-node}
 
 REACT_NATIVE_XCODE=$1
 
-[[ "$AUTO_RELEASE" != true ]] && [[ -z "$BUNDLE_COMMAND" || "$BUNDLE_COMMAND" != "ram-bundle" ]] && NO_AUTO_RELEASE="--no-auto-release"
+[[ "$AUTO_RELEASE" == false ]] && [[ -z "$BUNDLE_COMMAND" || "$BUNDLE_COMMAND" != "ram-bundle" ]] && NO_AUTO_RELEASE="--no-auto-release"
 ARGS="$NO_AUTO_RELEASE $SENTRY_CLI_EXTRA_ARGS $SENTRY_CLI_RN_XCODE_EXTRA_ARGS"
 
 REACT_NATIVE_XCODE_WITH_SENTRY="\"$SENTRY_CLI_EXECUTABLE\" react-native xcode $ARGS \"$REACT_NATIVE_XCODE\""

--- a/sentry.gradle
+++ b/sentry.gradle
@@ -130,10 +130,9 @@ gradle.projectsEvaluated {
                   def process = ["node", hasSourceMapDebugIdScript, sourcemapOutput].execute(null, new File("$reactRoot"))
                   def exitValue = process.waitFor()
                   project.logger.lifecycle("Check generated source map for Debug ID: ${process.text}")
-                  def notIncludeRelease = "$bundleCommand" == "bundle" && exitValue == 0
-                  def not = notIncludeRelease ? 'not ' : ''
-                  project.logger.lifecycle("Sentry Source Maps upload will ${not}include the release name and dist.")
-                  extraArgs.addAll(notIncludeRelease ? [] : [
+
+                  project.logger.lifecycle("Sentry Source Maps upload will include the release name and dist.")
+                  extraArgs.addAll([
                       "--release", releaseName,
                       "--dist", versionCode
                   ])


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
JS Bundlers Plugins do send the Release and Dist information regardless of the use of Debug IDs.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removal of the Release and Dist breaks compatibility with older Sentry versions without artifacts bundles support, so we will return it for a better user experience.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
