### PR TITLE
fix(xcode): Upload Debug Symbols continues when `node` not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fetch Organization slug from `@sentry/react-native/expo` config when uploading artifacts ([#3557](https://github.com/getsentry/sentry-react-native/pull/3557))
 - Remove 404 Http Client Errors reports for Metro Dev Server Requests ([#3553](https://github.com/getsentry/sentry-react-native/pull/3553))
 - Stop tracing Spotlight Sidecar network request in JS ([#3559](https://github.com/getsentry/sentry-react-native/pull/3559))
+- Upload Debug Symbols Build Phase continues execution when `node` not found in `WITH_ENVIRONMENT` ([#3573](https://github.com/getsentry/sentry-react-native/pull/3573))
 
 ## 5.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Fetch Organization slug from `@sentry/react-native/expo` config when uploading artifacts ([#3557](https://github.com/getsentry/sentry-react-native/pull/3557))
 - Remove 404 Http Client Errors reports for Metro Dev Server Requests ([#3553](https://github.com/getsentry/sentry-react-native/pull/3553))
 - Stop tracing Spotlight Sidecar network request in JS ([#3559](https://github.com/getsentry/sentry-react-native/pull/3559))
-- Upload Debug Symbols Build Phase continues execution when `node` not found in `WITH_ENVIRONMENT` ([#3573](https://github.com/getsentry/sentry-react-native/pull/3573))
+- Upload Debug Symbols Build Phase continues when `node` not found in `WITH_ENVIRONMENT` ([#3573](https://github.com/getsentry/sentry-react-native/pull/3573))
 
 ## 5.17.0
 

--- a/scripts/sentry-xcode-debug-files.sh
+++ b/scripts/sentry-xcode-debug-files.sh
@@ -2,8 +2,8 @@
 # Upload Debug Symbols to Sentry Xcode Build Phase
 # PWD=ios
 
-# print commands before executing them and stop on first error
-set -x -e
+# print commands before executing them
+set -x
 
 [ -z "$WITH_ENVIRONMENT" ] && WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 
@@ -11,6 +11,9 @@ if [ -f "$WITH_ENVIRONMENT" ]; then
   # load envs if loader file exists (since rn 0.68)
   . "$WITH_ENVIRONMENT"
 fi
+
+# stop on first error (we can't use -e before as any failed command in WITH_ENVIRONMENT would stop the debug files upload)
+set -e
 
 LOCAL_NODE_BINARY=${NODE_BINARY:-node}
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
RN script `WITH_ENVIRONMENT` calls `NODE_BINARY=$(command -v node)` which return non-zero when the command doesn't exist. We have `-e` to exit after the first error, which causes the debug symbols to stop uploading.

This PR enables `-e` after loading `WITH_ENVIRONMENT` so no errors in the env stop debug symbols upload.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes https://github.com/getsentry/sentry-react-native/issues/3551

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
