### PR TITLE
expo-upload-sourcemaps now works on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- expo-upload-sourcemaps now works on Windows ([#3643](https://github.com/getsentry/sentry-react-native/pull/3643))
 - Option `enabled: false` ensures no events are sent ([#3606](https://github.com/getsentry/sentry-react-native/pull/3606))
 - Ignore JSON response when retrieving source context from local Expo Dev Server ([#3611](https://github.com/getsentry/sentry-react-native/pull/3611))
 

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -180,7 +180,8 @@ for (const [assetGroupName, assets] of Object.entries(groupedAssets)) {
   }
 
   const isHermes = assets.find(asset => asset.endsWith('.hbc'));
-  execSync(`${sentryCliBin} sourcemaps upload ${isHermes ? '--debug-id-reference' : ''} ${assets.join(' ')}`, {
+  const windowsCallback = process.platform === "win32" ? 'node ' : '';
+  execSync(`${windowsCallback}${sentryCliBin} sourcemaps upload ${isHermes ? '--debug-id-reference' : ''} ${assets.join(' ')}`, {
     env: {
       ...process.env,
       [SENTRY_PROJECT]: sentryProject,
@@ -195,8 +196,7 @@ if (numAssetsUploaded === totalAssets) {
   console.log('✅ Uploaded bundles and sourcemaps to Sentry successfully.');
 } else {
   console.warn(
-    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${
-      numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
+    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
     }`,
   );
 }

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -196,7 +196,8 @@ if (numAssetsUploaded === totalAssets) {
   console.log('✅ Uploaded bundles and sourcemaps to Sentry successfully.');
 } else {
   console.warn(
-    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
+    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${
+      numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''```
     }`,
   );
 }

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -197,7 +197,7 @@ if (numAssetsUploaded === totalAssets) {
 } else {
   console.warn(
     `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${
-      numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''```
+      numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
     }`,
   );
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
when on Windows, the execution will call "node sentry-cli..."  which will behave the same as on MacOS and Linux.
The main difference is that only calling "sentry-cli ..." on a Unix system works is due to the first line on the file telling the shell to invoke the file with the Node cli. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It makes the script usable on Windows.
Fixes #3613


## :green_heart: How did you test it?

Localy on a  brand new project invoking the script the same way as users did, the below script shows sentry cli being invoked on a Windows device where previously it wouldn't execute it.
```
⬆️ Uploading dist\_expo\static\js\web\AppEntry-f904ff768b6e71e8cc866a59c8a999de1.js bundle and sourcemap...
> Found 1 file                                                             
> Found 1 file                                                             
> Analyzing 2 sources
> Analyzing completed in 0.01s
> Rewriting sources
> Rewriting completed in 0.07s
> Adding source map references
error: This version of Sentry does not support artifact bundles. A release slug is required (provide with --release)

Add --log-level=[info|debug] or export SENTRY_LOG_LEVEL=[info|debug] to see more output.
Please attach the full debug log to all bug reports.

Command failed, however, "SENTRY_ALLOW_FAILURE" variable or "allow-failure" flag was set. Exiting with 0 exit code.
✅ Uploaded bundles and sourcemaps to Sentry successfully.
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
