### PR TITLE
fix(symbolication): Ignore dev server JSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Option `enabled: false` ensures no events are sent ([#3606](https://github.com/getsentry/sentry-react-native/pull/3606))
+- Ignore JSON response when retrieving source context from local Expo Dev Server ([#3611](https://github.com/getsentry/sentry-react-native/pull/3611))
 
 ### Dependencies
 

--- a/src/js/integrations/debugsymbolicator.ts
+++ b/src/js/integrations/debugsymbolicator.ts
@@ -219,7 +219,13 @@ export class DebugSymbolicator implements Integration {
           if (xhr.status !== 200) {
             resolve(null);
           }
-          resolve(xhr.responseText);
+          const response = xhr.responseText;
+          if (typeof response !== 'string' ||
+              response.startsWith('{')) {
+            resolve(null);
+          }
+
+          resolve(response);
         }
       };
       xhr.onerror = (): void => {

--- a/src/js/integrations/debugsymbolicator.ts
+++ b/src/js/integrations/debugsymbolicator.ts
@@ -220,8 +220,12 @@ export class DebugSymbolicator implements Integration {
             resolve(null);
           }
           const response = xhr.responseText;
-          if (typeof response !== 'string' ||
-              response.startsWith('{')) {
+          if (
+            typeof response !== 'string' ||
+            // Expo Dev Server responses with status 200 and config JSON
+            // when web support not enabled and requested file not found
+            response.startsWith('{')
+          ) {
             resolve(null);
           }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The Expo Dev Server without web support behaves differently from the Bare React Native Dev Server and Expo with web support. It always returns 200 HTTP status with JSON config instead of the expected 404 for non-existing endpoints.

Since we are fetching source code context we can ignore the JSON response as the code can not be JSON.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes: https://github.com/getsentry/sentry-react-native/issues/3602

## :green_heart: How did you test it?
- repro from the issue https://github.com/stichingsd-vitrion/sentry-expo-bug-reproduction

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
