### PR TITLE
misc(sample): Enable expo-router auto instrumentation

### DIFF
--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -29,6 +29,7 @@
     },
     "web": {
       "bundler": "metro",
+      "output": "static",
       "favicon": "./assets/favicon.png"
     },
     "experiments": {

--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -29,7 +29,6 @@
     },
     "web": {
       "bundler": "metro",
-      "output": "static",
       "favicon": "./assets/favicon.png"
     },
     "experiments": {

--- a/samples/expo/utils/isExpoGo.ts
+++ b/samples/expo/utils/isExpoGo.ts
@@ -1,0 +1,5 @@
+import Constants, { AppOwnership } from 'expo-constants';
+
+export function isExpoGo(): boolean {
+  return Constants.appOwnership === AppOwnership.Expo;
+}


### PR DESCRIPTION
This PR adds Expo Router auto instrumentation to the Expo sample app.

#skip-changelog 