### PR TITLE
feat(expo): read .env file in upload script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   ```
 
 - Only upload Expo artifact if source map exists ([#3568](https://github.com/getsentry/sentry-react-native/pull/3568))
+- Read `.env` file in `sentry-expo-upload-sourcemaps` ([#3571](https://github.com/getsentry/sentry-react-native/pull/3571))
 
 ### Fixes
 

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -106,7 +106,7 @@ const projectRoot = '.'; // Assume script is run from the project root
 try {
   require('@expo/env').load(projectRoot);
 } catch (error) {
-  console.warn('⚠️ Failed to load environment variables from @expo/env.');
+  console.warn('⚠️ Failed to load environment variables using @expo/env.');
   console.warn(error);
 }
 

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -101,7 +101,6 @@ function groupAssets(assetPaths) {
   return groups;
 }
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 const projectRoot = '.'; // Assume script is run from the project root
 try {
   require('@expo/env').load(projectRoot);

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -101,6 +101,7 @@ function groupAssets(assetPaths) {
   return groups;
 }
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'; // Ensures precedence .env.development > .env (the same as @expo/cli)
 const projectRoot = '.'; // Assume script is run from the project root
 try {
   require('@expo/env').load(projectRoot);

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -101,6 +101,15 @@ function groupAssets(assetPaths) {
   return groups;
 }
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+const projectRoot = '.'; // Assume script is run from the project root
+try {
+  require('@expo/env').load(projectRoot);
+} catch (error) {
+  console.warn('⚠️ Failed to load environment variables from @expo/env.');
+  console.warn(error);
+}
+
 let sentryProject = getEnvVar(SENTRY_PROJECT);
 let authToken = getEnvVar(SENTRY_AUTH_TOKEN);
 const sentryCliBin = getEnvVar(SENTRY_CLI_EXECUTABLE) || require.resolve('@sentry/cli/bin/sentry-cli');


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Read from `.env` file if it exists in the user's project directory, based on https://github.com/getsentry/sentry-react-native/issues/3546#issuecomment-1911987720

Fixes https://github.com/getsentry/sentry-react-native/issues/3569

Most of the expo commands are of [this form](https://github.com/expo/expo/blob/97005b5a2528c2349e2c27d6d678f85e6f8eb754/packages/%40expo/cli/src/prebuild/prebuildAsync.ts#L65-L66): 
1. Set `NODE_ENV` to development if unset (unless if the command is `expo export`, where the metro bundler will output differently depending on NODE_ENV so we default it to production)
2. Read from `.env` file - `@expo/env` is a dependency of the `expo/cli` so we make a best effort to load it at runtime. 


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
test project

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
