### PR TITLE
fix(ci): Fix iOS builds failing Hermes cocoapods

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -307,10 +307,11 @@ jobs:
           [[ "${{ matrix.ios-use-frameworks }}" == "dynamic" ]] && export USE_FRAMEWORKS=dynamic && export NO_FLIPPER=1
           [[ "${{ matrix.build-type }}" == "production" ]] && ENABLE_PROD=1 || ENABLE_PROD=0
           [[ "${{ matrix.rn-architecture }}" == "new" ]] && ENABLE_NEW_ARCH=1 || ENABLE_NEW_ARCH=0
+          [[ "${{ matrix.rn-version }}" == "0.65.3" ]] && POD_INSTALL_COMMNAND="pod install" || POD_INSTALL_COMMNAND="bundle exec pod install"
           echo "ENABLE_PROD=$ENABLE_PROD"
           echo "ENABLE_NEW_ARCH=$ENABLE_NEW_ARCH"
           echo "USE_FRAMEWORKS=$USE_FRAMEWORKS"
-          PRODUCTION=$ENABLE_PROD RCT_NEW_ARCH_ENABLED=$ENABLE_NEW_ARCH bundle exec pod install
+          PRODUCTION=$ENABLE_PROD RCT_NEW_ARCH_ENABLED=$ENABLE_NEW_ARCH $POD_INSTALL_COMMNAND
           cat Podfile.lock | grep $RN_SENTRY_POD_NAME
 
       - name: Patch App RN

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -225,6 +225,16 @@ jobs:
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
+      - uses: ruby/setup-ruby@v1
+        if: ${{ matrix.platform == 'ios' && matrix.rn-version != '0.65.3' }}
+        with:
+          working-directory: samples/react-native
+          ruby-version: '3.3.0' # based on what is used in the sample
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 1 # cache the installed gems
+      - run: gem install cocoapods -v 1.15.2 # fixes Hermes pod install https://github.com/CocoaPods/CocoaPods/issues/12226#issuecomment-1930604302
+        if: ${{ matrix.platform == 'ios' && matrix.rn-version != '0.65.3' }}
+
       - name: Setup Global Tools
         run: |
           yarn global add yalc semver

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -225,16 +225,6 @@ jobs:
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
-      - uses: ruby/setup-ruby@v1
-        if: ${{ matrix.platform == 'ios' && matrix.rn-version != '0.65.3' }}
-        with:
-          working-directory: samples/react-native
-          ruby-version: '3.3.0' # based on what is used in the sample
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 1 # cache the installed gems
-      - run: gem install cocoapods -v 1.15.2 # fixes Hermes pod install https://github.com/CocoaPods/CocoaPods/issues/12226#issuecomment-1930604302
-        if: ${{ matrix.platform == 'ios' && matrix.rn-version != '0.65.3' }}
-
       - name: Setup Global Tools
         run: |
           yarn global add yalc semver
@@ -297,6 +287,17 @@ jobs:
         working-directory: test/react-native/versions/${{ matrix.rn-version }}/RnDiffApp
         run: yarn add ../../../../e2e
 
+      - uses: ruby/setup-ruby@v1
+        if: ${{ matrix.platform == 'ios' }}
+        with:
+          working-directory: test/react-native/versions/${{ matrix.rn-version }}/RnDiffApp
+          ruby-version: '3.3.0' # based on what is used in the sample
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 1 # cache the installed gems
+      - run: gem install cocoapods -v 1.15.2 # fixes Hermes pod install https://github.com/CocoaPods/CocoaPods/issues/12226#issuecomment-1930604302
+        working-directory: test/react-native/versions/${{ matrix.rn-version }}/RnDiffApp
+        if: ${{ matrix.platform == 'ios' }}
+
       - name: Install App Pods
         if: ${{ matrix.platform == 'ios' }}
         working-directory: test/react-native/versions/${{ matrix.rn-version }}/RnDiffApp/ios
@@ -309,7 +310,7 @@ jobs:
           echo "ENABLE_PROD=$ENABLE_PROD"
           echo "ENABLE_NEW_ARCH=$ENABLE_NEW_ARCH"
           echo "USE_FRAMEWORKS=$USE_FRAMEWORKS"
