### PR TITLE
fix(deprecations): Removes all trivial/drop-in-replacement deprecations

### DIFF
--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -16,7 +16,7 @@ import { Alert } from 'react-native';
 import { createIntegration } from './integrations/factory';
 import { defaultSdkInfo } from './integrations/sdkinfo';
 import type { ReactNativeClientOptions } from './options';
-import { ReactNativeTracing } from './tracing';
+import type { ReactNativeTracing } from './tracing';
 import { createUserFeedbackEnvelope, items } from './utils/envelope';
 import { ignoreRequireCycleLogs } from './utils/ignorerequirecyclelogs';
 import { mergeOutcomes } from './utils/outcome';
@@ -90,12 +90,12 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
   }
 
   /**
-   * Sets up the integrations
+   * @inheritdoc
    */
-  public setupIntegrations(): void {
-    super.setupIntegrations();
-    const tracing = this.getIntegration(ReactNativeTracing);
-    const routingName = tracing?.options.routingInstrumentation?.name;
+  protected _setupIntegrations(): void {
+    super._setupIntegrations();
+    const tracing = this.getIntegrationByName('ReactNativeTracing') as ReactNativeTracing;
+    const routingName = tracing?.options?.routingInstrumentation?.name;
     if (routingName) {
       this.addIntegration(createIntegration(routingName));
     }

--- a/src/js/profiling/integration.ts
+++ b/src/js/profiling/integration.ts
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import type { Hub } from '@sentry/core';
-import { getActiveTransaction } from '@sentry/core';
+import { getActiveTransaction, spanIsSampled } from '@sentry/core';
 import type { Envelope, Event, EventProcessor, Integration, ThreadCpuProfile, Transaction } from '@sentry/types';
 import { logger, uuid4 } from '@sentry/utils';
 import { Platform } from 'react-native';
@@ -112,7 +112,7 @@ export class HermesProfiling implements Integration {
   };
 
   private _shouldStartProfiling = (transaction: Transaction): boolean => {
-    if (!transaction.sampled) {
+    if (!spanIsSampled(transaction)) {
       logger.log('[Profiling] Transaction is not sampled, skipping profiling');
       return false;
     }

--- a/src/js/sdk.tsx
+++ b/src/js/sdk.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import type { Scope } from '@sentry/core';
-import { getIntegrationsToSetup, Hub, initAndBind, makeMain, setExtra } from '@sentry/core';
+import { getClient, getIntegrationsToSetup, Hub, initAndBind, makeMain, setExtra, withScope as coreWithScope } from '@sentry/core';
 import {
   defaultStackParser,
   getCurrentHub,
@@ -16,7 +16,8 @@ import type { ReactNativeClientOptions, ReactNativeOptions, ReactNativeWrapperOp
 import { shouldEnableNativeNagger } from './options';
 import { ReactNativeScope } from './scope';
 import { TouchEventBoundary } from './touchevents';
-import { ReactNativeProfiler, ReactNativeTracing } from './tracing';
+import type { ReactNativeTracing } from './tracing';
+import { ReactNativeProfiler } from './tracing';
 import { DEFAULT_BUFFER_SIZE, makeNativeTransportFactory } from './transports/native';
 import { makeUtf8TextEncoder } from './transports/TextEncoder';
 import { getDefaultEnvironment, isExpoGo } from './utils/environment';
@@ -108,7 +109,7 @@ export function wrap<P extends Record<string, unknown>>(
   RootComponent: React.ComponentType<P>,
   options?: ReactNativeWrapperOptions
 ): React.ComponentType<P> {
-  const tracingIntegration = getCurrentHub().getIntegration(ReactNativeTracing);
+  const tracingIntegration = getClient()?.getIntegrationByName?.('ReactNativeTracing') as ReactNativeTracing | undefined;
   if (tracingIntegration) {
     tracingIntegration.useAppStartWithProfiler = true;
   }
@@ -154,10 +155,7 @@ export function setDist(dist: string): void {
  * Use this only for testing purposes.
  */
 export function nativeCrash(): void {
-  const client = getCurrentHub().getClient<ReactNativeClient>();
-  if (client) {
-    client.nativeCrash();
-  }
+  NATIVE.nativeCrash();
 }
 
 /**
@@ -166,7 +164,7 @@ export function nativeCrash(): void {
  */
 export async function flush(): Promise<boolean> {
   try {
-    const client = getCurrentHub().getClient<ReactNativeClient>();
+    const client = getClient();
 
     if (client) {
       const result = await client.flush();
@@ -186,7 +184,7 @@ export async function flush(): Promise<boolean> {
  */
 export async function close(): Promise<void> {
   try {
-    const client = getCurrentHub().getClient<ReactNativeClient>();
+    const client = getClient();
 
     if (client) {
       await client.close();
@@ -200,7 +198,7 @@ export async function close(): Promise<void> {
  * Captures user feedback and sends it to Sentry.
  */
 export function captureUserFeedback(feedback: UserFeedback): void {
-  getCurrentHub().getClient<ReactNativeClient>()?.captureUserFeedback(feedback);
+  getClient<ReactNativeClient>()?.captureUserFeedback(feedback);
 }
 
 /**
@@ -225,12 +223,14 @@ export function withScope<T>(callback: (scope: Scope) => T): T | undefined {
       return undefined;
     }
   };
-  return getCurrentHub().withScope(safeCallback);
+  return coreWithScope(safeCallback);
 }
 
 /**
  * Callback to set context information onto the scope.
  * @param callback Callback function that receives Scope.
+ *
+ * @deprecated Use `getScope()` directly.
  */
 export function configureScope(callback: (scope: Scope) => void): ReturnType<Hub['configureScope']> {
   const safeCallback = (scope: Scope): void => {
@@ -240,5 +240,6 @@ export function configureScope(callback: (scope: Scope) => void): ReturnType<Hub
       logger.error('Error while running configureScope callback', e);
     }
   };
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().configureScope(safeCallback);
 }

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -1,4 +1,4 @@
-import { addBreadcrumb, getCurrentHub } from '@sentry/core';
+import { addBreadcrumb, getClient } from '@sentry/core';
 import type { SeverityLevel } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import * as React from 'react';
@@ -6,7 +6,7 @@ import type { GestureResponderEvent} from 'react-native';
 import { StyleSheet, View } from 'react-native';
 
 import { createIntegration } from './integrations/factory';
-import { ReactNativeTracing } from './tracing';
+import type { ReactNativeTracing } from './tracing';
 import { UI_ACTION_TOUCH } from './tracing/ops';
 
 export type TouchEventBoundaryProps = {
@@ -88,10 +88,10 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
    * Registers the TouchEventBoundary as a Sentry Integration.
    */
   public componentDidMount(): void {
-    const client = getCurrentHub().getClient();
+    const client = getClient();
     client?.addIntegration?.(createIntegration(this.name));
     if (!this._tracingIntegration && client) {
-      this._tracingIntegration = client.getIntegration(ReactNativeTracing);
+      this._tracingIntegration = client.getIntegrationByName?.('ReactNativeTracing') as ReactNativeTracing|| null;
     }
   }
 

--- a/src/js/tracing/addTracingExtensions.ts
+++ b/src/js/tracing/addTracingExtensions.ts
@@ -67,15 +67,14 @@ const _patchStartTransaction = (originalStartTransaction: StartTransactionFuncti
     if (reactNativeTracing) {
       reactNativeTracing.onTransactionStart(transaction);
 
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      const originalFinish = transaction.finish;
+      const originalFinish = transaction.end.bind(transaction);
 
-      transaction.finish = (endTimestamp: number | undefined) => {
+      transaction.end = (endTimestamp: number | undefined) => {
         if (reactNativeTracing) {
           reactNativeTracing.onTransactionFinish(transaction);
         }
 
-        return originalFinish.apply(transaction, [endTimestamp]);
+        return originalFinish(endTimestamp);
       };
     }
 

--- a/src/js/tracing/utils.ts
+++ b/src/js/tracing/utils.ts
@@ -94,7 +94,10 @@ export function instrumentChildSpanFinish(
 /**
  * Determines if the timestamp is now or within the specified margin of error from now.
  */
-export function isNearToNow(timestamp: number): boolean {
+export function isNearToNow(timestamp: number | undefined): boolean {
+  if (!timestamp) {
+    return false;
+  }
   return Math.abs(timestampInSeconds() - timestamp) <= MARGIN_OF_ERROR_SECONDS;
 }
 


### PR DESCRIPTION
This PR fixes trivial/drop-in-replacements deprecations coming from JS V7 (removed in V8).

- needs https://github.com/getsentry/sentry-react-native/pull/3721