### PR TITLE
misc(lint): Skip Android Tester App from JS eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,6 @@ test/perf/TestApp*
 
 # Ignore dangerfile
 dangerfile.js
+
+# Android Test App includes js in JVM test reports
+RNSentryAndroidTester


### PR DESCRIPTION
Android Test App includes js in JVM test reports after the test runs locally the repository lint fails.

#skip-changelog 
