### PR TITLE
fix(expo): Do not run the SDK during static routes generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Do not enable NativeFramesTracking when native is not available ([#3705](https://github.com/getsentry/sentry-react-native/pull/3705))
+- Do not initialize the SDK during `expo-router` static routes generation ([#3730](https://github.com/getsentry/sentry-react-native/pull/3730))
 
 ### Dependencies
 

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -19,7 +19,7 @@ import { TouchEventBoundary } from './touchevents';
 import { ReactNativeProfiler, ReactNativeTracing } from './tracing';
 import { DEFAULT_BUFFER_SIZE, makeNativeTransportFactory } from './transports/native';
 import { makeUtf8TextEncoder } from './transports/TextEncoder';
-import { getDefaultEnvironment, isExpoGo } from './utils/environment';
+import { getDefaultEnvironment, isExpoGo, isRunningInMetroDevServer } from './utils/environment';
 import { safeFactory, safeTracesSampler } from './utils/safe';
 import { NATIVE } from './wrapper';
 
@@ -44,6 +44,10 @@ const DEFAULT_OPTIONS: ReactNativeOptions = {
  * Inits the SDK and returns the final options.
  */
 export function init(passedOptions: ReactNativeOptions): void {
+  if (isRunningInMetroDevServer()) {
+    return;
+  }
+
   const reactNativeHub = new Hub(undefined, new ReactNativeScope());
   makeMain(reactNativeHub);
 

--- a/src/js/tools/metroconfig.ts
+++ b/src/js/tools/metroconfig.ts
@@ -131,6 +131,6 @@ export function withSentryFramesCollapsed(config: MetroConfig): MetroConfig {
  * This is used to determine if the SDK is running in Node in Metro Dev Server.
  * For example during static routes generation in `expo-router`.
  */
-function setSentryMetroDevServerEnvFlag() {
+function setSentryMetroDevServerEnvFlag(): void {
   env.___SENTRY_METRO_DEV_SERVER___ = 'true';
 }

--- a/src/js/tools/metroconfig.ts
+++ b/src/js/tools/metroconfig.ts
@@ -1,4 +1,5 @@
 import type { MetroConfig, MixedOutput, Module, ReadOnlyGraph } from 'metro';
+import { env } from 'process';
 
 import { createSentryMetroSerializer, unstable_beforeAssetSerializationPlugin } from './sentryMetroSerializer';
 import type { DefaultConfigOptions } from './vendor/expo/expoconfig';
@@ -12,6 +13,8 @@ export * from './sentryMetroSerializer';
  * Collapses Sentry frames from the stack trace view in LogBox.
  */
 export function withSentryConfig(config: MetroConfig): MetroConfig {
+  setSentryMetroDevServerEnvFlag();
+
   let newConfig = config;
 
   newConfig = withSentryDebugId(newConfig);
@@ -27,6 +30,8 @@ export function getSentryExpoConfig(
   projectRoot: string,
   options: DefaultConfigOptions & { getDefaultConfig?: typeof getSentryExpoConfig } = {},
 ): MetroConfig {
+  setSentryMetroDevServerEnvFlag();
+
   const getDefaultConfig = options.getDefaultConfig || loadExpoMetroConfigModule().getDefaultConfig;
   const config = getDefaultConfig(projectRoot, {
     ...options,
@@ -119,4 +124,13 @@ export function withSentryFramesCollapsed(config: MetroConfig): MetroConfig {
       customizeFrame,
     },
   };
+}
+
+/**
+ * Sets the `___SENTRY_METRO_DEV_SERVER___` environment flag.
+ * This is used to determine if the SDK is running in Node in Metro Dev Server.
+ * For example during static routes generation in `expo-router`.
+ */
+function setSentryMetroDevServerEnvFlag() {
+  env.___SENTRY_METRO_DEV_SERVER___ = 'true';
 }

--- a/src/js/utils/environment.ts
+++ b/src/js/utils/environment.ts
@@ -74,7 +74,11 @@ export function getDefaultEnvironment(): 'development' | 'production' {
 
 /** Check if SDK runs in Metro Dev Server side */
 export function isRunningInMetroDevServer(): boolean {
-  if (typeof RN_GLOBAL_OBJ.process !== 'undefined' && RN_GLOBAL_OBJ.process.env && RN_GLOBAL_OBJ.process.env.___SENTRY_METRO_DEV_SERVER___ === 'true') {
+  if (
+    typeof RN_GLOBAL_OBJ.process !== 'undefined' &&
+    RN_GLOBAL_OBJ.process.env &&
+    RN_GLOBAL_OBJ.process.env.___SENTRY_METRO_DEV_SERVER___ === 'true'
+  ) {
     return true;
   }
   return false;

--- a/src/js/utils/environment.ts
+++ b/src/js/utils/environment.ts
@@ -71,3 +71,11 @@ export function getHermesVersion(): string | undefined {
 export function getDefaultEnvironment(): 'development' | 'production' {
   return typeof __DEV__ !== 'undefined' && __DEV__ ? 'development' : 'production';
 }
+
+/** Check if SDK runs in Metro Dev Server side */
+export function isRunningInMetroDevServer(): boolean {
+  if (typeof RN_GLOBAL_OBJ.process !== 'undefined' && RN_GLOBAL_OBJ.process.env && RN_GLOBAL_OBJ.process.env.___SENTRY_METRO_DEV_SERVER___ === 'true') {
+    return true;
+  }
+  return false;
+}

--- a/src/js/utils/worldwide.ts
+++ b/src/js/utils/worldwide.ts
@@ -17,6 +17,11 @@ export interface ReactNativeInternalGlobal extends InternalGlobal {
   ErrorUtils?: ErrorUtils;
   expo?: ExpoGlobalObject;
   XMLHttpRequest?: typeof XMLHttpRequest;
+  process?: {
+    env?: {
+      ___SENTRY_METRO_DEV_SERVER___?: string;
+    };
+  };
 }
 
 /** Get's the global object for the current JavaScript runtime */


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Before this PR the Sentry RN SDK would be initialized during static routes generation by `expo-router`. This could cause issues as the SDK is not prepared to run on the server side. This behavior pollutes the dev server and export command logs.

Before: See the duplicate WARN labels caused by the SDK init.
<img width="1218" alt="Screenshot 2024-04-02 at 19 32 58" src="https://github.com/getsentry/sentry-react-native/assets/31292499/0f9495ff-5409-4d8c-878e-abb2b8c2bc17">

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
