### PR TITLE
fix(ios): Fix non UIKit builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix Apple non UIKit builds ([#3784](https://github.com/getsentry/sentry-react-native/pull/3784))
+
 ## 5.22.0
 
 ### Features

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -36,8 +36,11 @@
 
 #import "RNSentryEvents.h"
 #import "RNSentryDependencyContainer.h"
-#import "RNSentryFramesTrackerListener.h"
+
+#if SENTRY_HAS_UIKIT
 #import "RNSentryRNSScreen.h"
+#import "RNSentryFramesTrackerListener.h"
+#endif
 
 @interface SentryTraceContext : NSObject
 - (nullable instancetype)initWithDict:(NSDictionary<NSString *, id> *)dictionary;
@@ -207,7 +210,7 @@ RCT_EXPORT_METHOD(initNativeReactNavigationNewFrameTracking:(RCTPromiseResolveBl
 }
 
 - (void)initFramesTracking {
-#if !TARGET_OS_OSX
+#if SENTRY_HAS_UIKIT
 
   RNSentryEmitNewFrameEvent emitNewFrameEvent = ^(NSNumber *newFrameTimestampInSeconds) {
     if (self->hasListeners) {

--- a/ios/RNSentryDependencyContainer.h
+++ b/ios/RNSentryDependencyContainer.h
@@ -7,9 +7,12 @@ SENTRY_NO_INIT
 
 @property (class, readonly, strong) RNSentryDependencyContainer* sharedInstance;
 
+#if SENTRY_HAS_UIKIT
+
 @property (nonatomic, strong) RNSentryFramesTrackerListener *framesTrackerListener;
 
 - (void)initializeFramesTrackerListenerWith:(RNSentryEmitNewFrameEvent) eventEmitter;
 
-@end
+#endif
 
+@end

--- a/ios/RNSentryDependencyContainer.m
+++ b/ios/RNSentryDependencyContainer.m
@@ -21,6 +21,8 @@
     return self;
 }
 
+#if SENTRY_HAS_UIKIT
+
 - (void)initializeFramesTrackerListenerWith:(RNSentryEmitNewFrameEvent)eventEmitter
 {
   @synchronized(sentryDependencyContainerLock) {
@@ -28,5 +30,7 @@
                                                                                 andEventEmitter: eventEmitter];
   }
 }
+
+#endif
 
 @end

--- a/ios/RNSentryFramesTrackerListener.h
+++ b/ios/RNSentryFramesTrackerListener.h
@@ -1,3 +1,5 @@
+#import <Sentry/SentryDefines.h>
+
 #if SENTRY_HAS_UIKIT
 
 #import <Foundation/Foundation.h>

--- a/ios/RNSentryFramesTrackerListener.h
+++ b/ios/RNSentryFramesTrackerListener.h
@@ -1,3 +1,5 @@
+#if SENTRY_HAS_UIKIT
+
 #import <Foundation/Foundation.h>
 #import <React/RCTEventEmitter.h>
 #import <Sentry/SentryFramesTracker.h>
@@ -15,3 +17,5 @@ typedef void (^RNSentryEmitNewFrameEvent)(NSNumber *newFrameTimestampInSeconds);
 @property (strong, nonatomic) RNSentryEmitNewFrameEvent emitNewFrameEvent;
 
 @end
+
+#endif

--- a/ios/RNSentryFramesTrackerListener.m
+++ b/ios/RNSentryFramesTrackerListener.m
@@ -1,3 +1,5 @@
+#if SENTRY_HAS_UIKIT
+
 #import "RNSentryFramesTrackerListener.h"
 
 @implementation RNSentryFramesTrackerListener
@@ -28,3 +30,5 @@
 }
 
 @end
+
+#endif

--- a/ios/RNSentryFramesTrackerListener.m
+++ b/ios/RNSentryFramesTrackerListener.m
@@ -1,6 +1,6 @@
-#if SENTRY_HAS_UIKIT
-
 #import "RNSentryFramesTrackerListener.h"
+
+#if SENTRY_HAS_UIKIT
 
 @implementation RNSentryFramesTrackerListener
 

--- a/ios/RNSentryOnDrawReporter.m
+++ b/ios/RNSentryOnDrawReporter.m
@@ -1,3 +1,5 @@
+#if SENTRY_HAS_UIKIT
+
 #import <UIKit/UIKit.h>
 #import <React/RCTViewManager.h>
 #import "RNSentryFramesTrackerListener.h"
@@ -68,3 +70,5 @@ RCT_EXPORT_VIEW_PROPERTY(fullDisplay, BOOL)
 }
 
 @end
+
+#endif

--- a/ios/RNSentryRNSScreen.h
+++ b/ios/RNSentryRNSScreen.h
@@ -1,3 +1,5 @@
+#if SENTRY_HAS_UIKIT
+
 #import <Foundation/Foundation.h>
 
 @interface RNSentryRNSScreen : NSObject
@@ -5,3 +7,5 @@
 + (void)swizzleViewDidAppear;
 
 @end
+
+#endif

--- a/ios/RNSentryRNSScreen.h
+++ b/ios/RNSentryRNSScreen.h
@@ -1,3 +1,5 @@
+#import <Sentry/SentryDefines.h>
+
 #if SENTRY_HAS_UIKIT
 
 #import <Foundation/Foundation.h>

--- a/ios/RNSentryRNSScreen.m
+++ b/ios/RNSentryRNSScreen.m
@@ -1,10 +1,11 @@
+#import "RNSentryRNSScreen.h"
+
 #if SENTRY_HAS_UIKIT
 
 #import <Sentry/SentryFramesTracker.h>
 #import <Sentry/SentryDependencyContainer.h>
 #import <Sentry/SentrySwizzle.h>
 
-#import "RNSentryRNSScreen.h"
 #import "RNSentryDependencyContainer.h"
 
 @implementation RNSentryRNSScreen

--- a/ios/RNSentryRNSScreen.m
+++ b/ios/RNSentryRNSScreen.m
@@ -1,3 +1,5 @@
+#if SENTRY_HAS_UIKIT
+
 #import <Sentry/SentryFramesTracker.h>
 #import <Sentry/SentryDependencyContainer.h>
 #import <Sentry/SentrySwizzle.h>
@@ -24,3 +26,5 @@
 }
 
 @end
+
+#endif


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement

## :scroll: Description
This PR guard iOS code which requires UIKit with `SENTRY_HAS_UIKIT` compiler directive to enable non UIKit builds, for example `react-native-macos`.

## :bulb: Motivation and Context
- fixes: https://github.com/getsentry/sentry-react-native/issues/3774

## :green_heart: How did you test it?
- build sample app with react-native-macos
- follow-up PR adding the build to CI
- https://github.com/getsentry/sentry-react-native/pull/3785

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
