### PR TITLE
fix(ci): Only check for diff in to skip ci in pull requests

### DIFF
--- a/.github/workflows/skip-ci.yml
+++ b/.github/workflows/skip-ci.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Check diff from Pull Request
         id: check_diff
         run: |
+          if [ -z "${{ github.base_ref }}" ] || [ -z "${{ github.head_ref }}" ]; then
+            echo "This action is intended to be run on pull requests only."
+            exit 0
+          fi
+
           skipList=(".github/CODEOWNERS" ".prettierignore")
           # Ignores changelog.md, readme.md,...
           fileChangesArray=($(git diff --name-only  origin/${{ github.base_ref }}..origin/${{ github.head_ref }} | grep -v '\.md$'))


### PR DESCRIPTION
- follow up to https://github.com/getsentry/sentry-react-native/pull/3545

Skip CI job should check the diff only in pull requests.

#skip-changelog 