### PR TITLE
fix(performance): Missing frames measurements when active span is trimmed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### Fixes
 
 - Allow custom `sentryUrl` for Expo updates source maps uploads ([#3664](https://github.com/getsentry/sentry-react-native/pull/3664))
+- Missing Mobile Vitals (slow, frozen frames) when ActiveSpan (Transaction) is trimmed at the end ([#3684](https://github.com/getsentry/sentry-react-native/pull/3684))
 
 ## 5.19.3
 

--- a/src/js/tracing/utils.ts
+++ b/src/js/tracing/utils.ts
@@ -78,6 +78,15 @@ export function instrumentChildSpanFinish(
 
         callback(span, endTimestamp);
       };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const originalSpanEnd = span.end;
+
+      span.end = (endTimestamp?: number) => {
+        originalSpanEnd.apply(span, [endTimestamp]);
+
+        callback(span, endTimestamp);
+      };
     };
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
Introduced in https://github.com/getsentry/sentry-react-native/releases/tag/5.19.0 by the JS SDK update.

Caused by the integrations not calling finish() on spans.
- https://github.com/getsentry/sentry-javascript/pull/9954/files

## :green_heart: How did you test it?
sample app, the specific situation is hard to test in integration tests, so I have not added one, this should be tested in E2E tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- [ ] Add E2E tests for performance