### PR TITLE
feat(expo): Add getDefaultConfig option to getSentryExpoConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `getDefaultConfig` option to `getSentryExpoConfig` ([#3688](https://github.com/getsentry/sentry-react-native/pull/3688))
+- Add `getDefaultConfig` option to `getSentryExpoConfig` ([#3690](https://github.com/getsentry/sentry-react-native/pull/3690))
 
 ## 5.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `getDefaultConfig` option to `getSentryExpoConfig` ([#3688](https://github.com/getsentry/sentry-react-native/pull/3688))
+
 ## 5.20.0
 
 ### Features

--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -17,7 +17,7 @@ export {
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
-Sentry.init({
+process.env.EXPO_SKIP_DURING_EXPORT !== 'true' && Sentry.init({
   // Replace the example DSN below with your own DSN:
   dsn: SENTRY_INTERNAL_DSN,
   debug: true,

--- a/samples/expo/metro.config.js
+++ b/samples/expo/metro.config.js
@@ -1,4 +1,5 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('@expo/metro-config');
 const path = require('path');
 
 const { getSentryExpoConfig } = require('../../metro');
@@ -7,6 +8,7 @@ const { getSentryExpoConfig } = require('../../metro');
 const config = getSentryExpoConfig(__dirname, {
   // [Web-only]: Enables CSS support in Metro.
   isCSSEnabled: true,
+  getDefaultConfig,
 });
 
 config.watchFolders.push(path.resolve(__dirname, '../../node_modules/@sentry'));

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -7,7 +7,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "ts:check": "tsc"
+    "ts:check": "tsc",
+    "export": "EXPO_SKIP_DURING_EXPORT='true' expo export --dump-sourcemap --clear"
   },
   "dependencies": {
     "@types/react": "18.2.45",

--- a/samples/expo/utils/isExpoGo.ts
+++ b/samples/expo/utils/isExpoGo.ts
@@ -1,0 +1,5 @@
+import Constants, { AppOwnership } from 'expo-constants';
+
+export function isExpoGo(): boolean {
+  return Constants.appOwnership === AppOwnership.Expo;
+}

--- a/src/js/tools/metroconfig.ts
+++ b/src/js/tools/metroconfig.ts
@@ -23,8 +23,11 @@ export function withSentryConfig(config: MetroConfig): MetroConfig {
 /**
  * This function returns Default Expo configuration with Sentry plugins.
  */
-export function getSentryExpoConfig(projectRoot: string, options: DefaultConfigOptions = {}): MetroConfig {
-  const { getDefaultConfig } = loadExpoMetroConfigModule();
+export function getSentryExpoConfig(
+  projectRoot: string,
+  options: DefaultConfigOptions & { getDefaultConfig?: typeof getSentryExpoConfig } = {},
+): MetroConfig {
+  const getDefaultConfig = options.getDefaultConfig || loadExpoMetroConfigModule().getDefaultConfig;
   const config = getDefaultConfig(projectRoot, {
     ...options,
     unstable_beforeAssetSerializationPlugins: [


### PR DESCRIPTION
For special setups like our own repository, where the Sentry Metro Plugin is outside of the project structure it's needed to supply the correct (from the project node modules) default config. 

Otherwise, some features might not work, for example, hbc bundles are not emitted. 
