### PR TITLE
fix(expo): Fetch org from expo config in expo upload sourcemaps (#3556)

### DIFF
--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -4,8 +4,8 @@ const fs = require('fs');
 const path = require('path');
 const process = require('process');
 
+const SENTRY_ORG = 'SENTRY_ORG';
 const SENTRY_PROJECT = 'SENTRY_PROJECT';
-// The sentry org is inferred from the auth token
 const SENTRY_AUTH_TOKEN = 'SENTRY_AUTH_TOKEN';
 const SENTRY_CLI_EXECUTABLE = 'SENTRY_CLI_EXECUTABLE';
 
@@ -101,25 +101,42 @@ function groupAssets(assetPaths) {
   return groups;
 }
 
+let sentryOrg = getEnvVar(SENTRY_ORG);
 let sentryProject = getEnvVar(SENTRY_PROJECT);
 let authToken = getEnvVar(SENTRY_AUTH_TOKEN);
 const sentryCliBin = getEnvVar(SENTRY_CLI_EXECUTABLE) || require.resolve('@sentry/cli/bin/sentry-cli');
 
-if (!sentryProject) {
-  console.log(`🐕 Fetching ${SENTRY_PROJECT} from expo config...`);
+if (!sentryOrg || !sentryProject) {
+  console.log(`🐕 Fetching from expo config...`);
   const pluginConfig = getSentryPluginPropertiesFromExpoConfig();
   if (!pluginConfig) {
     console.error("Could not fetch '@sentry/react-native' plugin properties from expo config.");
     process.exit(1);
   }
-  if (!pluginConfig.project) {
-    console.error(
-      `Could not resolve sentry project, set it in the environment variable ${SENTRY_PROJECT} or in the '@sentry/react-native' plugin properties in your expo config.`,
-    );
-    process.exit(1);
+
+  if (!sentryOrg) {
+    if (!pluginConfig.organization) {
+      console.error(
+        `Could not resolve sentry org, set it in the environment variable ${SENTRY_ORG} or in the '@sentry/react-native' plugin properties in your expo config.`,
+      );
+      process.exit(1);
+    }
+
+    sentryOrg = pluginConfig.organization;
+    console.log(`${SENTRY_ORG} resolved to ${sentryOrg} from expo config.`);
   }
-  sentryProject = pluginConfig.project;
-  console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
+
+  if (!sentryProject) {
+    if (!pluginConfig.project) {
+      console.error(
+        `Could not resolve sentry project, set it in the environment variable ${SENTRY_PROJECT} or in the '@sentry/react-native' plugin properties in your expo config.`,
+      );
+      process.exit(1);
+    }
+
+    sentryProject = pluginConfig.project;
+    console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
+  }
 }
 
 if (!authToken) {
@@ -152,6 +169,7 @@ for (const [assetGroupName, assets] of Object.entries(groupedAssets)) {
     env: {
       ...process.env,
       [SENTRY_PROJECT]: sentryProject,
+      [SENTRY_ORG]: sentryOrg,
     },
     stdio: 'inherit',
   });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Allows the expo upload sourcemaps script to fetch the sentry org from the expo plugin configuration when not defined in env vars.


## :bulb: Motivation and Context

The [Expo documentation](https://docs.expo.dev/guides/using-sentry/#app-configuration) states to use the org slug or the environment variable but the upload script doesn't support both of these.

#3556


## :green_heart: How did you test it?

Manual testing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
