### PR TITLE
fix rn 0.65 e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -178,7 +178,7 @@ jobs:
             device: 'iPhone 14'
           - platform: ios
             rn-version: '0.65.3'
-            runs-on: macos-latest
+            runs-on: macos-12
             runtime: 'latest'
             device: 'iPhone 14'
           - platform: android
@@ -223,6 +223,9 @@ jobs:
         run: |
           echo "SENTRY_RELEASE=$SENTRY_RELEASE"
           echo "SENTRY_DIST=$SENTRY_DIST"
+
+      - run: sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
+        if: ${{ matrix.rn-version == '0.65.3' }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
macos-latest is now 14
rn 0.65 doesn't build on arm and xcode 15

this PR fixes 0.65 builds to macos-12 and xcode 14.2

#skip-changelog 