### PR TITLE
feat(expo): Added ability to provide sentryUrl for source maps upload

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "[json]": {
     "editor.formatOnType": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit"
+    "source.fixAll": true
   },
   "[json]": {
     "editor.formatOnType": false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Allow custom `sentryUrl` for Expo updates source maps uploads ([#3664](https://github.com/getsentry/sentry-react-native/pull/3664))
+
 ### Dependencies
 
 - Bump CLI from v2.25.2 to v2.29.1 ([#3534](https://github.com/getsentry/sentry-react-native/pull/3534))

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -117,7 +117,7 @@ let sentryProject = getEnvVar(SENTRY_PROJECT);
 let authToken = getEnvVar(SENTRY_AUTH_TOKEN);
 const sentryCliBin = getEnvVar(SENTRY_CLI_EXECUTABLE) || require.resolve('@sentry/cli/bin/sentry-cli');
 
-if (!sentryOrg || !sentryProject) {
+if (!sentryOrg || !sentryProject || !sentryUrl) {
   console.log('🐕 Fetching from expo config...');
   const pluginConfig = getSentryPluginPropertiesFromExpoConfig();
   if (!pluginConfig) {
@@ -148,14 +148,22 @@ if (!sentryOrg || !sentryProject) {
     sentryProject = pluginConfig.project;
     console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
   }
-}
-if (pluginConfig.url) {
-  sentryUrl = pluginConfig.url;
-} else {
-  sentryUrl
-}
-console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
+  if (!sentryProject) {
+    sentryUrl = pluginConfig.url;
 
+  }
+  if (!sentryUrl) {
+    if (!pluginConfig.url) {
+      console.error(
+        `Could not resolve sentry url, set it in the environment variable ${SENTRY_URL} or in the '@sentry/react-native' plugin properties in your expo config.`,
+      );
+      process.exit(1);
+    }
+
+    sentryUrl = pluginConfig.url;
+    console.log(`${SENTRY_URL} resolved to ${sentryUrl} from expo config.`);
+  } 
+}
 
 if (!authToken) {
   console.error(`${SENTRY_AUTH_TOKEN} environment variable must be set.`);

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const process = require('process');
 
+const SENTRY_URL = 'SENTRY_URL';
 const SENTRY_ORG = 'SENTRY_ORG';
 const SENTRY_PROJECT = 'SENTRY_PROJECT';
 const SENTRY_AUTH_TOKEN = 'SENTRY_AUTH_TOKEN';
@@ -111,6 +112,7 @@ try {
 }
 
 let sentryOrg = getEnvVar(SENTRY_ORG);
+let sentryUrl = getEnvVar(SENTRY_URL);
 let sentryProject = getEnvVar(SENTRY_PROJECT);
 let authToken = getEnvVar(SENTRY_AUTH_TOKEN);
 const sentryCliBin = getEnvVar(SENTRY_CLI_EXECUTABLE) || require.resolve('@sentry/cli/bin/sentry-cli');
@@ -147,6 +149,13 @@ if (!sentryOrg || !sentryProject) {
     console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
   }
 }
+if (pluginConfig.url) {
+  sentryUrl = pluginConfig.url;
+} else {
+  sentryUrl
+}
+console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
+
 
 if (!authToken) {
   console.error(`${SENTRY_AUTH_TOKEN} environment variable must be set.`);
@@ -186,6 +195,7 @@ for (const [assetGroupName, assets] of Object.entries(groupedAssets)) {
       ...process.env,
       [SENTRY_PROJECT]: sentryProject,
       [SENTRY_ORG]: sentryOrg,
+      [SENTRY_URL]: sentryUrl
     },
     stdio: 'inherit',
   });
@@ -196,8 +206,7 @@ if (numAssetsUploaded === totalAssets) {
   console.log('✅ Uploaded bundles and sourcemaps to Sentry successfully.');
 } else {
   console.warn(
-    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${
-      numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
+    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
     }`,
   );
 }

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -148,10 +148,6 @@ if (!sentryOrg || !sentryProject || !sentryUrl) {
     sentryProject = pluginConfig.project;
     console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
   }
-  if (!sentryProject) {
-    sentryUrl = pluginConfig.url;
-
-  }
   if (!sentryUrl) {
     if (!pluginConfig.url) {
       console.error(

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -206,7 +206,8 @@ if (numAssetsUploaded === totalAssets) {
   console.log('✅ Uploaded bundles and sourcemaps to Sentry successfully.');
 } else {
   console.warn(
-    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
+    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${
+      numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
     }`,
   );
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring


## :scroll: Description
Added sentryUrl for people that are self hosting


## :bulb: Motivation and Context
Its also possible to define URL inside app.json and this was missing from the command.


## :green_heart: How did you test it?
I tested it locally.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [X] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
