### PR TITLE
fix(client): Option `enabled: false` ensures no events are sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Option `enabled: false` ensures no events are sent ([#3606](https://github.com/getsentry/sentry-react-native/pull/3606))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.17.1 to v8.20.0 ([#3476](https://github.com/getsentry/sentry-react-native/pull/3476))

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -134,7 +134,7 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
     }
 
     let shouldClearOutcomesBuffer = true;
-    if (this._transport && this._dsn) {
+    if (this._isEnabled() && this._transport && this._dsn) {
       this.emit('beforeEnvelope', envelope);
 
       this._transport.send(envelope).then(null, reason => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -1,5 +1,5 @@
 import { defaultStackParser } from '@sentry/browser';
-import type { Envelope, Event, Outcome, Transport } from '@sentry/types';
+import type { Envelope, Event, MetricInstance, Outcome, Transport } from '@sentry/types';
 import { rejectedSyncPromise, SentryError } from '@sentry/utils';
 import * as RN from 'react-native';
 
@@ -11,6 +11,7 @@ import { NativeTransport } from '../src/js/transports/native';
 import { SDK_NAME, SDK_PACKAGE_NAME, SDK_VERSION } from '../src/js/version';
 import { NATIVE } from '../src/js/wrapper';
 import {
+  createMockTransport,
   envelopeHeader,
   envelopeItemHeader,
   envelopeItemPayload,
@@ -145,6 +146,83 @@ describe('Tests ReactNativeClient', () => {
       expect(client.getTransport()?.flush).toBe(myFlush);
       expect(client.getTransport()?.send).toBe(mySend);
     });
+  });
+
+  describe('enabled option', () => {
+    test('captureMessage does not call transport when enabled false', () => {
+      const mockTransport = createMockTransport();
+      const client = createDisabledClientWith(mockTransport);
+
+      client.captureMessage('This message will never be sent because the client is disabled.');
+
+      expect(mockTransport.send).not.toBeCalled();
+    });
+
+    test('captureException does not call transport when enabled false', () => {
+      const mockTransport = createMockTransport();
+      const client = createDisabledClientWith(mockTransport);
+
+      client.captureException(new Error('This exception will never be sent because the client is disabled.'));
+
+      expect(mockTransport.send).not.toBeCalled();
+    });
+
+    test('captureEvent does not call transport when enabled false', () => {
+      const mockTransport = createMockTransport();
+      const client = createDisabledClientWith(mockTransport);
+
+      client.captureEvent({
+        message: 'This event will never be sent because the client is disabled.',
+      });
+
+      expect(mockTransport.send).not.toBeCalled();
+    });
+
+    test('captureSession does not call transport when enabled false', () => {
+      const mockTransport = createMockTransport();
+      const client = createDisabledClientWith(mockTransport);
+
+      client.captureSession(getMockSession());
+
+      expect(mockTransport.send).not.toBeCalled();
+    });
+
+    test('captureUserFeedback does not call transport when enabled false', () => {
+      const mockTransport = createMockTransport();
+      const client = createDisabledClientWith(mockTransport);
+
+      client.captureUserFeedback(getMockUserFeedback());
+
+      expect(mockTransport.send).not.toBeCalled();
+    });
+
+    test('captureAggregateMetrics does not call transport when enabled false', () => {
+      const mockTransport = createMockTransport();
+      const client = createDisabledClientWith(mockTransport);
+
+      client.captureAggregateMetrics([
+        {
+          // https://github.com/getsentry/sentry-javascript/blob/a7097d9ba2a74b2cb323da0ef22988a383782ffb/packages/core/test/lib/metrics/aggregator.test.ts#L115
+          metric: { _value: 1 } as unknown as MetricInstance,
+          metricType: 'c',
+          name: 'requests',
+          tags: {},
+          timestamp: expect.any(Number),
+          unit: 'none',
+        },
+      ]);
+
+      expect(mockTransport.send).not.toBeCalled();
+    });
+
+    function createDisabledClientWith(transport: Transport) {
+      return new ReactNativeClient({
+        ...DEFAULT_OPTIONS,
+        dsn: EXAMPLE_DSN,
+        enabled: false,
+        transport: () => transport,
+      });
+    }
   });
 
   describe('onReady', () => {

--- a/test/testutils.ts
+++ b/test/testutils.ts
@@ -1,5 +1,5 @@
 import { Transaction } from '@sentry/core';
-import type { Session, UserFeedback } from '@sentry/types';
+import type { Session, Transport, UserFeedback } from '@sentry/types';
 import { rejectedSyncPromise } from '@sentry/utils';
 
 import { getBlankTransactionContext } from '../src/js/tracing/utils';
@@ -65,4 +65,11 @@ export const getSyncPromiseRejectOnFirstCall = <Y extends any[]>(reason: unknown
       return Promise.resolve();
     }
   });
+};
+
+export const createMockTransport = (): MockInterface<Transport> => {
+  return {
+    send: jest.fn().mockResolvedValue(undefined),
+    flush: jest.fn().mockResolvedValue(true),
+  };
 };


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Introduced in https://github.com/getsentry/sentry-javascript/pull/9101 `client.options.enabled` check was moved from `_processEvent` to `_sendEnvelope`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes https://github.com/getsentry/sentry-react-native/issues/3603

## :green_heart: How did you test it?
sample expo app and unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
