### PR TITLE
fix(ci): Only install `xcbeautify` if missing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -249,7 +249,7 @@ jobs:
 
       - name: Setup Global Xcode Tools
         if: ${{ matrix.platform == 'ios' }}
-        run: brew install xcbeautify
+        run: which xcbeautify || brew install xcbeautify
 
       - name: NPM cache SDK
         uses: actions/cache@v4
@@ -478,7 +478,7 @@ jobs:
 
       - name: Setup Global Xcode Tools
         if: ${{ matrix.platform == 'ios' }}
-        run: brew install xcbeautify
+        run: which xcbeautify || brew install xcbeautify
 
       - name: Download App Package
         if: matrix.build-type == 'production'

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Setup Global Xcode Tools
         if: ${{ matrix.platform == 'ios' }}
-        run: brew install xcbeautify
+        run: which xcbeautify || brew install xcbeautify
 
       - name: Install SDK Dependencies
         run: yarn install --frozen-lockfile


### PR DESCRIPTION
The new version of `xcbeautify`, 2.x.x, is not compatible with the `macos12` runners, but the runners include an older version, 1.6.0.

- https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
- https://github.com/cpisciotta/xcbeautify/releases/tag/2.0.1

This PR adds a check to only install the tool if missing.

#skip-changelog 