### PR TITLE
misc(sample): Disable Expo Web static routes, export command hangs

### DIFF
--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -29,7 +29,6 @@
     },
     "web": {
       "bundler": "metro",
-      "output": "static",
       "favicon": "./assets/favicon.png"
     },
     "experiments": {


### PR DESCRIPTION
Disable static output in the Expo sample app, this option causes the export command to hang.

I was  unable to determine why, but it happens when running the command multiple times, which is common during the SDK development.

- related issue https://github.com/expo/eas-cli/issues/1907