### PR TITLE
fix(stalls): Missing measurements when using new .end() span API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Do not enable NativeFramesTracking when native is not available ([#3705](https://github.com/getsentry/sentry-react-native/pull/3705))
+- Fix missing Stall measurements when using new `.end()` span API ([#3737](https://github.com/getsentry/sentry-react-native/pull/3737))
 
 ### Dependencies
 

--- a/src/js/tracing/addTracingExtensions.ts
+++ b/src/js/tracing/addTracingExtensions.ts
@@ -72,10 +72,21 @@ const _patchStartTransaction = (originalStartTransaction: StartTransactionFuncti
 
       transaction.finish = (endTimestamp: number | undefined) => {
         if (reactNativeTracing) {
-          reactNativeTracing.onTransactionFinish(transaction);
+          reactNativeTracing.onTransactionFinish(transaction, endTimestamp);
         }
 
         return originalFinish.apply(transaction, [endTimestamp]);
+      };
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const originalEnd = transaction.end;
+
+      transaction.end = (endTimestamp: number | undefined) => {
+        if (reactNativeTracing) {
+          reactNativeTracing.onTransactionFinish(transaction, endTimestamp);
+        }
+
+        return originalEnd.apply(transaction, [endTimestamp]);
       };
     }
 

--- a/src/js/tracing/stalltracking.ts
+++ b/src/js/tracing/stalltracking.ts
@@ -122,6 +122,19 @@ export class StallTrackingInstrumentation {
             this._markSpanFinish(transaction, span.endTimestamp);
           }
         };
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        const originalSpanEnd = span.end;
+
+        span.end = (endTimestamp?: number) => {
+          // We let the span determine its own end timestamp as well in case anything gets changed upstream
+          originalSpanEnd.apply(span, [endTimestamp]);
+
+          // The span should set a timestamp, so this would be defined.
+          if (span.endTimestamp) {
+            this._markSpanFinish(transaction, span.endTimestamp);
+          }
+        };
       };
     }
   }

