### PR TITLE
fix(expo): Ensure authToken is not written to application package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Option `enabled: false` ensures no events are sent ([#3606](https://github.com/getsentry/sentry-react-native/pull/3606))
+- Remove Expo Plugin `authToken` option from application bundle ([#3630](https://github.com/getsentry/sentry-react-native/pull/3630))
 
 ### Dependencies
 

--- a/plugin/src/withSentry.ts
+++ b/plugin/src/withSentry.ts
@@ -14,6 +14,12 @@ interface PluginProps {
 
 const withSentryPlugin: ConfigPlugin<PluginProps | void> = (config, props) => {
   const sentryProperties = getSentryProperties(props);
+
+  if (props && props.authToken) {
+    // If not removed, the plugin config with the authToken will be written to the application package
+    delete props.authToken;
+  }
+
   let cfg = config;
   if (sentryProperties !== null) {
     try {
@@ -33,12 +39,14 @@ const withSentryPlugin: ConfigPlugin<PluginProps | void> = (config, props) => {
       );
     }
   }
+
   return cfg;
 };
 
-const missingAuthTokenMessage = '# auth.token is configured through SENTRY_AUTH_TOKEN environment variable';
 const missingProjectMessage = '# no project found, falling back to SENTRY_PROJECT environment variable';
 const missingOrgMessage = '# no org found, falling back to SENTRY_ORG environment variable';
+const existingAuthTokenMessage = `# DO NOT COMMIT the auth token, use SENTRY_AUTH_TOKEN instead, see https://docs.sentry.io/platforms/react-native/manual-setup/`;
+const missingAuthTokenMessage = `# Using SENTRY_AUTH_TOKEN environment variable`;
 
 export function getSentryProperties(props: PluginProps | void): string | null {
   const { organization, project, authToken, url = 'https://sentry.io/' } = props ?? {};
@@ -56,12 +64,7 @@ export function getSentryProperties(props: PluginProps | void): string | null {
   return `defaults.url=${url}
 ${organization ? `defaults.org=${organization}` : missingOrgMessage}
 ${project ? `defaults.project=${project}` : missingProjectMessage}
-${
-  authToken
-    ? `# Configure this value through \`SENTRY_AUTH_TOKEN\` environment variable instead. See: https://docs.sentry.io/platforms/react-native/manual-setup/\nauth.token=${authToken}`
-    : missingAuthTokenMessage
-}
-`;
+${authToken ? `${existingAuthTokenMessage}\nauth.token=${authToken}` : missingAuthTokenMessage}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Processed Expo plugin configuration is saved in plain text in the application package.

This PR removes the `authToken` property to ensure the value won't be saved in the app package.

## :green_heart: How did you test it?
expo sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- [ ] Update docs to emphasize use of `SENTRY_AUTH_TOKEN` env
- [ ] Inform users about the possibly exposed token