### PR TITLE
fix(ios): Warn and do not overwrite when iOS build uses outdated source maps configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Warn and do not overwrite when `$EXTRA_PACKAGER_ARGS` with `--sourcemap-output` detected during iOS build ([#3775](https://github.com/getsentry/sentry-react-native/pull/3775))
+  - Only when using `sentry-xcode.sh`, learn how to use it at https://docs.sentry.io/platforms/react-native/manual-setup/manual-setup/#configure-automatic-source-maps-upload
+
 ## 5.22.0
 
 ### Features

--- a/scripts/sentry-xcode.sh
+++ b/scripts/sentry-xcode.sh
@@ -10,12 +10,28 @@ set -x -e
 LOCAL_NODE_BINARY=${NODE_BINARY:-node}
 
 [ -z "$SENTRY_PROPERTIES" ] && export SENTRY_PROPERTIES=sentry.properties
-[ -z "$SOURCEMAP_FILE" ] && export SOURCEMAP_FILE="$DERIVED_FILE_DIR/main.jsbundle.map"
 
 [ -z "$SENTRY_CLI_EXECUTABLE" ] && SENTRY_CLI_PACKAGE_PATH=$("$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/cli/package.json'))")
 [ -z "$SENTRY_CLI_EXECUTABLE" ] && SENTRY_CLI_EXECUTABLE="${SENTRY_CLI_PACKAGE_PATH}/bin/sentry-cli"
 
 REACT_NATIVE_XCODE=$1
+
+if [[ "$EXTRA_PACKAGER_ARGS" == *"--sourcemap-output"* ]]; then
+echo "*****************************************************************************************" >&2
+echo "*****************************************************************************************" >&2
+echo "*****                               WARNING                                         *****" >&2
+echo "*****************************************************************************************" >&2
+echo "*****************************************************************************************" >&2
+echo "" >&2
+echo "Using \$EXTRA_PACKAGER_ARG variable with \`--sourcemap-output\` will cause" >&2
+echo "unpredictable behaviour with Hermes, use \$SOURCEMAP_FILE instead." >&2
+echo "" >&2
+echo "See https://reactnative.dev/docs/0.74/debugging-release-builds#enabling-source-maps" >&2
+echo "" >&2
+echo "*****************************************************************************************" >&2
+else
+  [ -z "$SOURCEMAP_FILE" ] && export SOURCEMAP_FILE="$DERIVED_FILE_DIR/main.jsbundle.map"
+fi
 
 [[ "$AUTO_RELEASE" == false ]] && [[ -z "$BUNDLE_COMMAND" || "$BUNDLE_COMMAND" != "ram-bundle" ]] && NO_AUTO_RELEASE="--no-auto-release"
 ARGS="$NO_AUTO_RELEASE $SENTRY_CLI_EXTRA_ARGS $SENTRY_CLI_RN_XCODE_EXTRA_ARGS"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