-          PRODUCTION=$ENABLE_PROD RCT_NEW_ARCH_ENABLED=$ENABLE_NEW_ARCH pod install
+          PRODUCTION=$ENABLE_PROD RCT_NEW_ARCH_ENABLED=$ENABLE_NEW_ARCH bundle exec pod install
           cat Podfile.lock | grep $RN_SENTRY_POD_NAME
 
       - name: Patch App RN

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -54,8 +54,12 @@ jobs:
         if: ${{ matrix.platform == 'ios' }}
         with:
           working-directory: samples/react-native
-          ruby-version: '3.2.2' # based on what is used in the sample
+          ruby-version: '3.3.0' # based on what is used in the sample
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - uses: maxim-lobanov/setup-cocoapods@8e97e1e98e6ccf42564fdf5622c8feec74199377 # v1.4.0
+        with:
+          podfile-path: myApp/Podfile.lock
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           working-directory: samples/react-native
           ruby-version: '3.3.0' # based on what is used in the sample
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: false # runs 'bundle install' and caches installed gems automatically
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -57,10 +57,6 @@ jobs:
           ruby-version: '3.3.0' # based on what is used in the sample
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - uses: maxim-lobanov/setup-cocoapods@8e97e1e98e6ccf42564fdf5622c8feec74199377 # v1.4.0
-        with:
-          podfile-path: myApp/Podfile.lock
-
       - uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -55,7 +55,8 @@ jobs:
         with:
           working-directory: samples/react-native
           ruby-version: '3.3.0' # based on what is used in the sample
-          bundler-cache: false # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 1 # cache the installed gems
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -87,7 +87,7 @@ jobs:
           [[ "${{ matrix.rn-architecture }}" == "new" ]] && ENABLE_NEW_ARCH=1 || ENABLE_NEW_ARCH=0
           echo "ENABLE_PROD=$ENABLE_PROD"
           echo "ENABLE_NEW_ARCH=$ENABLE_NEW_ARCH"
-          PRODUCTION=$ENABLE_PROD RCT_NEW_ARCH_ENABLED=$ENABLE_NEW_ARCH pod install
+          PRODUCTION=$ENABLE_PROD RCT_NEW_ARCH_ENABLED=$ENABLE_NEW_ARCH bundle exec pod install
           cat Podfile.lock | grep $RN_SENTRY_POD_NAME
 
       - name: Build Android App

--- a/samples/react-native/Gemfile
+++ b/samples/react-native/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby "3.2.2"
+ruby "3.3.0"
 
-gem 'cocoapods', '~> 1.13'
+gem 'cocoapods', '~> 1.15.2'
 gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'

--- a/samples/react-native/Gemfile
+++ b/samples/react-native/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby "3.3.0"
 
-gem 'cocoapods', '~> 1.15.2'
+gem 'cocoapods', '1.15.2'
 gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'

--- a/samples/react-native/Gemfile.lock
+++ b/samples/react-native/Gemfile.lock
@@ -92,7 +92,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.3, < 7.1.0)
-  cocoapods (~> 1.15.2)
+  cocoapods (= 1.15.2)
 
 RUBY VERSION
    ruby 3.3.0p0

--- a/samples/react-native/Gemfile.lock
+++ b/samples/react-native/Gemfile.lock
@@ -8,17 +8,17 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.1.0)
-    cocoapods (1.14.3)
+    cocoapods (1.15.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.3)
+      cocoapods-core (= 1.15.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -33,7 +33,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.3)
+    cocoapods-core (1.15.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -64,7 +64,7 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    json (2.6.3)
+    json (2.7.1)
     minitest (5.20.0)
     molinillo (0.8.0)
     nanaimo (0.3.0)
@@ -77,7 +77,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.23.0)
+    xcodeproj (1.24.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -87,14 +87,15 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
 
 DEPENDENCIES
   activesupport (>= 6.1.7.3, < 7.1.0)
-  cocoapods (~> 1.13)
+  cocoapods (~> 1.15.2)
 
 RUBY VERSION
-   ruby 3.2.2p53
+   ruby 3.3.0p0
 
 BUNDLED WITH
    2.4.20


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
- failing ios cocoapods caused by https://github.com/CocoaPods/CocoaPods/issues/12226#issuecomment-1930604302

- This PR forces the latest 1.15.2 cocoapods for the sample application CI and RN 0.73 e2e tests. As with previous Cocoapods versions, the Hermes pod will crash the pod install.

## :green_heart: How did you test it?
ci, could not reproduce locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 