### PR TITLE
chore(deps): update JavaScript SDK to v7.99.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -66,5 +66,6 @@ module.exports = {
     '@sentry-internal/sdk/no-nullish-coalescing': 'off',
     '@sentry-internal/sdk/no-unsupported-es6-methods': 'off',
     '@sentry-internal/sdk/no-class-field-initializers': 'off',
+    'deprecation/deprecation': 'off',
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@
 - Remove 404 Http Client Errors reports for Metro Dev Server Requests ([#3553](https://github.com/getsentry/sentry-react-native/pull/3553))
 - Stop tracing Spotlight Sidecar network request in JS ([#3559](https://github.com/getsentry/sentry-react-native/pull/3559))
 
+### Dependencies
+
+- Bump JavaScript SDK from v7.81.1 to v7.99.0 ([#3426](https://github.com/getsentry/sentry-react-native/pull/3426))
+  - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7990)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.81.1...7.99.0)
+
 ## 5.17.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This release contains upgrade of `sentry-android` dependency to major version 7.
 - Bump Android SDK from v6.34.0 to v7.3.0 ([#3434](https://github.com/getsentry/sentry-react-native/pull/3434))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#730)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.34.0...7.3.0)
+- Bump JavaScript SDK from v7.81.1 to v7.99.0 ([#3426](https://github.com/getsentry/sentry-react-native/pull/3426))
+  - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7990)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.81.1...7.99.0)
 
 ## 5.18.0
 
@@ -40,12 +43,6 @@ This release contains upgrade of `sentry-android` dependency to major version 7.
 - Fetch Organization slug from `@sentry/react-native/expo` config when uploading artifacts ([#3557](https://github.com/getsentry/sentry-react-native/pull/3557))
 - Remove 404 Http Client Errors reports for Metro Dev Server Requests ([#3553](https://github.com/getsentry/sentry-react-native/pull/3553))
 - Stop tracing Spotlight Sidecar network request in JS ([#3559](https://github.com/getsentry/sentry-react-native/pull/3559))
-
-### Dependencies
-
-- Bump JavaScript SDK from v7.81.1 to v7.99.0 ([#3426](https://github.com/getsentry/sentry-react-native/pull/3426))
-  - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7990)
-  - [diff](https://github.com/getsentry/sentry-javascript/compare/7.81.1...7.99.0)
 
 ## 5.17.0
 

--- a/package.json
+++ b/package.json
@@ -66,22 +66,22 @@
     "react-native": ">=0.65.0"
   },
   "dependencies": {
-    "@sentry/browser": "7.81.1",
+    "@sentry/browser": "7.99.0",
     "@sentry/cli": "2.25.2",
-    "@sentry/core": "7.81.1",
-    "@sentry/hub": "7.81.1",
-    "@sentry/integrations": "7.81.1",
-    "@sentry/react": "7.81.1",
-    "@sentry/types": "7.81.1",
-    "@sentry/utils": "7.81.1"
+    "@sentry/core": "7.99.0",
+    "@sentry/hub": "7.99.0",
+    "@sentry/integrations": "7.99.0",
+    "@sentry/react": "7.99.0",
+    "@sentry/types": "7.99.0",
+    "@sentry/utils": "7.99.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.5",
     "@expo/metro-config": "0.16.0",
     "@mswjs/interceptors": "^0.25.15",
-    "@sentry-internal/eslint-config-sdk": "7.81.1",
-    "@sentry-internal/eslint-plugin-sdk": "7.81.1",
-    "@sentry-internal/typescript": "7.80.0",
+    "@sentry-internal/eslint-config-sdk": "7.99.0",
+    "@sentry-internal/eslint-plugin-sdk": "7.99.0",
+    "@sentry-internal/typescript": "7.99.0",
     "@sentry/wizard": "3.16.3",
     "@types/jest": "^29.5.3",
     "@types/node": "^20.9.3",

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -44,7 +44,7 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
     super(options);
 
     this._outcomesBuffer = [];
-    void this._initNativeSdk();
+    this._initNativeSdk();
   }
 
   /**
@@ -159,20 +159,23 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
   /**
    * Starts native client with dsn and options
    */
-  private async _initNativeSdk(): Promise<void> {
-    let didCallNativeInit = false;
-
-    try {
-      didCallNativeInit = await NATIVE.initNativeSdk(this._options);
-    } catch (_) {
-      this._showCannotConnectDialog();
-    } finally {
-      try {
+  private _initNativeSdk(): void {
+    NATIVE.initNativeSdk(this._options)
+      .then(
+        (result: boolean) => {
+          return result;
+        },
+        () => {
+          this._showCannotConnectDialog();
+          return false;
+        },
+      )
+      .then((didCallNativeInit: boolean) => {
         this._options.onReady?.({ didCallNativeInit });
-      } catch (error) {
+      })
+      .then(undefined, error => {
         logger.error('The OnReady callback threw an error: ', error);
-      }
-    }
+      });
   }
 
   /**

--- a/src/js/integrations/debugsymbolicator.ts
+++ b/src/js/integrations/debugsymbolicator.ts
@@ -6,6 +6,7 @@ import { ReactNativeLibraries } from '../utils/rnlibraries';
 import { createStealthXhr, XHR_READYSTATE_DONE } from '../utils/xhr';
 import type * as ReactNative from '../vendor/react-native';
 
+// eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
 const INTERNAL_CALLSITES_REGEX = new RegExp(['ReactNativeRenderer-dev\\.js$', 'MessageQueue\\.js$'].join('|'));
 
 /**

--- a/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/src/js/integrations/reactnativeerrorhandlers.ts
@@ -241,9 +241,17 @@ export class ReactNativeErrorHandlers implements Integration {
         currentHub.captureEvent(event, hint);
 
         if (!__DEV__) {
-          void client.flush(options.shutdownTimeout || 2000).then(() => {
-            defaultHandler(error, isFatal);
-          });
+          void client.flush(options.shutdownTimeout || 2000).then(
+            () => {
+              defaultHandler(error, isFatal);
+            },
+            (reason: unknown) => {
+              logger.error(
+                '[ReactNativeErrorHandlers] Error while flushing the event cache after uncaught error.',
+                reason,
+              );
+            },
+          );
         } else {
           // If in dev, we call the default handler anyway and hope the error will be sent
           // Just for a better dev experience

--- a/src/js/integrations/rewriteframes.ts
+++ b/src/js/integrations/rewriteframes.ts
@@ -1,5 +1,5 @@
 import { RewriteFrames } from '@sentry/integrations';
-import type { StackFrame } from '@sentry/types';
+import type { Integration, StackFrame } from '@sentry/types';
 import { Platform } from 'react-native';
 
 import { isExpo, isHermesEnabled } from '../utils/environment';
@@ -13,7 +13,7 @@ export const IOS_DEFAULT_BUNDLE_NAME = 'app:///main.jsbundle';
  * and removes file://, 'address at' prefixes, CodePush postfix,
  * and Expo bundle postfix.
  */
-export function createReactNativeRewriteFrames(): RewriteFrames {
+export function createReactNativeRewriteFrames(): Integration {
   return new RewriteFrames({
     iteratee: (frame: StackFrame) => {
       if (frame.platform === 'java' || frame.platform === 'cocoa') {

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -216,15 +216,16 @@ export function captureUserFeedback(feedback: UserFeedback): void {
  *
  * @param callback that will be enclosed into push/popScope.
  */
-export function withScope(callback: (scope: Scope) => void): ReturnType<Hub['withScope']> {
-  const safeCallback = (scope: Scope): void => {
+export function withScope<T>(callback: (scope: Scope) => T): T | undefined {
+  const safeCallback = (scope: Scope): T | undefined => {
     try {
-      callback(scope);
+      return callback(scope);
     } catch (e) {
       logger.error('Error while running withScope callback', e);
+      return undefined;
     }
   };
-  getCurrentHub().withScope(safeCallback);
+  return getCurrentHub().withScope(safeCallback);
 }
 
 /**

--- a/src/js/tools/sentryMetroSerializer.ts
+++ b/src/js/tools/sentryMetroSerializer.ts
@@ -192,5 +192,6 @@ function calculateDebugId(bundle: Bundle): string {
 }
 
 function injectDebugId(code: string, debugId: string): string {
+  // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor
   return code.replace(new RegExp(DEBUG_ID_PLACE_HOLDER, 'g'), debugId);
 }

--- a/src/js/tracing/addTracingExtensions.ts
+++ b/src/js/tracing/addTracingExtensions.ts
@@ -1,6 +1,6 @@
-import type { Hub, Transaction } from '@sentry/core';
+import type { Hub, Span, Transaction } from '@sentry/core';
 import { addTracingExtensions, getCurrentHub, getMainCarrier } from '@sentry/core';
-import type { CustomSamplingContext, Span, SpanContext, TransactionContext } from '@sentry/types';
+import type { CustomSamplingContext, SpanContext, TransactionContext } from '@sentry/types';
 
 import { DEFAULT } from '../tracing/ops';
 import { ReactNativeTracing } from '../tracing/reactnativetracing';

--- a/src/js/tracing/nativeframes.ts
+++ b/src/js/tracing/nativeframes.ts
@@ -64,7 +64,9 @@ export class NativeFramesInstrumentation {
    * To be called when a transaction is finished
    */
   public onTransactionFinish(transaction: Transaction): void {
-    void this._fetchFramesForTransaction(transaction);
+    this._fetchFramesForTransaction(transaction).then(undefined, (reason: unknown) => {
+      logger.error(`[ReactNativeTracing] Error while fetching native frames:`, reason);
+    });
   }
 
   /**

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -230,7 +230,9 @@ export class ReactNativeTracing implements Integration {
     }
 
     if (enableAppStartTracking) {
-      void this._instrumentAppStart();
+      this._instrumentAppStart().then(undefined, (reason: unknown) => {
+        logger.error(`[ReactNativeTracing] Error while instrumenting app start:`, reason);
+      });
     }
 
     if (enableNativeFramesTracking) {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -163,6 +163,19 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
+    test('catches errors from onReady callback', () => {
+      new ReactNativeClient(
+        mockedOptions({
+          dsn: EXAMPLE_DSN,
+          enableNative: true,
+          onReady: () => {
+            throw new Error('This error should be caught by the SDK');
+          },
+          transport: () => new NativeTransport(),
+        }),
+      );
+    });
+
     test('calls onReady callback with false if Native SDK was not initialized', done => {
       new ReactNativeClient(
         mockedOptions({

--- a/test/e2e/test/utils/fetchEvent.ts
+++ b/test/e2e/test/utils/fetchEvent.ts
@@ -1,5 +1,5 @@
 import type { Event } from '@sentry/types';
-import fetch from 'node-fetch';
+import fetch, { Request } from 'node-fetch';
 
 const domain = 'sentry.io';
 const eventEndpoint = '/api/0/projects/sentry-sdks/sentry-react-native/events/';
@@ -18,9 +18,9 @@ const fetchEvent = async (eventId: string): Promise<ApiEvent> => {
   const url = `https://${domain}${eventEndpoint}${eventId}/`;
 
   expect(process.env.SENTRY_AUTH_TOKEN).toBeDefined();
-  expect(process.env.SENTRY_AUTH_TOKEN.length).toBeGreaterThan(0);
+  expect(process.env.SENTRY_AUTH_TOKEN?.length).toBeGreaterThan(0);
 
-  const request = new fetch.Request(url, {
+  const request = new Request(url, {
     headers: {
       Authorization: `Bearer ${process.env.SENTRY_AUTH_TOKEN}`,
       'Content-Type': 'application/json',
@@ -51,10 +51,10 @@ const fetchEvent = async (eventId: string): Promise<ApiEvent> => {
       }
     });
 
-  const json: ApiEvent = await fetch(request)
+  const json: ApiEvent = (await fetch(request)
     // tslint:disable-next-line: no-unsafe-any
     .then(res => res.json())
-    .then(retryer);
+    .then(retryer)) as ApiEvent;
 
   return json;
 };

--- a/test/integrations/rewriteframes.test.ts
+++ b/test/integrations/rewriteframes.test.ts
@@ -1,6 +1,6 @@
 import type { Exception } from '@sentry/browser';
 import { defaultStackParser, eventFromException } from '@sentry/browser';
-import type { Event } from '@sentry/types';
+import type { Client, Event, EventHint } from '@sentry/types';
 import { Platform } from 'react-native';
 
 import { createReactNativeRewriteFrames } from '../../src/js/integrations/rewriteframes';
@@ -22,9 +22,13 @@ describe('RewriteFrames', () => {
     const error = new Error(options.message);
     error.stack = options.stack;
     const event = await eventFromException(defaultStackParser, error, HINT, ATTACH_STACKTRACE);
-    createReactNativeRewriteFrames().process(event);
+    createReactNativeRewriteFrames().processEvent?.(event, {} as EventHint, {} as Client);
     const exception = event.exception?.values?.[0];
     return exception;
+  };
+
+  const processEvent = (event: Event): Event | undefined | null | PromiseLike<Event | null> => {
+    return createReactNativeRewriteFrames().processEvent?.(event, {} as EventHint, {} as Client);
   };
 
   beforeEach(() => {
@@ -67,7 +71,7 @@ describe('RewriteFrames', () => {
       },
     };
 
-    const event = createReactNativeRewriteFrames().process(SENTRY_COCOA_EXCEPTION_EVENT);
+    const event = processEvent(SENTRY_COCOA_EXCEPTION_EVENT) as Event;
     expect(event.exception?.values?.[0]).toEqual(EXPECTED_SENTRY_COCOA_EXCEPTION);
   });
 
@@ -101,7 +105,7 @@ describe('RewriteFrames', () => {
       },
     };
 
-    const event = createReactNativeRewriteFrames().process(SENTRY_JVM_EXCEPTION_EVENT);
+    const event = processEvent(SENTRY_JVM_EXCEPTION_EVENT) as Event;
     expect(event.exception?.values?.[0]).toEqual(EXPECTED_SENTRY_JVM_EXCEPTION);
   });
 

--- a/test/tracing/gesturetracing.test.ts
+++ b/test/tracing/gesturetracing.test.ts
@@ -47,6 +47,9 @@ const getMockScope = () => {
       // Placeholder
     },
     getUser: () => scopeUser,
+    captureEvent(_event: unknown) {
+      // Placeholder
+    },
   };
 };
 

--- a/test/tracing/reactnativenavigation.test.ts
+++ b/test/tracing/reactnativenavigation.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import { spanToJSON } from '@sentry/core';
 import type { Transaction, TransactionContext } from '@sentry/types';
 import type { EmitterSubscription } from 'react-native';
 
@@ -95,7 +96,7 @@ describe('React Native Navigation Instrumentation', () => {
     };
     mockEventsRegistry.onComponentWillAppear(mockEvent);
 
-    expect(mockTransaction).toEqual(
+    expect(spanToJSON(mockTransaction)).toEqual(
       expect.objectContaining(<Partial<Transaction>>{
         name: 'Test',
         tags: {
@@ -145,7 +146,7 @@ describe('React Native Navigation Instrumentation', () => {
     };
     mockEventsRegistry.onComponentWillAppear(mockEvent);
 
-    expect(mockTransaction).toEqual(
+    expect(spanToJSON(mockTransaction)).toEqual(
       expect.objectContaining(<Partial<Transaction>>{
         name: 'New Name',
         description: 'Description',
@@ -232,7 +233,7 @@ describe('React Native Navigation Instrumentation', () => {
         passProps: {},
       });
 
-      expect(mockTransaction.toContext()).toEqual(
+      expect(spanToJSON(mockTransaction)).toEqual(
         expect.objectContaining(<Partial<TransactionContext>>{
           name: 'TestScreenName',
           tags: {

--- a/test/tracing/reactnativenavigation.test.ts
+++ b/test/tracing/reactnativenavigation.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { spanToJSON } from '@sentry/core';
-import type { Transaction, TransactionContext } from '@sentry/types';
+import type { SpanJSON, Transaction, TransactionContext } from '@sentry/types';
 import type { EmitterSubscription } from 'react-native';
 
 import type {
@@ -86,7 +86,7 @@ describe('React Native Navigation Instrumentation', () => {
   test('Correctly instruments a route change', () => {
     mockEventsRegistry.onCommand('root', {});
 
-    expect(mockTransaction.name).toBe('Route Change');
+    expect(spanToJSON(mockTransaction).description).toBe('Route Change');
 
     const mockEvent: ComponentWillAppearEvent = {
       componentId: '0',
@@ -98,7 +98,7 @@ describe('React Native Navigation Instrumentation', () => {
 
     expect(spanToJSON(mockTransaction)).toEqual(
       expect.objectContaining(<Partial<Transaction>>{
-        name: 'Test',
+        description: 'Test',
         tags: {
           'routing.instrumentation': 'react-native-navigation',
           'routing.route.name': 'Test',
@@ -113,10 +113,10 @@ describe('React Native Navigation Instrumentation', () => {
             hasBeenSeen: false,
           },
           previousRoute: null,
+          'sentry.op': 'navigation',
+          'sentry.origin': 'manual',
+          'sentry.source': 'component',
         },
-        metadata: expect.objectContaining({
-          source: 'component',
-        }),
       }),
     );
   });
@@ -147,10 +147,8 @@ describe('React Native Navigation Instrumentation', () => {
     mockEventsRegistry.onComponentWillAppear(mockEvent);
 
     expect(spanToJSON(mockTransaction)).toEqual(
-      expect.objectContaining(<Partial<Transaction>>{
-        name: 'New Name',
-        description: 'Description',
-        sampled: false,
+      expect.objectContaining(<Partial<SpanJSON>>{
+        description: 'New Name',
         tags: {
           'routing.instrumentation': 'react-native-navigation',
           'routing.route.name': 'Test',
@@ -165,10 +163,10 @@ describe('React Native Navigation Instrumentation', () => {
             hasBeenSeen: false,
           },
           previousRoute: null,
+          'sentry.op': 'navigation',
+          'sentry.origin': 'manual',
+          'sentry.source': 'custom',
         },
-        metadata: expect.objectContaining({
-          source: 'custom',
-        }),
       }),
     );
   });
@@ -234,8 +232,8 @@ describe('React Native Navigation Instrumentation', () => {
       });
 
       expect(spanToJSON(mockTransaction)).toEqual(
-        expect.objectContaining(<Partial<TransactionContext>>{
-          name: 'TestScreenName',
+        expect.objectContaining(<Partial<SpanJSON>>{
+          description: 'TestScreenName',
           tags: {
             'routing.instrumentation': 'react-native-navigation',
             'routing.route.name': 'TestScreenName',
@@ -250,6 +248,9 @@ describe('React Native Navigation Instrumentation', () => {
               hasBeenSeen: false,
             },
             previousRoute: null,
+            'sentry.op': 'navigation',
+            'sentry.origin': 'manual',
+            'sentry.source': 'component',
           },
         }),
       );
@@ -323,14 +324,14 @@ describe('React Native Navigation Instrumentation', () => {
       expect(confirmedContext).toEqual(
         expect.objectContaining(<Partial<TransactionContext>>{
           name: 'Test 2',
-          data: {
+          data: expect.objectContaining({
             route: expect.objectContaining({
               name: 'Test 2',
             }),
             previousRoute: expect.objectContaining({
               name: 'Test 1',
             }),
-          },
+          }),
         }),
       );
     });

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -73,6 +73,9 @@ const getMockScope = () => {
       // Placeholder
     },
     getUser: () => scopeUser,
+    captureEvent(_event: any) {
+      // Placeholder
+    },
   };
 };
 

--- a/test/tracing/reactnavigation.test.ts
+++ b/test/tracing/reactnavigation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Transaction } from '@sentry/core';
 import type { TransactionContext } from '@sentry/types';
@@ -68,6 +69,8 @@ describe('ReactNavigationInstrumentation', () => {
         hasBeenSeen: false,
       },
       previousRoute: null,
+      'sentry.op': 'navigation',
+      'sentry.origin': 'manual',
     });
     expect(mockTransaction.metadata.source).toBe('component');
   });
@@ -131,6 +134,8 @@ describe('ReactNavigationInstrumentation', () => {
             key: dummyRoute.key,
             params: {},
           },
+          'sentry.op': 'navigation',
+          'sentry.origin': 'manual',
         });
         expect(mockTransaction.metadata.source).toBe('component');
 
@@ -152,7 +157,6 @@ describe('ReactNavigationInstrumentation', () => {
       tracingListener as any,
       context => {
         context.sampled = false;
-        context.description = 'Description';
         context.name = 'New Name';
 
         return context;
@@ -182,7 +186,7 @@ describe('ReactNavigationInstrumentation', () => {
 
         expect(mockTransaction.sampled).toBe(false);
         expect(mockTransaction.name).toBe('New Name');
-        expect(mockTransaction.description).toBe('Description');
+        expect(mockTransaction.description).toBe('New Name');
         expect(mockTransaction.metadata.source).toBe('custom');
         resolve();
       }, 50);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3775,13 +3775,13 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@sentry-internal/eslint-config-sdk@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.81.1.tgz#69c56b377c7016cf111ca6baa39be6983616c9b9"
-  integrity sha512-B6epH75xVmL77lvgkKKD/wI8SL1q//WsJmyemHD/OVd6f+sagfS3/Y5qqdHrvFdzDQztomlnl7aWjena77VbhA==
+"@sentry-internal/eslint-config-sdk@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-config-sdk/-/eslint-config-sdk-7.99.0.tgz#b1e048f518c597171f37fb0fb1556deffa2dcc5c"
+  integrity sha512-ks21Z8xXbprYCoqjhAX9NbJX3Q9CXCNhzFL2VGPCLnDEpcPQVg2Td0uaFCJ9njvtPNNfxzdDES8BicVbjsNBag==
   dependencies:
-    "@sentry-internal/eslint-plugin-sdk" "7.81.1"
-    "@sentry-internal/typescript" "7.81.1"
+    "@sentry-internal/eslint-plugin-sdk" "7.99.0"
+    "@sentry-internal/typescript" "7.99.0"
     "@typescript-eslint/eslint-plugin" "^5.48.0"
     "@typescript-eslint/parser" "^5.48.0"
     eslint-config-prettier "^6.11.0"
@@ -3791,12 +3791,31 @@
     eslint-plugin-jsdoc "^30.0.3"
     eslint-plugin-simple-import-sort "^5.0.3"
 
-"@sentry-internal/eslint-plugin-sdk@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.81.1.tgz#8d4647407c9c4bf3b87d885c2f3f527e248e2d0a"
-  integrity sha512-MJlqkrr0Wsc7eep6kuoOGftivLwO0fSc5Qp9iKS5vXiX87Z/Dq0QHIlyQRZcArr4hQA7AxI//TEpvK+3GVIV7g==
+"@sentry-internal/eslint-plugin-sdk@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/eslint-plugin-sdk/-/eslint-plugin-sdk-7.99.0.tgz#3489b0d169c088a8ea2c01ee7178bd25ea644ab1"
+  integrity sha512-ay9T2s2Vog2Z5obxbdGIowGg//1eKSSglxeRZGo3+qEBiEy+bJ9hv3n1vD/v3ePiFd0tFBdnY+MvbLdnxooAyQ==
   dependencies:
     requireindex "~1.1.0"
+
+"@sentry-internal/feedback@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/feedback/-/feedback-7.99.0.tgz#c3fec1500cb24c9a5e09479d478fddca909477da"
+  integrity sha512-exIO1o+bE0MW4z30FxC0cYzJ4ZHSMlDPMHCBDPzU+MWGQc/fb8s58QUrx5Dnm6HTh9G3H+YlroCxIo9u0GSwGQ==
+  dependencies:
+    "@sentry/core" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
+
+"@sentry-internal/replay-canvas@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/replay-canvas/-/replay-canvas-7.99.0.tgz#d6ba7eec7ab2f7210a7deb6daa4dd82f7b1e9e29"
+  integrity sha512-PoIkfusToDq0snfl2M6HJx/1KJYtXxYhQplrn11kYadO04SdG0XGXf4h7wBTMEQ7LDEAtQyvsOu4nEQtTO3YjQ==
+  dependencies:
+    "@sentry/core" "7.99.0"
+    "@sentry/replay" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
 
 "@sentry-internal/tracing@7.76.0":
   version "7.76.0"
@@ -3807,35 +3826,32 @@
     "@sentry/types" "7.76.0"
     "@sentry/utils" "7.76.0"
 
-"@sentry-internal/tracing@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.81.1.tgz#1180365cd8a9e18cb0f92e1ea970161840ec0e2e"
-  integrity sha512-E5xm27xrLXL10knH2EWDQsQYh5nb4SxxZzJ3sJwDGG9XGKzBdlp20UUhKqx00wixooVX9uCj3e4Jg8SvNB1hKg==
+"@sentry-internal/tracing@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.99.0.tgz#ad13f8343444ecf7323a4220d4e57a55166565d7"
+  integrity sha512-z3JQhHjoM1KdM20qrHwRClKJrNLr2CcKtCluq7xevLtXHJWNAQQbafnWD+Aoj85EWXBzKt9yJMv2ltcXJ+at+w==
   dependencies:
-    "@sentry/core" "7.81.1"
-    "@sentry/types" "7.81.1"
-    "@sentry/utils" "7.81.1"
+    "@sentry/core" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
 
-"@sentry-internal/typescript@7.80.0":
-  version "7.80.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.80.0.tgz#30cae7c5bd8049f1a4083de351f396091d749e60"
-  integrity sha512-CXXh8vm4a0ZJhlMv4YcapeDmJh1pGtlO7wsdmur4Pu2YF+32z8lDxE5sKrItSdgu7RX5eR7aGQGiJI+YKZgsDQ==
+"@sentry-internal/typescript@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.99.0.tgz#7aa7ea46e0ac6ffc3b3a405c32b38e60f495bf84"
+  integrity sha512-Lsz8MkZRzd+yBclqIo5EnFh49sLAY5VLvPW2pus0VS/6f70xHP/As3nNLJnwz8MaLF9q087izZ2UXpzWlaivRQ==
 
-"@sentry-internal/typescript@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/typescript/-/typescript-7.81.1.tgz#135fe95602eeae338f8decc57cd8ab4deae6e251"
-  integrity sha512-gYFM6inH8Wnc8Mn2nwiuJj1w/c7Hj2D12yM0WlqJujf+iRjKkq1oYPMRYDSfNHhTlr4fOqKFtfNZ1BIy/s9w9Q==
-
-"@sentry/browser@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.81.1.tgz#5ee6ae3679ee80f444d2e8c5662430e7a734ae50"
-  integrity sha512-DNtS7bZEnFPKVoGazKs5wHoWC0FwsOFOOMNeDvEfouUqKKbjO7+RDHbr7H6Bo83zX4qmZWRBf8V+3n3YPIiJFw==
+"@sentry/browser@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.99.0.tgz#3e78beb490d141c988038ea902689a1e9171c6cf"
+  integrity sha512-bgfoUv3wkwwLgN5YUOe0ibB3y268ZCnamZh6nLFqnY/UBKC1+FXWFdvzVON/XKUm62LF8wlpCybOf08ebNj2yg==
   dependencies:
-    "@sentry-internal/tracing" "7.81.1"
-    "@sentry/core" "7.81.1"
-    "@sentry/replay" "7.81.1"
-    "@sentry/types" "7.81.1"
-    "@sentry/utils" "7.81.1"
+    "@sentry-internal/feedback" "7.99.0"
+    "@sentry-internal/replay-canvas" "7.99.0"
+    "@sentry-internal/tracing" "7.99.0"
+    "@sentry/core" "7.99.0"
+    "@sentry/replay" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
 
 "@sentry/cli-darwin@2.25.2":
   version "2.25.2"
@@ -3912,31 +3928,31 @@
     "@sentry/types" "7.76.0"
     "@sentry/utils" "7.76.0"
 
-"@sentry/core@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.81.1.tgz#082fd9122bf9a488c8e05b1754724ddbc2d5cf30"
-  integrity sha512-tU37yAmckOGCw/moWKSwekSCWWJP15O6luIq+u7wal22hE88F3Vc5Avo8SeF3upnPR+4ejaOFH+BJTr6bgrs6Q==
+"@sentry/core@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.99.0.tgz#6881aae5ac1436637b3d88e0b12df4ab56016c5f"
+  integrity sha512-vOAtzcAXEUtS/oW7wi3wMkZ3hsb5Ch96gKyrrj/mXdOp2zrcwdNV6N9/pawq2E9P/7Pw8AXw4CeDZztZrjQLuA==
   dependencies:
-    "@sentry/types" "7.81.1"
-    "@sentry/utils" "7.81.1"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
 
-"@sentry/hub@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.81.1.tgz#c49bcc1894bfeb019811bac8e3b6fd81011b6f7c"
-  integrity sha512-25cvsI3HKiRLJBZGFC8ntuy7/yB8M1w8YLTjr3tIqydYmjFUX7f18w0iuWEtd204d8OQSPBJDapbGMdfkE5x6w==
+"@sentry/hub@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.99.0.tgz#2f2ff792473a3f72b6945a627a155461f8a39859"
+  integrity sha512-m7eg3tv6sWOFsrfM7UhxGWf+pSHgHRq9dOXePjG3R966NjWd2z7Zh+bzSGr267/WAqmiLERz/K+BdBnHGIqTEw==
   dependencies:
-    "@sentry/core" "7.81.1"
-    "@sentry/types" "7.81.1"
-    "@sentry/utils" "7.81.1"
+    "@sentry/core" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
 
-"@sentry/integrations@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.81.1.tgz#1b12c0cf3a7fa88224e86c0be46523ed7e3f3a43"
-  integrity sha512-DN5ONn0/LX5HHVPf1EBGHFssIZaZmLgkqUIeMqCNYBpB4DiOrJANnGwTcWKDPphqhdPxjnPv9AGRLaU0PdvvZQ==
+"@sentry/integrations@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.99.0.tgz#31a25595b40d09a1e0f29cb40f3db067eebfd4b9"
+  integrity sha512-q4Nwpc27DTWlR7nDerd1o6KHlT/0usK+3xfBTZ1feVIAHCxt6ohCyZdoQ97+4kQiJJdX47MEmJYsXUlj62yZNg==
   dependencies:
-    "@sentry/core" "7.81.1"
-    "@sentry/types" "7.81.1"
-    "@sentry/utils" "7.81.1"
+    "@sentry/core" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
     localforage "^1.8.1"
 
 "@sentry/node@^7.69.0":
@@ -3950,35 +3966,36 @@
     "@sentry/utils" "7.76.0"
     https-proxy-agent "^5.0.0"
 
-"@sentry/react@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.81.1.tgz#6a94e8e373a5bf27330cea2eb1a603ae0eb0b8ba"
-  integrity sha512-kk0plP/mf8KgVLOiImIpp1liYysmh3Un8uXcVAToomSuHZPGanelFAdP0XhY+0HlWU9KIfxTjhMte1iSwQ8pYw==
+"@sentry/react@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-7.99.0.tgz#5adab8f0e3314ad12a128ae6a79f587c46b32243"
+  integrity sha512-RtHwgzMHJhzJfSQpVG0SDPQYMTGDX3Q37/YWI59S4ALMbSW4/F6n/eQAvGVYZKbh2UCSqgFuRWaXOYkSZT17wA==
   dependencies:
-    "@sentry/browser" "7.81.1"
-    "@sentry/types" "7.81.1"
-    "@sentry/utils" "7.81.1"
+    "@sentry/browser" "7.99.0"
+    "@sentry/core" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
     hoist-non-react-statics "^3.3.2"
 
-"@sentry/replay@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.81.1.tgz#a656d55e2a00b34e42be6eeb79018d21efc223af"
-  integrity sha512-4ueT0C4bYjngN/9p0fEYH10dTMLovHyk9HxJ6zSTgePvGVexhg+cSEHXisoBDwHeRZVnbIvsVM0NA7rmEDXJJw==
+"@sentry/replay@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.99.0.tgz#c63f2bd79a791538ba54bcd91f02379dc4d5c1cc"
+  integrity sha512-gyN/I2WpQrLAZDT+rScB/0jnFL2knEVBo8U8/OVt8gNP20Pq8T/rDZKO/TG0cBfvULDUbJj2P4CJryn2p/O2rA==
   dependencies:
-    "@sentry-internal/tracing" "7.81.1"
-    "@sentry/core" "7.81.1"
-    "@sentry/types" "7.81.1"
-    "@sentry/utils" "7.81.1"
+    "@sentry-internal/tracing" "7.99.0"
+    "@sentry/core" "7.99.0"
+    "@sentry/types" "7.99.0"
+    "@sentry/utils" "7.99.0"
 
 "@sentry/types@7.76.0":
   version "7.76.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.76.0.tgz#628c9899bfa82ea762708314c50fd82f2138587d"
   integrity sha512-vj6z+EAbVrKAXmJPxSv/clpwS9QjPqzkraMFk2hIdE/kii8s8kwnkBwTSpIrNc8GnzV3qYC4r3qD+BXDxAGPaw==
 
-"@sentry/types@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.81.1.tgz#2b2551fc291e1089651fd574a68f7c4175878bd5"
-  integrity sha512-dvJvGyctiaPMIQqa46k56Re5IODWMDxiHJ1UjBs/WYDLrmWFPGrEbyJ8w8CYLhYA+7qqrCyIZmHbWSTRIxstHw==
+"@sentry/types@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.99.0.tgz#bba7a514abab445026ee42f40f92f81275a6deba"
+  integrity sha512-94qwOw4w40sAs5mCmzcGyj8ZUu/KhnWnuMZARRq96k+SjRW/tHFAOlIdnFSrt3BLPvSOK7R3bVAskZQ0N4FTmA==
 
 "@sentry/utils@7.76.0":
   version "7.76.0"
@@ -3987,12 +4004,12 @@
   dependencies:
     "@sentry/types" "7.76.0"
 
-"@sentry/utils@7.81.1":
-  version "7.81.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.81.1.tgz#42f3e77baf90205cec1f8599eb8445a6918030bd"
-  integrity sha512-gq+MDXIirHKxNZ+c9/lVvCXd6y2zaZANujwlFggRH2u9SRiPaIXVilLpvMm4uJqmqBMEcY81ArujExtHvkbCqg==
+"@sentry/utils@7.99.0":
+  version "7.99.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.99.0.tgz#ef96c3b59e23c79f3ef500db508234a48fa1cfbe"
+  integrity sha512-cYZy5WNTkWs5GgggGnjfGqC44CWir0pAv4GVVSx0fsup4D4pMKBJPrtub15f9uC+QkUf3vVkqwpBqeFxtmJQTQ==
   dependencies:
-    "@sentry/types" "7.81.1"
+    "@sentry/types" "7.99.0"
 
 "@sentry/wizard@3.16.3":
   version "3.16.3"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR bumps JS SDK to 7.99.0 and disables lint deprecation warnings TMP.

There are over 150 deprecations in the SDK code and over 250 in the test. I will create a follow-up PR which fixes the deprecations to make it easier to review.

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
