### PR TITLE
feat(sample): Add bottom tabs navigation to the RN sample app

### DIFF
--- a/samples/react-native/android/app/build.gradle
+++ b/samples/react-native/android/app/build.gradle
@@ -3,6 +3,12 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 apply plugin: "io.sentry.android.gradle"
 
+project.ext.vectoricons = [
+    iconFontNames: [ 'Ionicons.ttf' ] // Specify font files
+]
+
+apply from: file("../../node_modules/react-native-vector-icons/fonts.gradle")
+
 project.ext.sentryCli = [
     collectModulesScript: "../../../../dist/js/tools/collectModules.js",
     modulesPaths: [

--- a/samples/react-native/ios/sampleNewArchitecture.xcodeproj/project.pbxproj
+++ b/samples/react-native/ios/sampleNewArchitecture.xcodeproj/project.pbxproj
@@ -595,10 +595,7 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_CFLAGS = "$(inherited)  ";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -670,10 +667,7 @@
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_CFLAGS = "$(inherited)  ";
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",

--- a/samples/react-native/ios/sampleNewArchitecture/Info.plist
+++ b/samples/react-native/ios/sampleNewArchitecture/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Ionicons.ttf</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -17,6 +17,7 @@
     "clean-watchman": "watchman watch-del-all"
   },
   "dependencies": {
+    "@react-navigation/bottom-tabs": "^6.5.12",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/stack": "^6.3.20",
     "react": "18.2.0",
@@ -24,6 +25,7 @@
     "react-native-gesture-handler": "^2.14.0",
     "react-native-safe-area-context": "4.8.0",
     "react-native-screens": "3.29.0",
+    "react-native-vector-icons": "^10.0.3",
     "react-redux": "^8.1.3",
     "redux": "^4.2.1"
   },
@@ -36,6 +38,7 @@
     "@react-native/metro-config": "^0.73.1",
     "@react-native/typescript-config": "^0.73.1",
     "@types/react": "^18.2.13",
+    "@types/react-native-vector-icons": "^6.4.18",
     "@types/react-test-renderer": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -4,12 +4,14 @@ import {
   NavigationContainerRef,
 } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 // Import the Sentry React Native SDK
 import * as Sentry from '@sentry/react-native';
 
 import { SENTRY_INTERNAL_DSN } from './dsn';
-import HomeScreen from './Screens/HomeScreen';
+import ErrorsScreen from './Screens/ErrorsScreen';
+import PerformanceScreen from './Screens/PerformanceScreen';
 import TrackerScreen from './Screens/TrackerScreen';
 import ManualTrackerScreen from './Screens/ManualTrackerScreen';
 import PerformanceTimingScreen from './Screens/PerformanceTimingScreen';
@@ -20,6 +22,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import GesturesTracingScreen from './Screens/GesturesTracingScreen';
 import { StyleSheet } from 'react-native';
 import { HttpClient } from '@sentry/integrations';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 
 const reactNavigationInstrumentation =
   new Sentry.ReactNavigationInstrumentation({
@@ -98,39 +101,95 @@ Sentry.init({
 });
 
 const Stack = createStackNavigator();
+const Tab = createBottomTabNavigator();
 
-const App = () => {
-  const navigation = React.useRef<NavigationContainerRef<{}>>(null);
-
+const TabOneStack = () => {
   return (
     <GestureHandlerRootView style={styles.wrapper}>
       <Provider store={store}>
-        <NavigationContainer
-          ref={navigation}
-          onReady={() => {
-            reactNavigationInstrumentation.registerNavigationContainer(
-              navigation,
-            );
-          }}>
-          <Stack.Navigator>
-            <Stack.Screen name="Home" component={HomeScreen} />
-            <Stack.Screen name="Tracker" component={TrackerScreen} />
-            <Stack.Screen
-              name="ManualTracker"
-              component={ManualTrackerScreen}
-            />
-            <Stack.Screen
-              name="PerformanceTiming"
-              component={PerformanceTimingScreen}
-            />
-            <Stack.Screen name="Redux" component={ReduxScreen} />
-            <Stack.Screen name="Gestures" component={GesturesTracingScreen} />
-          </Stack.Navigator>
-        </NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="ErrorsScreen"
+            component={ErrorsScreen}
+            options={{ title: 'Errors' }}
+          />
+        </Stack.Navigator>
       </Provider>
     </GestureHandlerRootView>
   );
 };
+
+const TabTwoStack = () => {
+  return (
+    <GestureHandlerRootView style={styles.wrapper}>
+      <Provider store={store}>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="PerformanceScreen"
+            component={PerformanceScreen}
+            options={{ title: 'Performance' }}
+          />
+          <Stack.Screen name="Tracker" component={TrackerScreen} />
+          <Stack.Screen name="ManualTracker" component={ManualTrackerScreen} />
+          <Stack.Screen
+            name="PerformanceTiming"
+            component={PerformanceTimingScreen}
+          />
+          <Stack.Screen name="Redux" component={ReduxScreen} />
+          <Stack.Screen name="Gestures" component={GesturesTracingScreen} />
+        </Stack.Navigator>
+      </Provider>
+    </GestureHandlerRootView>
+  );
+};
+
+function BottomTabs() {
+  const navigation = React.useRef<NavigationContainerRef<{}>>(null);
+
+  return (
+    <NavigationContainer
+      ref={navigation}
+      onReady={() => {
+        reactNavigationInstrumentation.registerNavigationContainer(navigation);
+      }}>
+      <Tab.Navigator
+        screenOptions={{
+          headerShown: false,
+        }}
+        detachInactiveScreens={false} // workaround for https://github.com/react-navigation/react-navigation/issues/11384
+      >
+        <Tab.Screen
+          name="ErrorsTab"
+          component={TabOneStack}
+          options={{
+            tabBarLabel: 'Errors',
+            tabBarIcon: ({ focused, color, size }) => (
+              <Ionicons
+                name={focused ? 'bug' : 'bug-outline'}
+                size={size}
+                color={color}
+              />
+            ),
+          }}
+        />
+        <Tab.Screen
+          name="PerformanceTab"
+          component={TabTwoStack}
+          options={{
+            tabBarLabel: 'Performance',
+            tabBarIcon: ({ focused, color, size }) => (
+              <Ionicons
+                name={focused ? 'speedometer' : 'speedometer-outline'}
+                size={size}
+                color={color}
+              />
+            ),
+          }}
+        />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
 
 const styles = StyleSheet.create({
   wrapper: {
@@ -138,4 +197,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default Sentry.wrap(App);
+export default Sentry.wrap(BottomTabs);

--- a/samples/react-native/src/Screens/ErrorsScreen.tsx
+++ b/samples/react-native/src/Screens/ErrorsScreen.tsx
@@ -15,7 +15,6 @@ import * as Sentry from '@sentry/react-native';
 
 import { setScopeProperties } from '../setScopeProperties';
 import { StackNavigationProp } from '@react-navigation/stack';
-import { CommonActions } from '@react-navigation/native';
 import { UserFeedbackModal } from '../components/UserFeedbackModal';
 import { FallbackRender } from '@sentry/react';
 import NativeSampleModule from '../../tm/NativeSampleModule';
@@ -27,7 +26,7 @@ interface Props {
   navigation: StackNavigationProp<any, 'HomeScreen'>;
 }
 
-const HomeScreen = (props: Props) => {
+const ErrorsScreen = (_props: Props) => {
   const [componentMountStartTimestamp] = React.useState<number>(() => {
     return timestampInSeconds();
   });
@@ -51,22 +50,6 @@ const HomeScreen = (props: Props) => {
   const [showBadCode, setShowBadCode] = React.useState(false);
   const [isFeedbackVisible, setFeedbackVisible] = React.useState(false);
 
-  const onPressPerformanceTiming = () => {
-    // Navigate with a reset action just to test
-    props.navigation.dispatch(
-      CommonActions.reset({
-        index: 1,
-        routes: [
-          { name: 'Home' },
-          {
-            name: 'PerformanceTiming',
-            params: { someParam: 'hello' },
-          },
-        ],
-      }),
-    );
-  };
-
   const errorBoundaryFallback: FallbackRender = ({ eventId }) => (
     <Text>Error boundary caught with event id: {eventId}</Text>
   );
@@ -82,7 +65,6 @@ const HomeScreen = (props: Props) => {
     <>
       <StatusBar barStyle="dark-content" />
       <ScrollView style={styles.mainView}>
-        <Text style={styles.welcomeTitle}>Hey there!</Text>
         <Button
           title="Capture message"
           onPress={() => {
@@ -219,31 +201,6 @@ const HomeScreen = (props: Props) => {
           }}
         />
         <Button
-          title="Auto Tracing Example"
-          onPress={() => {
-            props.navigation.navigate('Tracker');
-          }}
-        />
-        <Button
-          title="Manual Tracing Example"
-          onPress={() => {
-            props.navigation.navigate('ManualTracker');
-          }}
-        />
-        <Button
-          title="Gestures Tracing Example"
-          onPress={() => {
-            props.navigation.navigate('Gestures');
-          }}
-        />
-        <Button title="Performance Timing" onPress={onPressPerformanceTiming} />
-        <Button
-          title="Redux Example"
-          onPress={() => {
-            props.navigation.navigate('Redux');
-          }}
-        />
-        <Button
           title="Send user feedback"
           onPress={() => {
             setFeedbackVisible(true);
@@ -296,4 +253,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default HomeScreen;
+export default ErrorsScreen;

--- a/samples/react-native/src/Screens/PerformanceScreen.tsx
+++ b/samples/react-native/src/Screens/PerformanceScreen.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  StatusBar,
+  ScrollView,
+  Button as NativeButton,
+  View,
+  ButtonProps,
+  StyleSheet,
+} from 'react-native';
+
+import { StackNavigationProp } from '@react-navigation/stack';
+import { CommonActions } from '@react-navigation/native';
+
+interface Props {
+  navigation: StackNavigationProp<any, 'PerformanceScreen'>;
+}
+
+const PerformanceScreen = (props: Props) => {
+  const onPressPerformanceTiming = () => {
+    // Navigate with a reset action just to test
+    props.navigation.dispatch(
+      CommonActions.reset({
+        index: 1,
+        routes: [
+          { name: 'PerformanceScreen' },
+          {
+            name: 'PerformanceTiming',
+            params: { someParam: 'hello' },
+          },
+        ],
+      }),
+    );
+  };
+
+  return (
+    <>
+      <StatusBar barStyle="dark-content" />
+      <ScrollView style={styles.mainView}>
+        <Button
+          title="Auto Tracing Example"
+          onPress={() => {
+            props.navigation.navigate('Tracker');
+          }}
+        />
+        <Button
+          title="Manual Tracing Example"
+          onPress={() => {
+            props.navigation.navigate('ManualTracker');
+          }}
+        />
+        <Button
+          title="Gestures Tracing Example"
+          onPress={() => {
+            props.navigation.navigate('Gestures');
+          }}
+        />
+        <Button title="Performance Timing" onPress={onPressPerformanceTiming} />
+        <Button
+          title="Redux Example"
+          onPress={() => {
+            props.navigation.navigate('Redux');
+          }}
+        />
+        <View style={styles.mainViewBottomWhiteSpace} />
+      </ScrollView>
+    </>
+  );
+};
+
+const Button = (props: ButtonProps) => (
+  <>
+    <NativeButton {...props} color="#6C5FC7" />
+    <View style={styles.buttonSpacer} />
+  </>
+);
+
+const styles = StyleSheet.create({
+  welcomeTitle: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#362D59',
+    marginBottom: 20,
+  },
+  buttonSpacer: {
+    marginBottom: 8,
+  },
+  spacer: {
+    height: 1,
+    width: '100%',
+    backgroundColor: '#c6becf',
+    marginBottom: 16,
+    marginTop: 8,
+  },
+  mainView: {
+    padding: 20,
+  },
+  mainViewBottomWhiteSpace: {
+    marginTop: 32,
+  },
+});
+
+export default PerformanceScreen;

--- a/samples/react-native/yarn.lock
+++ b/samples/react-native/yarn.lock
@@ -2791,6 +2791,15 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
+"@react-navigation/bottom-tabs@^6.5.12":
+  version "6.5.12"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.12.tgz#73adce8b147debe909985257bf436757894e99f6"
+  integrity sha512-8gBHHvgmJSRGfQ5fcFUgDFcXj1MzDzEZJ/llDYvcSb6ZxgN5xVq+4oVkwPMxOM6v+Qm2nKvXiUKuB/YydhzpLw==
+  dependencies:
+    "@react-navigation/elements" "^1.3.22"
+    color "^4.2.3"
+    warn-once "^0.1.0"
+
 "@react-navigation/core@^6.4.10":
   version "6.4.10"
   resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-6.4.10.tgz#0c52621968b35e3a75e189e823d3b9e3bad77aff"
@@ -2807,6 +2816,11 @@
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.21.tgz#debac6becc6b6692da09ec30e705e476a780dfe1"
   integrity sha512-eyS2C6McNR8ihUoYfc166O1D8VYVh9KIl0UQPI8/ZJVsStlfSTgeEEh+WXge6+7SFPnZ4ewzEJdSAHH+jzcEfg==
+
+"@react-navigation/elements@^1.3.22":
+  version "1.3.22"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.22.tgz#37e25e46ca4715049795471056a9e7e58ac4a14e"
+  integrity sha512-HYKucs0TwQT8zMvgoZbJsY/3sZfzeP8Dk9IDv4agst3zlA7ReTx4+SROCG6VGC7JKqBCyQykHIwkSwxhapoc+Q==
 
 "@react-navigation/native@^6.1.9":
   version "6.1.9"
@@ -2961,6 +2975,21 @@
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/react-native-vector-icons@^6.4.18":
+  version "6.4.18"
+  resolved "https://registry.yarnpkg.com/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.18.tgz#18671c617b9d0958747bc959903470dde91a8c79"
+  integrity sha512-YGlNWb+k5laTBHd7+uZowB9DpIK3SXUneZqAiKQaj1jnJCZM0x71GDim5JCTMi4IFkhc9m8H/Gm28T5BjyivUw==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-native" "^0.70"
+
+"@types/react-native@^0.70":
+  version "0.70.19"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.70.19.tgz#b4e651dcf7f49c69ff3a4c3072584cad93155582"
+  integrity sha512-c6WbyCgWTBgKKMESj/8b4w+zWcZSsCforson7UdXtXMecG3MxCinYi6ihhrHVPyUrVzORsvEzK8zg32z4pK6Sg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/react-test-renderer@^18.0.0":
   version "18.0.0"
@@ -3882,6 +3911,15 @@ cliui@^6.0.0:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -7217,6 +7255,14 @@ react-native-screens@3.29.0:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
+react-native-vector-icons@^10.0.3:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-10.0.3.tgz#369824a3b17994b2cd65edbaa32dbf9540d49678"
+  integrity sha512-ZgVlV5AdQgnPHHvBEihGf2xwyziT1acpXV1U+WfCgCv3lcEeCRsmwAsBU+kUSNsU+8TcWVsX04kdI6qUaS8D7w==
+  dependencies:
+    prop-types "^15.7.2"
+    yargs "^16.1.1"
+
 react-native@0.73.2:
   version "0.73.2"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.73.2.tgz#74ee163c8189660d41d1da6560411da7ce41a608"
@@ -8374,6 +8420,11 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
@@ -8395,6 +8446,19 @@ yargs@^15.1.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.1.1:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^17.3.1:
   version "17.6.2"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds bottom tabs navigation to our bare react native sample application.

Note: Expo sample application already has bottom tabs navigation.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Bottom tabs are very popular in mobile applications, having sample with it makes verifying our auto instrumentation easier.

## :green_heart: How did you test it?
sample app

![Screenshot 2024-02-14 at 11 20 14](https://github.com/getsentry/sentry-react-native/assets/31292499/f170b74b-4787-4489-90d9-bfd81e6c6024)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 