### PR TITLE
misc: Update VSC settings fixAll option changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "[json]": {
     "editor.formatOnType": false,


### PR DESCRIPTION
#skip-changelog 

New versions of VSC deprecated the bool option replaced by enum, 'explicit'.