### PR TITLE
fix(sample): RN Sample doesn't show multiple promise packages warning

### DIFF
--- a/samples/react-native/metro.config.js
+++ b/samples/react-native/metro.config.js
@@ -19,6 +19,21 @@ const config = {
     `${parentDir}/node_modules`,
   ],
   resolver: {
+    resolveRequest: (context, moduleName, platform) => {
+      if (moduleName.includes('promise/')) {
+        return context.resolveRequest(
+          {
+            ...context,
+            // Ensures the promise module is resolved from the sample's node_modules.
+            allowHaste: false,
+            disableHierarchicalLookup: true,
+          },
+          moduleName,
+          platform,
+        );
+      }
+      return context.resolveRequest(context, moduleName, platform);
+    },
     blacklistRE: blacklist([
       new RegExp(`${parentDir}/node_modules/react-native/.*`),
       new RegExp('.*\\android\\.*'), // Required for Windows in order to run the Sample.


### PR DESCRIPTION
This PR fixes the bare RN sample multiple promise package versions. 

It overwrites the default resolve function to ensure promise from the sample node_modules is used.

#skip-changelog 