--- a/test/mocks/client.ts
+++ b/test/mocks/client.ts
@@ -13,6 +13,8 @@ import { resolvedSyncPromise } from '@sentry/utils';
 
 export function getDefaultTestClientOptions(options: Partial<TestClientOptions> = {}): TestClientOptions {
   return {
+    dsn: 'https://1234@some-domain.com/4505526893805568',
+    enabled: true,
     integrations: [],
     sendClientReports: true,
     transport: () =>
@@ -39,6 +41,7 @@ export class TestClient extends BaseClient<TestClientOptions> {
   public static sendEventCalled?: (event: Event) => void;
 
   public event?: Event;
+  public eventQueue: Array<Event> = [];
   public session?: Session;
 
   public constructor(options: TestClientOptions) {
@@ -73,6 +76,7 @@ export class TestClient extends BaseClient<TestClientOptions> {
 
   public sendEvent(event: Event, hint?: EventHint): void {
     this.event = event;
+    this.eventQueue.push(event);
 
     // In real life, this will get deleted as part of envelope creation.
     delete event.sdkProcessingMetadata;

--- a/test/tracing/reactnavigation.stalltracking.test.ts
+++ b/test/tracing/reactnavigation.stalltracking.test.ts
@@ -1,0 +1,69 @@
+import {
+  addGlobalEventProcessor,
+  getCurrentHub,
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  setCurrentClient,
+  startSpanManual,
+} from '@sentry/core';
+
+import { ReactNativeTracing, ReactNavigationInstrumentation } from '../../src/js';
+import { _addTracingExtensions } from '../../src/js/tracing/addTracingExtensions';
+import { RN_GLOBAL_OBJ } from '../../src/js/utils/worldwide';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+import { createMockNavigationAndAttachTo } from './reactnavigationutils';
+import { expectStallMeasurements } from './stalltrackingutils';
+
+jest.useFakeTimers({ advanceTimers: true });
+
+describe('StallTracking with ReactNavigation', () => {
+  let client: TestClient;
+  let mockNavigation: ReturnType<typeof createMockNavigationAndAttachTo>;
+
+  beforeEach(() => {
+    RN_GLOBAL_OBJ.__sentry_rn_v5_registered = false;
+    _addTracingExtensions();
+
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    const rnavigation = new ReactNavigationInstrumentation();
+    mockNavigation = createMockNavigationAndAttachTo(rnavigation);
+
+    const rnTracing = new ReactNativeTracing({
+      routingInstrumentation: rnavigation,
+      enableStallTracking: true,
+      enableNativeFramesTracking: false,
+      enableAppStartTracking: false,
+    });
+
+    const options = getDefaultTestClientOptions({
+      tracesSampleRate: 1.0,
+      integrations: [rnTracing],
+    });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    // We have to call this manually as setupOnce is executed once per runtime (global var check)
+    rnTracing.setupOnce(addGlobalEventProcessor, getCurrentHub);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Stall tracking supports idleTransaction with unfinished spans', async () => {
+    jest.runOnlyPendingTimers(); // Flush app start transaction
+    mockNavigation.navigateToNewScreen();
+    startSpanManual({ name: 'This child span will never finish' }, () => {});
+
+    jest.runOnlyPendingTimers(); // Flush new screen transaction
+
+    await client.flush();
+
+    expectStallMeasurements(client.event?.measurements);
+  });
+});

--- a/test/tracing/reactnavigationutils.ts
+++ b/test/tracing/reactnavigationutils.ts
@@ -1,0 +1,67 @@
+import type { NavigationRoute, ReactNavigationInstrumentation } from '../../src/js/tracing/reactnavigation';
+
+export function createMockNavigationAndAttachTo(sut: ReactNavigationInstrumentation) {
+  const mockedNavigationContained = mockNavigationContainer();
+  const mockedNavigation = {
+    navigateToNewScreen: () => {
+      mockedNavigationContained.listeners['__unsafe_action__']({
+        // this object is not used by the instrumentation
+      });
+      mockedNavigationContained.currentRoute = {
+        key: 'new_screen',
+        name: 'New Screen',
+      };
+      mockedNavigationContained.listeners['state']({
+        // this object is not used by the instrumentation
+      });
+    },
+    navigateToInitialScreen: () => {
+      mockedNavigationContained.listeners['__unsafe_action__']({
+        // this object is not used by the instrumentation
+      });
+      mockedNavigationContained.currentRoute = {
+        key: 'initial_screen',
+        name: 'Initial Screen',
+      };
+      mockedNavigationContained.listeners['state']({
+        // this object is not used by the instrumentation
+      });
+    },
+    finishAppStartNavigation: () => {
+      mockedNavigationContained.currentRoute = {
+        key: 'initial_screen',
+        name: 'Initial Screen',
+      };
+      mockedNavigationContained.listeners['state']({
+        // this object is not used by the instrumentation
+      });
+    },
+  };
+  sut.registerNavigationContainer(mockRef(mockedNavigationContained));
+
+  return mockedNavigation;
+}
+
+function mockRef<T>(wat: T): { current: T } {
+  return {
+    current: wat,
+  };
+}
+
+function mockNavigationContainer(): MockNavigationContainer {
+  return new MockNavigationContainer();
+}
+
+export class MockNavigationContainer {
+  currentRoute: NavigationRoute = {
+    key: 'initial_screen',
+    name: 'Initial Screen',
+  };
+  listeners: Record<string, (e: any) => void> = {};
+  addListener: any = jest.fn((eventType: string, listener: (e: any) => void): void => {
+    this.listeners[eventType] = listener;
+  });
+  getCurrentRoute(): NavigationRoute | undefined {
+    return this.currentRoute;
+  }
+}

--- a/test/tracing/stalltracking.test.ts
+++ b/test/tracing/stalltracking.test.ts
@@ -15,7 +15,7 @@ import { timestampInSeconds } from '@sentry/utils';
 import { ReactNativeTracing } from '../../src/js';
 import { _addTracingExtensions } from '../../src/js/tracing/addTracingExtensions';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
-import { expectNonZeroStallMeasurements,expectStallMeasurements } from './stalltrackingutils';
+import { expectNonZeroStallMeasurements, expectStallMeasurements } from './stalltrackingutils';
 
 jest.useFakeTimers({ advanceTimers: true });
 

--- a/test/tracing/stalltracking.test.ts
+++ b/test/tracing/stalltracking.test.ts
@@ -1,17 +1,22 @@
-import type { Hub } from '@sentry/core';
-import { IdleTransaction, Transaction } from '@sentry/core';
-import type { Event } from '@sentry/types';
+import {
+  addGlobalEventProcessor,
+  getCurrentHub,
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  setCurrentClient,
+  startSpan,
+  startSpanManual,
+  startTransaction,
+} from '@sentry/core';
+import type { Measurements, Span } from '@sentry/types';
+import { timestampInSeconds } from '@sentry/utils';
 
-import { StallTrackingInstrumentation } from '../../src/js/tracing/stalltracking';
+import { ReactNativeTracing } from '../../src/js';
+import { _addTracingExtensions } from '../../src/js/tracing/addTracingExtensions';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 
-const mockHub = {
-  captureEvent: jest.fn(),
-  getClient: jest.fn(),
-};
-
-const getLastEvent = (): Event => {
-  return mockHub.captureEvent.mock.calls[mockHub.captureEvent.mock.calls.length - 1][0];
-};
+jest.useFakeTimers({ advanceTimers: true });
 
 const expensiveOperation = () => {
   const expensiveObject: { value: string[] } = {
@@ -24,506 +29,259 @@ const expensiveOperation = () => {
   }
 };
 
-describe('StallTracking', () => {
-  const localHub: Hub = mockHub as unknown as Hub;
+describe('StallTrackingNew', () => {
+  let client: TestClient;
 
-  it('Stall tracking detects a JS stall', done => {
-    const stallTracking = new StallTrackingInstrumentation();
+  beforeEach(() => {
+    _addTracingExtensions();
 
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        sampled: true,
-      },
-      localHub,
-    );
-    transaction.initSpanRecorder();
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
 
-    stallTracking.onTransactionStart(transaction);
+    const rnTracing = new ReactNativeTracing({
+      enableStallTracking: true,
+      enableNativeFramesTracking: false,
+      enableAppStartTracking: false,
+    });
 
-    expensiveOperation();
+    const options = getDefaultTestClientOptions({
+      tracesSampleRate: 1.0,
+      integrations: [rnTracing],
+    });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
 
-    setTimeout(() => {
-      stallTracking.onTransactionFinish(transaction);
-      transaction.finish();
-
-      const measurements = getLastEvent()?.measurements;
-
-      expect(measurements).toBeDefined();
-      if (measurements) {
-        expect(measurements.stall_count.value).toBeGreaterThan(0);
-        expect(measurements.stall_count.unit).toBe('none');
-
-        expect(measurements.stall_longest_time.value).toBeGreaterThan(0);
-        expect(measurements.stall_longest_time.unit).toBe('millisecond');
-
-        expect(measurements.stall_total_time.value).toBeGreaterThan(0);
-        expect(measurements.stall_total_time.unit).toBe('millisecond');
-      }
-
-      done();
-    }, 500);
+    // We have to call this manually as setupOnce is executed once per runtime (global var check)
+    rnTracing.setupOnce(addGlobalEventProcessor, getCurrentHub);
   });
 
-  it('Stall tracking detects multiple JS stalls', done => {
-    const stallTracking = new StallTrackingInstrumentation();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        sampled: true,
-      },
-      localHub,
-    );
-    transaction.initSpanRecorder();
-
-    stallTracking.onTransactionStart(transaction);
-
-    expensiveOperation();
-
-    setTimeout(() => {
+  it('Stall tracking detects a JS stall', async () => {
+    startSpan({ name: 'Stall will happen during this span' }, () => {
       expensiveOperation();
-    }, 200);
-
-    setTimeout(() => {
-      stallTracking.onTransactionFinish(transaction);
-      transaction.finish();
-      const measurements = getLastEvent()?.measurements;
-
-      expect(measurements).toBeDefined();
-      if (measurements) {
-        expect(measurements.stall_count.value).toBeGreaterThanOrEqual(2);
-        expect(measurements.stall_longest_time.value).toBeGreaterThan(0);
-        expect(measurements.stall_total_time.value).toBeGreaterThan(0);
-      }
-
-      done();
-    }, 500);
-  });
-
-  it('Stall tracking timeout is stopped after finishing all transactions (single)', () => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        sampled: true,
-      },
-      localHub,
-    );
-
-    stallTracking.onTransactionStart(transaction);
-
-    stallTracking.onTransactionFinish(transaction);
-    transaction.finish();
-
-    const measurements = getLastEvent()?.measurements;
-
-    expect(measurements).not.toBe(null);
-
-    expect(stallTracking.isTracking).toBe(false);
-  });
-
-  it('Stall tracking timeout is stopped after finishing all transactions (multiple)', done => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction0 = new Transaction(
-      {
-        name: 'Test Transaction 0',
-        sampled: true,
-      },
-      localHub,
-    );
-    const transaction1 = new Transaction(
-      {
-        name: 'Test Transaction 1',
-        sampled: true,
-      },
-      localHub,
-    );
-    const transaction2 = new Transaction(
-      {
-        name: 'Test Transaction 2',
-        sampled: true,
-      },
-      localHub,
-    );
-
-    stallTracking.onTransactionStart(transaction0);
-    stallTracking.onTransactionStart(transaction1);
-
-    stallTracking.onTransactionFinish(transaction0);
-    transaction0.finish();
-    const measurements0 = getLastEvent()?.measurements;
-    expect(measurements0).toBeDefined();
-
-    setTimeout(() => {
-      stallTracking.onTransactionFinish(transaction1);
-      transaction1.finish();
-      const measurements1 = getLastEvent()?.measurements;
-      expect(measurements1).toBeDefined();
-    }, 600);
-
-    setTimeout(() => {
-      stallTracking.onTransactionStart(transaction2);
-
-      setTimeout(() => {
-        stallTracking.onTransactionFinish(transaction2);
-        transaction2.finish();
-        const measurements2 = getLastEvent()?.measurements;
-        expect(measurements2).not.toBe(null);
-
-        expect(stallTracking.isTracking).toBe(false);
-
-        done();
-      }, 200);
-    }, 500);
-
-    // If the stall tracking does not correctly stop, the process will keep running. We detect this by passing --detectOpenHandles to jest.
-  });
-
-  it('Stall tracking returns measurements format on finish', () => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        sampled: true,
-      },
-      localHub,
-    );
-
-    stallTracking.onTransactionStart(transaction);
-
-    stallTracking.onTransactionFinish(transaction);
-    transaction.finish();
-    const measurements = getLastEvent()?.measurements;
-
-    expect(measurements).toBeDefined();
-
-    if (measurements) {
-      expect(measurements.stall_count.value).toBe(0);
-      expect(measurements.stall_longest_time.value).toBe(0);
-      expect(measurements.stall_total_time.value).toBe(0);
-    }
-  });
-
-  it("Stall tracking returns null on a custom endTimestamp that is not a span's", () => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        sampled: true,
-      },
-      localHub,
-    );
-
-    stallTracking.onTransactionStart(transaction);
-
-    stallTracking.onTransactionFinish(transaction, Date.now() / 1000);
-    transaction.finish();
-    const measurements = getLastEvent()?.measurements;
-
-    expect(measurements).toBeUndefined();
-  });
-
-  it('Stall tracking supports endTimestamp that is from the last span (trimEnd case)', done => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        trimEnd: true,
-        sampled: true,
-      },
-      localHub,
-    );
-    transaction.initSpanRecorder();
-
-    stallTracking.onTransactionStart(transaction);
-
-    const span = transaction.startChild({
-      description: 'Test Span',
+      // Ensures at least one iteration of the JS loop check
+      // (executed the last scheduled one which might be also the first scheduled)
+      jest.runOnlyPendingTimers();
     });
 
-    let spanFinishTime: number | undefined;
+    await client.flush();
 
-    setTimeout(() => {
-      spanFinishTime = Date.now() / 1000;
-
-      span.finish(spanFinishTime);
-    }, 100);
-
-    setTimeout(() => {
-      expect(spanFinishTime).toEqual(expect.any(Number));
-
-      stallTracking.onTransactionFinish(transaction);
-      transaction.finish();
-      const measurements = getLastEvent()?.measurements;
-
-      expect(measurements).toBeDefined();
-
-      if (measurements) {
-        expect(measurements.stall_count.value).toEqual(expect.any(Number));
-        expect(measurements.stall_longest_time.value).toEqual(expect.any(Number));
-        expect(measurements.stall_total_time.value).toEqual(expect.any(Number));
-      }
-
-      done();
-    }, 400);
+    expectValidNonZeroStallMeasurements(client.event?.measurements);
   });
 
