### PR TITLE
fix(xcode): Upload debug files only for non-debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - expo-upload-sourcemaps now works on Windows ([#3643](https://github.com/getsentry/sentry-react-native/pull/3643))
 - Option `enabled: false` ensures no events are sent ([#3606](https://github.com/getsentry/sentry-react-native/pull/3606))
 - Ignore JSON response when retrieving source context from local Expo Dev Server ([#3611](https://github.com/getsentry/sentry-react-native/pull/3611))
+- Upload native debug files only for non-debug builds ([#3649](https://github.com/getsentry/sentry-react-native/pull/3649))
 
 ### Dependencies
 

--- a/scripts/sentry-xcode-debug-files.sh
+++ b/scripts/sentry-xcode-debug-files.sh
@@ -28,8 +28,12 @@ EXTRA_ARGS="$SENTRY_CLI_EXTRA_ARGS $SENTRY_CLI_DEBUG_FILES_UPLOAD_EXTRA_ARGS $IN
 
 UPLOAD_DEBUG_FILES="\"$SENTRY_CLI_EXECUTABLE\" debug-files upload $EXTRA_ARGS \"$DWARF_DSYM_FOLDER_PATH\""
 
-if [ "$SENTRY_DISABLE_AUTO_UPLOAD" != true ]; then
-  /bin/sh -c "\"$LOCAL_NODE_BINARY\" $UPLOAD_DEBUG_FILES"
-else
+XCODE_BUILD_CONFIGURATION="${CONFIGURATION}"
+
+if [ "$SENTRY_DISABLE_AUTO_UPLOAD" == true ]; then
   echo "SENTRY_DISABLE_AUTO_UPLOAD=true, skipping debug files upload"
+elif echo "$XCODE_BUILD_CONFIGURATION" | grep -iq "debug"; then # case insensitive check for "debug"
+  echo "Skipping debug files upload for *Debug* configuration"
+else
+  /bin/sh -c "\"$LOCAL_NODE_BINARY\" $UPLOAD_DEBUG_FILES"
 fi


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
`sentry-cocoa` symbolicates crashes/errors locally in debug builds, there is no need to upload the native debug files to Sentry.

This makes onboarding Sentry simpler, in larger projects, as devs don't have to have a Sentry token to create debug builds. And don't have to actively disable Sentry auto upload.  

The same condition as for source maps auto upload https://github.com/getsentry/sentry-cli/blob/a2a4d543f4d191db553f7b1b3385c5cd0c9cfefd/src/commands/react_native/xcode.rs#L160

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
