### PR TITLE
extend screenshot integration to allow conditional screenshot attachment based on logic around event/hint

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Wix.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/js/integrations/screenshot.ts
+++ b/src/js/integrations/screenshot.ts
@@ -16,6 +16,10 @@ export class Screenshot implements Integration {
    */
   public name: string = Screenshot.id;
 
+  protected shouldAttachScreenshot(_event: Event, _hint: EventHint): boolean {
+    return true;
+  }
+
   /**
    * If enabled attaches a screenshot to the event hint.
    *
@@ -43,7 +47,7 @@ export class Screenshot implements Integration {
   public setupOnce(addGlobalEventProcessor: (e: EventProcessor) => void): void {
     addGlobalEventProcessor(async (event: Event, hint: EventHint) => {
       const hasException = event.exception && event.exception.values && event.exception.values.length > 0;
-      if (!hasException) {
+      if (!hasException || !this.shouldAttachScreenshot(event, hint)) {
         return event;
       }
 


### PR DESCRIPTION
to allow conditional screenshot attachment based on logic around event/hint

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
extend screenshot integration to allow conditional screenshot attachment based on logic around event/hint

## :bulb: Motivation and Context
We at Wix, would like to attach screenshot in a more granular way.

## :green_heart: How did you test it?
Locally, instead of sending `attachScreenShot: true` we simply extend the integration and add it.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [-] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
