### PR TITLE
chore: remove legacy `rnpm` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Remove unused `rnpm` config ([#3811](https://github.com/getsentry/sentry-react-native/pull/3811))
+
 ### Dependencies
 
 - Bump CLI from v2.30.4 to v2.31.2 ([#3719](https://github.com/getsentry/sentry-react-native/pull/3719))

--- a/package.json
+++ b/package.json
@@ -117,14 +117,6 @@
     "uuid": "^9.0.1",
     "xmlhttprequest": "^1.8.0"
   },
-  "rnpm": {
-    "commands": {},
-    "android": {
-      "packageInstance": "new RNSentryPackage()",
-      "packageImportPath": "import io.sentry.react.RNSentryPackage;"
-    },
-    "ios": {}
-  },
   "codegenConfig": {
     "name": "RNSentrySpec",
     "type": "modules",


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description

This Pull Request removes legacy `rnpm` config. `rnpm` was depracated ~8 years ago, and currently there's no tool that read this property.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make things simpler.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
