### PR TITLE
fix(timetodisplay): Change TimeToDisplay unsupported message from error to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Change TimeToDisplay unsupported log from error to warning level. ([#3699](https://github.com/getsentry/sentry-react-native/pull/3699))
+
 ## 5.20.0
 
 ### Features

--- a/src/js/tracing/timetodisplay.tsx
+++ b/src/js/tracing/timetodisplay.tsx
@@ -61,7 +61,9 @@ function TimeToDisplay(props: {
 
   if (__DEV__ && !nativeComponentMissingLogged && !nativeComponentExists) {
     nativeComponentMissingLogged = true;
-    logger.log('TimeToInitialDisplay and TimeToFullDisplay are not supported on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
+    setTimeout(() => {
+      logger.warn('TimeToInitialDisplay and TimeToFullDisplay are not supported on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
+    }, 0);
   }
 
   const onDraw = (event: { nativeEvent: RNSentryOnDrawNextFrameEvent }): void => onDrawNextFrame(event);

--- a/src/js/tracing/timetodisplay.tsx
+++ b/src/js/tracing/timetodisplay.tsx
@@ -61,6 +61,7 @@ function TimeToDisplay(props: {
 
   if (__DEV__ && !nativeComponentMissingLogged && !nativeComponentExists) {
     nativeComponentMissingLogged = true;
+    // Using setTimeout with a delay of 0 milliseconds to defer execution and avoid printing the React stack trace.
     setTimeout(() => {
       logger.warn('TimeToInitialDisplay and TimeToFullDisplay are not supported on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
     }, 0);

--- a/src/js/tracing/timetodisplay.tsx
+++ b/src/js/tracing/timetodisplay.tsx
@@ -61,7 +61,7 @@ function TimeToDisplay(props: {
 
   if (__DEV__ && !nativeComponentMissingLogged && !nativeComponentExists) {
     nativeComponentMissingLogged = true;
-    logger.error('RNSentryOnDrawReporter is not available on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
+    logger.warn('RNSentryOnDrawReporter is not available on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
   }
 
   const onDraw = (event: { nativeEvent: RNSentryOnDrawNextFrameEvent }): void => onDrawNextFrame(event);

--- a/src/js/tracing/timetodisplay.tsx
+++ b/src/js/tracing/timetodisplay.tsx
@@ -61,7 +61,7 @@ function TimeToDisplay(props: {
 
   if (__DEV__ && !nativeComponentMissingLogged && !nativeComponentExists) {
     nativeComponentMissingLogged = true;
-    logger.warn('RNSentryOnDrawReporter is not available on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
+    logger.log('TimeToInitialDisplay and TimeToFullDisplay are not supported on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
   }
 
   const onDraw = (event: { nativeEvent: RNSentryOnDrawNextFrameEvent }): void => onDrawNextFrame(event);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
The error log will trigger a stack trace log in React which is an unwanted side-effect. The log then looks like a crash/uncaught error. Plus the stack trace is not symbolicated so it's not useful.

This PR changes the log to a warning and uses Timeout to avoid the React stack printing.

Before:
![Screenshot 2024-03-20 at 19 16 30](https://github.com/getsentry/sentry-react-native/assets/31292499/d32f2b7a-964f-44f7-90c7-85142fcb2f9e)

After:
![Screenshot 2024-03-21 at 16 37 44](https://github.com/getsentry/sentry-react-native/assets/31292499/a0b28749-6265-4330-aedf-7e36dc25c1ab)
![Screenshot 2024-03-21 at 16 37 39](https://github.com/getsentry/sentry-react-native/assets/31292499/088d237d-0deb-4a5c-954a-82e822db4b23)

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