-  it('Stall tracking rejects endTimestamp that is from the last span if trimEnd is false (trimEnd case)', done => {
-    const stallTracking = new StallTrackingInstrumentation();
+  it('Stall tracking detects multiple JS stalls', async () => {
+    startSpan({ name: 'Stall will happen during this span' }, () => {
+      expensiveOperation();
+      // Ensures at least one iteration of the JS loop check
+      // (executed the last scheduled one which might be also the first scheduled)
+      jest.runOnlyPendingTimers();
 
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        trimEnd: false,
-        sampled: true,
-      },
-      localHub,
-    );
-    transaction.initSpanRecorder();
-
-    stallTracking.onTransactionStart(transaction);
-
-    const span = transaction.startChild({
-      description: 'Test Span',
+      expensiveOperation();
+      jest.runOnlyPendingTimers();
     });
 
-    let spanFinishTime: number | undefined;
+    await client.flush();
 
-    setTimeout(() => {
-      spanFinishTime = Date.now() / 1000;
-
-      span.finish(spanFinishTime);
-    }, 100);
-
-    setTimeout(() => {
-      expect(spanFinishTime).toEqual(expect.any(Number));
-
-      stallTracking.onTransactionFinish(transaction, spanFinishTime);
-      transaction.finish();
-      const measurements = getLastEvent()?.measurements;
-
-      expect(measurements).toBeUndefined();
-
-      done();
-    }, 400);
+    const measurements = client.event?.measurements;
+    expectValidNonZeroStallMeasurements(measurements);
+    expect(measurements?.stall_count.value).toBeGreaterThanOrEqual(2);
   });
 
-  it('Stall tracking rejects endTimestamp even if it is a span time (custom endTimestamp case)', done => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        sampled: true,
-      },
-      localHub,
-    );
-    transaction.initSpanRecorder();
-
-    stallTracking.onTransactionStart(transaction);
-
-    const span = transaction.startChild({
-      description: 'Test Span',
+  it('Stall tracking timeout is stopped after finishing all transactions (single)', async () => {
+    startSpan({ name: 'Stall will happen during this span' }, () => {
+      expensiveOperation();
+      // Ensures at least one iteration of the JS loop check
+      // (executed the last scheduled one which might be also the first scheduled)
+      jest.runOnlyPendingTimers();
     });
 
-    let spanFinishTime: number | undefined;
+    await client.flush();
 
-    setTimeout(() => {
-      spanFinishTime = Date.now() / 1000;
+    jest.runAllTimers(); // If tracking would be running there would always be a new timer creating infinite loop
 
-      span.finish(spanFinishTime);
-    }, 100);
-
-    setTimeout(() => {
-      expect(spanFinishTime).toEqual(expect.any(Number));
-
-      if (typeof spanFinishTime === 'number') {
-        stallTracking.onTransactionFinish(transaction, spanFinishTime + 0.015);
-        transaction.finish();
-        const evt = getLastEvent();
-        const measurements = evt?.measurements;
-
-        expect(measurements).toBeUndefined();
-      }
-
-      done();
-    }, 400);
+    expectValidNonZeroStallMeasurements(client.event?.measurements);
   });
 
-  it('Stall tracking supports idleTransaction with unfinished spans', async () => {
-    jest.useFakeTimers();
-    const stallTracking = new StallTrackingInstrumentation();
-    const idleTransaction = new IdleTransaction(
-      {
-        name: 'Test Transaction',
-        trimEnd: true,
-        sampled: true,
-      },
-      localHub,
-      undefined,
-      undefined,
-    );
-    idleTransaction.initSpanRecorder();
+  it('Stall tracking timeout is stopped after finishing all transactions (multiple)', async () => {
+    // new `startSpan` API doesn't allow creation of multiple transactions
+    const t0 = startTransaction({ name: 'Test Transaction 0' });
+    const t1 = startTransaction({ name: 'Test Transaction 1' });
+    const t2 = startTransaction({ name: 'Test Transaction 2' });
 
-    stallTracking.onTransactionStart(idleTransaction);
-
-    idleTransaction.registerBeforeFinishCallback((_, endTimestamp) => {
-      stallTracking.onTransactionFinish(idleTransaction, endTimestamp);
-    });
-
-    // Span is never finished.
-    idleTransaction.startChild({
-      description: 'Test Span',
-    });
-
-    await Promise.resolve();
-    jest.advanceTimersByTime(100);
-
-    stallTracking.onTransactionFinish(idleTransaction, +0.015);
-    idleTransaction.finish();
-
-    const measurements = getLastEvent()?.measurements;
-
-    expect(measurements).toBeDefined();
-
-    expect(measurements?.stall_count.value).toEqual(expect.any(Number));
-    expect(measurements?.stall_longest_time.value).toEqual(expect.any(Number));
-    expect(measurements?.stall_total_time.value).toEqual(expect.any(Number));
-
+    t0.end();
     jest.runOnlyPendingTimers();
-    jest.useRealTimers();
+    t1.end();
+    jest.runOnlyPendingTimers();
+    t2.end();
+    jest.runOnlyPendingTimers();
+
+    await client.flush();
+
+    jest.runAllTimers(); // If tracking would be running there would always be a new timer creating infinite loop
+
+    const measurements2 = client.eventQueue.pop()?.measurements;
+    const measurements1 = client.eventQueue.pop()?.measurements;
+    const measurements0 = client.eventQueue.pop()?.measurements;
+
+    expectStallMeasurements(measurements0);
+    expectStallMeasurements(measurements1);
+    expectStallMeasurements(measurements2);
   });
 
-  it('Stall tracking ignores unfinished spans in normal transactions', done => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        trimEnd: true,
-        sampled: true,
-      },
-      localHub,
-    );
-    transaction.initSpanRecorder();
-
-    stallTracking.onTransactionStart(transaction);
-
-    // Span is never finished.
-    transaction.startChild({
-      description: 'Test Span',
+  it('Stall tracking returns measurements format on finish', async () => {
+    startSpan({ name: 'Stall will happen during this span' }, () => {
+      // no expensive operation
     });
 
-    // Span will be finished
-    const span = transaction.startChild({
-      description: 'To Finish',
-    });
+    await client.flush();
 
-    setTimeout(() => {
-      span.finish();
-    }, 100);
-
-    setTimeout(() => {
-      stallTracking.onTransactionFinish(transaction);
-      transaction.finish();
-      const measurements = getLastEvent()?.measurements;
-
-      expect(measurements).toBeDefined();
-
-      if (measurements) {
-        expect(measurements.stall_count.value).toEqual(expect.any(Number));
-        expect(measurements.stall_longest_time.value).toEqual(expect.any(Number));
-        expect(measurements.stall_total_time.value).toEqual(expect.any(Number));
-      }
-
-      done();
-    }, 500);
+    expectStallMeasurements(client.event?.measurements);
   });
 
-  it('Stall tracking only measures stalls inside the final time when trimEnd is used', done => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transaction = new Transaction(
-      {
-        name: 'Test Transaction',
-        trimEnd: true,
-        sampled: true,
-      },
-      localHub,
-    );
-    transaction.initSpanRecorder();
-
-    stallTracking.onTransactionStart(transaction);
-
-    // Span will be finished
-    const span = transaction.startChild({
-      description: 'To Finish',
+  it("Stall tracking returns null on a custom endTimestamp that is not a span's", async () => {
+    startSpanManual({ name: 'Stall will happen during this span', trimEnd: false }, (rootSpan: Span | undefined) => {
+      rootSpan!.end(timestampInSeconds());
     });
 
-    setTimeout(() => {
-      span.finish();
-    }, 200);
+    await client.flush();
 
-    setTimeout(() => {
-      stallTracking.onTransactionFinish(transaction);
-      transaction.finish();
-      const measurements = getLastEvent()?.measurements;
-
-      expect(measurements).toBeDefined();
-
-      if (measurements) {
-        expect(measurements.stall_count.value).toEqual(1);
-        expect(measurements.stall_longest_time.value).toEqual(expect.any(Number));
-        expect(measurements.stall_total_time.value).toEqual(expect.any(Number));
-      }
-
-      done();
-    }, 500);
-
-    setTimeout(() => {
-      // this should be run after the span finishes, and not logged.
-      expensiveOperation();
-    }, 300);
-
-    expensiveOperation();
+    expect(client.event?.measurements).toBeUndefined();
   });
 
-  it('Stall tracking does not track the first transaction if more than 10 are running', () => {
-    const stallTracking = new StallTrackingInstrumentation();
-
-    const transactions = new Array(11).fill(0).map((_, i) => {
-      const transaction = new Transaction(
-        {
-          name: `Test Transaction ${i}`,
-          sampled: true,
-        },
-        localHub,
-      );
-
-      stallTracking.onTransactionStart(transaction);
-
-      return transaction;
+  it('Stall tracking supports endTimestamp that is from the last span (trimEnd case)', async () => {
+    startSpanManual({ name: 'Stall will happen during this span', trimEnd: true }, (rootSpan: Span | undefined) => {
+      let childSpanEnd: number | undefined = undefined;
+      startSpanManual({ name: 'This is a child of the active span' }, (childSpan: Span | undefined) => {
+        childSpanEnd = timestampInSeconds();
+        childSpan!.end(childSpanEnd);
+        jest.runOnlyPendingTimers();
+      });
+      jest.runOnlyPendingTimers();
+      rootSpan!.end(childSpanEnd);
     });
 
-    stallTracking.onTransactionFinish(transactions[0]);
-    transactions[0].finish();
-    const measurements0 = getLastEvent()?.measurements;
-    expect(measurements0).toBeUndefined();
+    await client.flush();
 
-    stallTracking.onTransactionFinish(transactions[1]);
-    transactions[1].finish();
-    const measurements1 = getLastEvent()?.measurements;
-    expect(measurements1).toBeDefined();
+    expectStallMeasurements(client.event?.measurements);
+  });
 
-    transactions.slice(2).forEach(transaction => {
-      stallTracking.onTransactionFinish(transaction);
-      transaction.finish();
+  it('Stall tracking rejects endTimestamp that is from the last span if trimEnd is false (trimEnd case)', async () => {
+    startSpanManual({ name: 'Stall will happen during this span', trimEnd: false }, (rootSpan: Span | undefined) => {
+      let childSpanEnd: number | undefined = undefined;
+      startSpanManual({ name: 'This is a child of the active span' }, (childSpan: Span | undefined) => {
+        childSpanEnd = timestampInSeconds();
+        childSpan!.end(childSpanEnd);
+        jest.runOnlyPendingTimers();
+      });
+      jest.runOnlyPendingTimers();
+      rootSpan!.end(childSpanEnd);
     });
+
+    await client.flush();
+
+    expect(client.event?.measurements).toBeUndefined();
+  });
+
+  it('Stall tracking rejects endTimestamp even if it is a span time (custom endTimestamp case)', async () => {
+    startSpanManual({ name: 'Stall will happen during this span', trimEnd: false }, (rootSpan: Span | undefined) => {
+      let childSpanEnd: number | undefined = undefined;
+      startSpanManual({ name: 'This is a child of the active span' }, (childSpan: Span | undefined) => {
+        childSpanEnd = timestampInSeconds();
+        childSpan!.end(childSpanEnd);
+        jest.runOnlyPendingTimers();
+      });
+      jest.runOnlyPendingTimers();
+      rootSpan!.end(childSpanEnd! + 0.1);
+    });
+
+    await client.flush();
+
+    expect(client.event?.measurements).toBeUndefined();
+  });
+
+  // it('Stall tracking supports idleTransaction with unfinished spans', async () => {
+  // TODO: This is only possible to test via public API with mocked auto navigation instrumentation
+  // https://github.com/getsentry/sentry-react-native/blob/a5fdf556822f33677ca587bd82dbf54cc4d46e72/src/js/tracing/reactnativetracing.ts#L556
+  // });
+
+  it('Stall tracking ignores unfinished spans in normal transactions', async () => {
+    startSpan({ name: 'Stall will happen during this span', trimEnd: true }, () => {
+      startSpan({ name: 'This child span will finish' }, () => {
+        jest.runOnlyPendingTimers();
+      });
+      startSpanManual({ name: 'This child span never finishes' }, () => {
+        jest.runOnlyPendingTimers();
+      });
+      jest.runOnlyPendingTimers();
+    });
+
+    await client.flush();
+
+    expectStallMeasurements(client.event?.measurements);
+  });
+
+  it('Stall tracking only measures stalls inside the final time when trimEnd is used', async () => {
+    startSpan({ name: 'Stall will happen during this span', trimEnd: true }, () => {
+      startSpan({ name: 'This child span contains expensive operation' }, () => {
+        expensiveOperation();
+        jest.runOnlyPendingTimers();
+      });
+
+      expensiveOperation(); // This should not be recorded
+      jest.runOnlyPendingTimers();
+    });
+
+    await client.flush();
+
+    const measurements = client.event?.measurements;
+    expectValidNonZeroStallMeasurements(measurements);
+    expect(measurements?.stall_count.value).toEqual(1);
+  });
+
+  it('Stall tracking does not track the first transaction if more than 10 are running', async () => {
+    // new `startSpan` API doesn't allow creation of multiple transactions
+    new Array(11)
+      .fill(undefined)
+      .map((_, i) => {
+        return startTransaction({ name: `Test Transaction ${i}` });
+      })
+      .forEach(t => {
+        t.end();
+      });
+
+    await client.flush();
+
+    expect(client.eventQueue[0].measurements).toBeUndefined();
   });
 });
+
+function expectStallMeasurements(measurements: Measurements | undefined) {
+  expect(measurements).toBeDefined();
+
+  expect(measurements?.stall_count.value).toBeGreaterThanOrEqual(0);
+  expect(measurements?.stall_count.unit).toBe('none');
+
+  expect(measurements?.stall_longest_time.value).toBeGreaterThanOrEqual(0);
+  expect(measurements?.stall_longest_time.unit).toBe('millisecond');
+
+  expect(measurements?.stall_total_time.value).toBeGreaterThanOrEqual(0);
+  expect(measurements?.stall_total_time.unit).toBe('millisecond');
+}
+
+function expectValidNonZeroStallMeasurements(measurements: Measurements | undefined) {
+  expect(measurements).toBeDefined();
+
+  expect(measurements?.stall_count.value).toBeGreaterThan(0);
+  expect(measurements?.stall_count.unit).toBe('none');
+
+  expect(measurements?.stall_longest_time.value).toBeGreaterThan(0);
+  expect(measurements?.stall_longest_time.unit).toBe('millisecond');
+
+  expect(measurements?.stall_total_time.value).toBeGreaterThan(0);
+  expect(measurements?.stall_total_time.unit).toBe('millisecond');
+}

--- a/test/tracing/stalltrackingutils.ts
+++ b/test/tracing/stalltrackingutils.ts
@@ -1,0 +1,27 @@
+import type { Measurements } from '@sentry/types';
+
+export function expectStallMeasurements(measurements: Measurements | undefined) {
+  expect(measurements).toBeDefined();
+
+  expect(measurements?.stall_count.value).toBeGreaterThanOrEqual(0);
+  expect(measurements?.stall_count.unit).toBe('none');
+
+  expect(measurements?.stall_longest_time.value).toBeGreaterThanOrEqual(0);
+  expect(measurements?.stall_longest_time.unit).toBe('millisecond');
+
+  expect(measurements?.stall_total_time.value).toBeGreaterThanOrEqual(0);
+  expect(measurements?.stall_total_time.unit).toBe('millisecond');
+}
+
+export function expectNonZeroStallMeasurements(measurements: Measurements | undefined) {
+  expect(measurements).toBeDefined();
+
+  expect(measurements?.stall_count.value).toBeGreaterThan(0);
+  expect(measurements?.stall_count.unit).toBe('none');
+
+  expect(measurements?.stall_longest_time.value).toBeGreaterThan(0);
+  expect(measurements?.stall_longest_time.unit).toBe('millisecond');
+
+  expect(measurements?.stall_total_time.value).toBeGreaterThan(0);
+  expect(measurements?.stall_total_time.unit).toBe('millisecond');
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR is a preparation for JS V8 and its new performance spans-only API. It fixes a small bug where `.end` methods were not patched.

This PR refactors StallTracking integration tests to avoid using Transaction and internal APIs. 

This will enable us to refactor the integration in the future with confidence and minimal test changes.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps