### PR TITLE
fix(CONTRIBUTION.md): Fix iOS guide, dependency on Sentry is required

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ target 'sample' do
 
   # ... react native config
 
- pod 'Sentry/HybridSDK', :path => '../../../sentry-cocoa'
+ pod 'Sentry/HybridSDK', :path => '../../../../sentry-cocoa'
   # ... rest of the configuration
 
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Comment out sentry dependency in `RNSentry.podspec`.
 
 ```diff
 -   s.dependency 'Sentry/HybridSDK', '7.31.0'
-+   # s.dependency 'Sentry/HybridSDK', '7.31.0'
++   s.dependency 'Sentry/HybridSDK'
 ```
 
 Add local pods to `sample/ios/Podfile`.
@@ -123,9 +123,7 @@ target 'sample' do
 
   # ... react native config
 
-+  pod 'Sentry/HybridSDK', :path => '../../../sentry-cocoa'
-+  pod 'SentryPrivate', :path => '../../../sentry-cocoa/SentryPrivate.podspec'
-
+ pod 'Sentry/HybridSDK', :path => '../../../sentry-cocoa'
   # ... rest of the configuration
 
 end
@@ -151,12 +149,12 @@ cd sentry-react-native/sample
 
 Add local maven to `sample/android/build.gradle`.
 
-```diff
-+ allprojects {
-+     repositories {
-+         mavenLocal()
-+     }
-+ }
+```gradle
+allprojects {
+    repositories {
+        mavenLocal()
+    }
+}
 ```
 
 Update `sentry-android` version, to the one locally published, in `android/build.gradle`.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
Without the dependency in RNSentry the Sentry module would not be found and all Swift code would not be working in RN.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 