### PR TITLE
misc(ci): Disable auto debug files upload

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
+    env:
+      SENTRY_DISABLE_AUTO_UPLOAD: true
     strategy:
       # we want that the matrix keeps running, default is to cancel them if it fails.
       fail-fast: false
@@ -156,6 +158,7 @@ jobs:
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     env:
+      SENTRY_DISABLE_AUTO_UPLOAD: true # TODO: Remove this when testing against a mocked Sentry server
       RN_SENTRY_POD_NAME: RNSentry
       RN_DIFF_REPOSITORY: https://github.com/react-native-community/rn-diff-purge.git
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     env:
-      SENTRY_DISABLE_AUTO_UPLOAD: true
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:
       # we want that the matrix keeps running, default is to cancel them if it fails.
       fail-fast: false
@@ -158,7 +158,7 @@ jobs:
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     env:
-      SENTRY_DISABLE_AUTO_UPLOAD: true # TODO: Remove this when testing against a mocked Sentry server
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true' # TODO: Remove this when testing against a mocked Sentry server
       RN_SENTRY_POD_NAME: RNSentry
       RN_DIFF_REPOSITORY: https://github.com/react-native-community/rn-diff-purge.git
     strategy:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
+    env:
+      SENTRY_DISABLE_AUTO_UPLOAD: true
     strategy:
       # we want that the matrix keeps running, default is to cancel them if it fails.
       fail-fast: false

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -33,7 +33,7 @@ jobs:
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     env:
-      SENTRY_DISABLE_AUTO_UPLOAD: true
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:
       # we want that the matrix keeps running, default is to cancel them if it fails.
       fail-fast: false

--- a/samples/react-native/android/app/build.gradle
+++ b/samples/react-native/android/app/build.gradle
@@ -46,7 +46,7 @@ sentry {
     // code as part of your stack traces in Sentry.
     //
     // Default is disabled.
-    includeSourceContext = true
+    includeSourceContext = shouldSentryAutoUpload()
 
     // Includes additional source directories into the source bundle.
     // These directories are resolved relative to the project directory


### PR DESCRIPTION
I can't track down the cause of the uploads timing out in GitHub actions. Currently, ~80% of the uploads fail, so it's better to turn them off until we implement a mock server to test against.

It might be related to the amount of the files uploaded to the `sentry-react-native` project as these uploads run on every PR.

For the sample application builds and the perf metrics the upload can be disabled permanently as the debug files are of no use.

For the e2e tests, the missing debug files will result in non-symbolicated test errors. But since this is not checked in the tests, disabling the uploads won't be an issue.

### Note
With the disabled auto upload, we are losing the smoke test of `sentry-cli` integration with the current RN scripts. 
But since `sentry-cli` has its integration tests for the RN commands it should be OK, especially in the current situation, when the uploads time out most of the time.  

#skip-changelog 