### PR TITLE
misc(sample): Do not execute Sentry in NodeJS during npx expo export

### DIFF
--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -17,7 +17,7 @@ export {
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
-Sentry.init({
+process.env.EXPO_SKIP_DURING_EXPORT !== 'true' && Sentry.init({
   // Replace the example DSN below with your own DSN:
   dsn: SENTRY_INTERNAL_DSN,
   debug: true,

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -7,7 +7,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "ts:check": "tsc"
+    "ts:check": "tsc",
+    "export": "EXPO_SKIP_DURING_EXPORT='true' expo export --dump-sourcemap --clear"
   },
   "dependencies": {
     "@types/react": "18.2.45",


### PR DESCRIPTION
During Expo export, the JS code is executed, which spams the export output.

This PR adds env to the sample app to avoid this.

#skip-changelog 