### PR TITLE
fix(ci): `diff_check` should not fail when all files are filtered

### DIFF
--- a/.github/workflows/skip-ci.yml
+++ b/.github/workflows/skip-ci.yml
@@ -28,7 +28,7 @@ jobs:
 
           skipList=(".github/CODEOWNERS" ".prettierignore")
           # Ignores changelog.md, readme.md,...
-          fileChangesArray=($(git diff --name-only  origin/${{ github.base_ref }}..origin/${{ github.head_ref }} | grep -v '\.md$'))
+          fileChangesArray=($(git diff --name-only  origin/${{ github.base_ref }}..origin/${{ github.head_ref }} | grep -v '\.md$' || true))
           printf '%s\n' "${fileChangesArray[@]}"
           for item in "${fileChangesArray[@]}"
           do


### PR DESCRIPTION
This PR fixes `skip-ci` jobs which failed when only `*.md` files were changed.

`grep -v '\.md$'` returns code `1` when all lines are filtered out.

#skip-changelog 
