### PR TITLE
Prevent pod install crash when visionos is not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Prevent pod install crash when visionos is not present ([#3548](https://github.com/getsentry/sentry-react-native/pull/3548))
+
 ## 5.17.0
 
 ### Features

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "11.0"
   s.osx.deployment_target = "10.13"
   s.tvos.deployment_target = "11.0"
-  s.visionos.deployment_target = "1.0"
+  s.visionos.deployment_target = "1.0" if s.respond_to?(:visionos)
 
   s.preserve_paths = '*.js'
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Fixes #3547, builds were breaking due to a visionos change

## :bulb: Motivation and Context
#3547 

## :green_heart: How did you test it?
Tested against my project and my builds no longer break

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ x I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
