### PR TITLE
fix: Missing `RNSentryOnDrawReporterView` on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 ### Fixes
 
 - Remove unused `rnpm` config ([#3811](https://github.com/getsentry/sentry-react-native/pull/3811))
+- Missing `RNSentryOnDrawReporterView` on iOS ([#3832](https://github.com/getsentry/sentry-react-native/pull/3832))
 
 ### Dependencies
 

--- a/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
+++ b/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		33958C692BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33958C682BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m */; };
 		33AFDFED2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33AFDFEC2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m */; };
 		33AFDFF12B8D15E500AAB120 /* RNSentryDependencyContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33AFDFF02B8D15E500AAB120 /* RNSentryDependencyContainerTests.m */; };
 		33F58AD02977037D008F60EA /* RNSentryTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33F58ACF2977037D008F60EA /* RNSentryTests.mm */; };
@@ -17,6 +18,8 @@
 		1482D5685A340AB93348A43D /* Pods-RNSentryCocoaTesterTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNSentryCocoaTesterTests.release.xcconfig"; path = "Target Support Files/Pods-RNSentryCocoaTesterTests/Pods-RNSentryCocoaTesterTests.release.xcconfig"; sourceTree = "<group>"; };
 		3360898D29524164007C7730 /* RNSentryCocoaTesterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RNSentryCocoaTesterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		338739072A7D7D2800950DDD /* RNSentryTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNSentryTests.h; sourceTree = "<group>"; };
+		33958C672BFCEF5A00AD1FB6 /* RNSentryOnDrawReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNSentryOnDrawReporter.h; path = ../ios/RNSentryOnDrawReporter.h; sourceTree = "<group>"; };
+		33958C682BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentryOnDrawReporterTests.m; sourceTree = "<group>"; };
 		33AFDFEC2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentryFramesTrackerListenerTests.m; sourceTree = "<group>"; };
 		33AFDFEE2B8D14C200AAB120 /* RNSentryFramesTrackerListenerTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNSentryFramesTrackerListenerTests.h; sourceTree = "<group>"; };
 		33AFDFF02B8D15E500AAB120 /* RNSentryDependencyContainerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentryDependencyContainerTests.m; sourceTree = "<group>"; };
@@ -76,6 +79,7 @@
 				33AFDFEE2B8D14C200AAB120 /* RNSentryFramesTrackerListenerTests.h */,
 				33AFDFF02B8D15E500AAB120 /* RNSentryDependencyContainerTests.m */,
 				33AFDFF22B8D15F600AAB120 /* RNSentryDependencyContainerTests.h */,
+				33958C682BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m */,
 			);
 			path = RNSentryCocoaTesterTests;
 			sourceTree = "<group>";
@@ -83,6 +87,7 @@
 		33AFE0122B8F319000AAB120 /* RNSentry */ = {
 			isa = PBXGroup;
 			children = (
+				33958C672BFCEF5A00AD1FB6 /* RNSentryOnDrawReporter.h */,
 				33AFE0132B8F31AF00AAB120 /* RNSentryDependencyContainer.h */,
 			);
 			name = RNSentry;
@@ -198,6 +203,7 @@
 			files = (
 				33AFDFF12B8D15E500AAB120 /* RNSentryDependencyContainerTests.m in Sources */,
 				33F58AD02977037D008F60EA /* RNSentryTests.mm in Sources */,
+				33958C692BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m in Sources */,
 				33AFDFED2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryOnDrawReporterTests.m
+++ b/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryOnDrawReporterTests.m
@@ -1,0 +1,16 @@
+#import <XCTest/XCTest.h>
+#import "RNSentryOnDrawReporter.h"
+
+@interface RNSentryOnDrawReporterTests : XCTestCase
+
+@end
+
+@implementation RNSentryOnDrawReporterTests
+
+- (void)testRNSentryOnDrawReporterViewIsAvailableWhenUIKitIs
+{
+  RNSentryOnDrawReporterView* view = [[RNSentryOnDrawReporterView alloc] init];
+  XCTAssertNotNil(view);
+}
+
+@end

--- a/ios/RNSentryOnDrawReporter.h
+++ b/ios/RNSentryOnDrawReporter.h
@@ -1,0 +1,23 @@
+#import <Sentry/SentryDefines.h>
+
+#if SENTRY_HAS_UIKIT
+
+#import <UIKit/UIKit.h>
+#import <React/RCTViewManager.h>
+#import "RNSentryFramesTrackerListener.h"
+
+@interface RNSentryOnDrawReporter : RCTViewManager
+
+@end
+
+@interface RNSentryOnDrawReporterView : UIView
+
+@property (nonatomic, strong) RNSentryFramesTrackerListener* framesListener;
+@property (nonatomic, copy) RCTBubblingEventBlock onDrawNextFrame;
+@property (nonatomic) bool fullDisplay;
+@property (nonatomic) bool initialDisplay;
+@property (nonatomic, weak) RNSentryOnDrawReporter* delegate;
+
+@end
+
+#endif

--- a/ios/RNSentryOnDrawReporter.m
+++ b/ios/RNSentryOnDrawReporter.m
@@ -1,23 +1,8 @@
+#import "RNSentryOnDrawReporter.h"
+
 #if SENTRY_HAS_UIKIT
 
-#import <UIKit/UIKit.h>
-#import <React/RCTViewManager.h>
-#import "RNSentryFramesTrackerListener.h"
 #import <Sentry/SentryDependencyContainer.h>
-
-@interface RNSentryOnDrawReporter : RCTViewManager
-
-@end
-
-@interface RNSentryOnDrawReporterView : UIView
-
-@property (nonatomic, strong) RNSentryFramesTrackerListener* framesListener;
-@property (nonatomic, copy) RCTBubblingEventBlock onDrawNextFrame;
-@property (nonatomic) bool fullDisplay;
-@property (nonatomic) bool initialDisplay;
-@property (nonatomic, weak) RNSentryOnDrawReporter* delegate;
-
-@end
 
 @implementation RNSentryOnDrawReporter
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
- This PR fixes regression introduced in https://github.com/getsentry/sentry-react-native/pull/3784

The RNSentryOnDrawReporterView was never available after the change for non UIKit builds. 

## :green_heart: How did you test it?
Added native test which checks if the class is available.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
