### PR TITLE
fix(expo): Reduce waning messages spam when a property in configuration is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Option `enabled: false` ensures no events are sent ([#3606](https://github.com/getsentry/sentry-react-native/pull/3606))
+- Remove Expo Plugin `authToken` option from application bundle ([#3630](https://github.com/getsentry/sentry-react-native/pull/3630))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Reduce waning messages spam when a property in Expo plugin configuration is missing ([#3631](https://github.com/getsentry/sentry-react-native/pull/3631))
 - Option `enabled: false` ensures no events are sent ([#3606](https://github.com/getsentry/sentry-react-native/pull/3606))
 - Remove Expo Plugin `authToken` option from application bundle ([#3630](https://github.com/getsentry/sentry-react-native/pull/3630))
 

--- a/plugin/src/utils.ts
+++ b/plugin/src/utils.ts
@@ -15,6 +15,35 @@ const sdkPackage: {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
 } = require('../../package.json');
 
-const SDK_PACKAGE_NAME = sdkPackage.name;
+const SDK_PACKAGE_NAME = `${sdkPackage.name}/expo`;
+
+const warningMap = new Map<string, boolean>();
+export function warnOnce(message: string): void {
+  if (!warningMap.has(message)) {
+    warningMap.set(message, true);
+    // eslint-disable-next-line no-console
+    console.warn(yellow(`${logPrefix()} ${message}`));
+  }
+}
+
+export function logPrefix(): string {
+  return `› ${bold('[@sentry/react-native/expo]')}`;
+}
+
+/**
+ * The same as `chalk.yellow`
+ * This code is part of the SDK, we don't want to introduce a dependency on `chalk` just for this.
+ */
+export function yellow(message: string): string {
+  return `\x1b[33m${message}\x1b[0m`;
+}
+
+/**
+ * The same as `chalk.bold`
+ * This code is part of the SDK, we don't want to introduce a dependency on `chalk` just for this.
+ */
+export function bold(message: string): string {
+  return `\x1b[1m${message}\x1b[22m`;
+}
 
 export { sdkPackage, SDK_PACKAGE_NAME };

--- a/plugin/src/withSentry.ts
+++ b/plugin/src/withSentry.ts
@@ -14,6 +14,12 @@ interface PluginProps {
 
 const withSentryPlugin: ConfigPlugin<PluginProps | void> = (config, props) => {
   const sentryProperties = getSentryProperties(props);
+
+  if (props && props.authToken) {
+    // If not removed, the plugin config with the authToken will be written to the application package
+    delete props.authToken;
+  }
+
   let cfg = config;
   if (sentryProperties !== null) {
     try {
@@ -33,12 +39,14 @@ const withSentryPlugin: ConfigPlugin<PluginProps | void> = (config, props) => {
       );
     }
   }
+
   return cfg;
 };
 
-const missingAuthTokenMessage = '# auth.token is configured through SENTRY_AUTH_TOKEN environment variable';
 const missingProjectMessage = '# no project found, falling back to SENTRY_PROJECT environment variable';
 const missingOrgMessage = '# no org found, falling back to SENTRY_ORG environment variable';
+const existingAuthTokenMessage = `# DO NOT COMMIT the auth token, use SENTRY_AUTH_TOKEN instead, see https://docs.sentry.io/platforms/react-native/manual-setup/`;
+const missingAuthTokenMessage = `# Using SENTRY_AUTH_TOKEN environment variable`;
 
 export function getSentryProperties(props: PluginProps | void): string | null {
   const { organization, project, authToken, url = 'https://sentry.io/' } = props ?? {};
@@ -56,12 +64,7 @@ export function getSentryProperties(props: PluginProps | void): string | null {
   return `defaults.url=${url}
 ${organization ? `defaults.org=${organization}` : missingOrgMessage}
 ${project ? `defaults.project=${project}` : missingProjectMessage}
-${
-  authToken
-    ? `# Configure this value through \`SENTRY_AUTH_TOKEN\` environment variable instead. See: https://docs.sentry.io/platforms/react-native/manual-setup/\nauth.token=${authToken}`
-    : missingAuthTokenMessage
-}
-`;
+${authToken ? `${existingAuthTokenMessage}\nauth.token=${authToken}` : missingAuthTokenMessage}`;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/plugin/src/withSentryAndroid.ts
+++ b/plugin/src/withSentryAndroid.ts
@@ -1,8 +1,8 @@
 import type { ConfigPlugin } from 'expo/config-plugins';
-import { WarningAggregator, withAppBuildGradle, withDangerousMod } from 'expo/config-plugins';
+import { withAppBuildGradle, withDangerousMod } from 'expo/config-plugins';
 import * as path from 'path';
 
-import { SDK_PACKAGE_NAME, writeSentryPropertiesTo } from './utils';
+import { warnOnce, writeSentryPropertiesTo } from './utils';
 
 export const withSentryAndroid: ConfigPlugin<string> = (config, sentryProperties: string) => {
   const cfg = withAppBuildGradle(config, config => {
@@ -39,8 +39,7 @@ export function modifyAppBuildGradle(buildGradle: string): string {
   const pattern = /^android {/m;
 
   if (!buildGradle.match(pattern)) {
-    WarningAggregator.addWarningAndroid(
-      SDK_PACKAGE_NAME,
+    warnOnce(
       'Could not find `^android {` in `android/app/build.gradle`. Please open a bug report at https://github.com/getsentry/sentry-react-native.',
     );
     return buildGradle;

--- a/plugin/src/withSentryIOS.ts
+++ b/plugin/src/withSentryIOS.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import type { ConfigPlugin, XcodeProject } from 'expo/config-plugins';
-import { WarningAggregator, withDangerousMod, withXcodeProject } from 'expo/config-plugins';
+import { withDangerousMod, withXcodeProject } from 'expo/config-plugins';
 import * as path from 'path';
 
-import { SDK_PACKAGE_NAME, writeSentryPropertiesTo } from './utils';
+import { warnOnce, writeSentryPropertiesTo } from './utils';
 
 type BuildPhase = { shellScript: string };
 
@@ -47,8 +47,7 @@ export const withSentryIOS: ConfigPlugin<string> = (config, sentryProperties: st
 
 export function modifyExistingXcodeBuildScript(script: BuildPhase): void {
   if (!script.shellScript.match(/(packager|scripts)\/react-native-xcode\.sh\b/)) {
-    WarningAggregator.addWarningIOS(
-      SDK_PACKAGE_NAME,
+    warnOnce(
       `'react-native-xcode.sh' not found in 'Bundle React Native code and images'.
 Please open a bug report at https://github.com/getsentry/sentry-react-native`,
     );
@@ -56,16 +55,12 @@ Please open a bug report at https://github.com/getsentry/sentry-react-native`,
   }
 
   if (script.shellScript.includes('sentry-xcode.sh')) {
-    WarningAggregator.addWarningIOS(
-      SDK_PACKAGE_NAME,
-      "The latest 'sentry-xcode.sh' script already exists in 'Bundle React Native code and images'.",
-    );
+    warnOnce("The latest 'sentry-xcode.sh' script already exists in 'Bundle React Native code and images'.");
     return;
   }
 
   if (script.shellScript.includes('@sentry')) {
-    WarningAggregator.addWarningIOS(
-      SDK_PACKAGE_NAME,
+    warnOnce(
       `Outdated or custom Sentry script found in 'Bundle React Native code and images'.
 Regenerate the native project to use the latest script.
 Run npx expo prebuild --clean`,

--- a/test/expo-plugin/modifyAppBuildGradle.test.ts
+++ b/test/expo-plugin/modifyAppBuildGradle.test.ts
@@ -1,8 +1,7 @@
-import { WarningAggregator } from 'expo/config-plugins';
-
+import { warnOnce } from '../../plugin/src/utils';
 import { modifyAppBuildGradle } from '../../plugin/src/withSentryAndroid';
 
-jest.mock('expo/config-plugins');
+jest.mock('../../plugin/src/utils');
 
 const buildGradleWithSentry = `
 apply from: new File(["node", "--print", "require('path').dirname(require.resolve('@sentry/react-native/package.json'))"].execute().text.trim(), "sentry.gradle")
@@ -49,8 +48,7 @@ describe('Configures Android native project correctly', () => {
   });
 
   it('Warns to file a bug report if no react.gradle is found', () => {
-    (WarningAggregator.addWarningAndroid as jest.Mock).mockImplementationOnce(jest.fn());
     modifyAppBuildGradle(buildGradleWithOutReactGradleScript);
-    expect(WarningAggregator.addWarningAndroid).toHaveBeenCalled();
+    expect(warnOnce).toHaveBeenCalled();
   });
 });

--- a/test/expo-plugin/modifyXcodeProject.test.ts
+++ b/test/expo-plugin/modifyXcodeProject.test.ts
@@ -1,8 +1,7 @@
-import { WarningAggregator } from 'expo/config-plugins';
-
+import { warnOnce } from '../../plugin/src/utils';
 import { modifyExistingXcodeBuildScript } from '../../plugin/src/withSentryIOS';
 
-jest.mock('expo/config-plugins');
+jest.mock('../../plugin/src/utils');
 
 const buildScriptWithoutSentry = {
   shellScript: JSON.stringify(`"
@@ -74,8 +73,7 @@ describe('Configures iOS native project correctly', () => {
   });
 
   it("Warns to file a bug report if build script isn't what we expect to find", () => {
-    (WarningAggregator.addWarningAndroid as jest.Mock).mockImplementationOnce(jest.fn());
     modifyExistingXcodeBuildScript(buildScriptWeDontExpect);
-    expect(WarningAggregator.addWarningIOS).toHaveBeenCalled();
+    expect(warnOnce).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR reduced the warning spam when a config property is missing in Expo plugin configuration.

### Before
<img width="1834" alt="Screenshot 2024-02-26 at 12 02 22" src="https://github.com/getsentry/sentry-react-native/assets/31292499/6a5324f7-950c-4551-82fc-9372f41ca09d">

### After
<img width="1973" alt="Screenshot 2024-02-26 at 12 02 01" src="https://github.com/getsentry/sentry-react-native/assets/31292499/3232e750-d8cb-4cb8-b9e5-fd468217c318">

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
