### PR TITLE
ref(ios): Move breadcrumbs conversion to pure obj-c to ensure compatibility with the swift implementation

### DIFF
--- a/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
+++ b/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		330F308C2C0F3840002A0D4E /* RNSentryBreadcrumbTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 330F308B2C0F3840002A0D4E /* RNSentryBreadcrumbTests.m */; };
 		33958C692BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33958C682BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m */; };
 		33AFDFED2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33AFDFEC2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m */; };
 		33AFDFF12B8D15E500AAB120 /* RNSentryDependencyContainerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33AFDFF02B8D15E500AAB120 /* RNSentryDependencyContainerTests.m */; };
@@ -16,6 +17,8 @@
 
 /* Begin PBXFileReference section */
 		1482D5685A340AB93348A43D /* Pods-RNSentryCocoaTesterTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNSentryCocoaTesterTests.release.xcconfig"; path = "Target Support Files/Pods-RNSentryCocoaTesterTests/Pods-RNSentryCocoaTesterTests.release.xcconfig"; sourceTree = "<group>"; };
+		330F308B2C0F3840002A0D4E /* RNSentryBreadcrumbTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentryBreadcrumbTests.m; sourceTree = "<group>"; };
+		330F308D2C0F385A002A0D4E /* RNSentryBreadcrumb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNSentryBreadcrumb.h; path = ../ios/RNSentryBreadcrumb.h; sourceTree = "<group>"; };
 		3360898D29524164007C7730 /* RNSentryCocoaTesterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RNSentryCocoaTesterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		338739072A7D7D2800950DDD /* RNSentryTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNSentryTests.h; sourceTree = "<group>"; };
 		33958C672BFCEF5A00AD1FB6 /* RNSentryOnDrawReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNSentryOnDrawReporter.h; path = ../ios/RNSentryOnDrawReporter.h; sourceTree = "<group>"; };
@@ -80,6 +83,7 @@
 				33AFDFF02B8D15E500AAB120 /* RNSentryDependencyContainerTests.m */,
 				33AFDFF22B8D15F600AAB120 /* RNSentryDependencyContainerTests.h */,
 				33958C682BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m */,
+				330F308B2C0F3840002A0D4E /* RNSentryBreadcrumbTests.m */,
 			);
 			path = RNSentryCocoaTesterTests;
 			sourceTree = "<group>";
@@ -87,6 +91,7 @@
 		33AFE0122B8F319000AAB120 /* RNSentry */ = {
 			isa = PBXGroup;
 			children = (
+				330F308D2C0F385A002A0D4E /* RNSentryBreadcrumb.h */,
 				33958C672BFCEF5A00AD1FB6 /* RNSentryOnDrawReporter.h */,
 				33AFE0132B8F31AF00AAB120 /* RNSentryDependencyContainer.h */,
 			);
@@ -204,6 +209,7 @@
 				33AFDFF12B8D15E500AAB120 /* RNSentryDependencyContainerTests.m in Sources */,
 				33F58AD02977037D008F60EA /* RNSentryTests.mm in Sources */,
 				33958C692BFCF12600AD1FB6 /* RNSentryOnDrawReporterTests.m in Sources */,
+				330F308C2C0F3840002A0D4E /* RNSentryBreadcrumbTests.m in Sources */,
 				33AFDFED2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryBreadcrumbTests.m
+++ b/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryBreadcrumbTests.m
@@ -1,0 +1,40 @@
+#import <XCTest/XCTest.h>
+#import "RNSentryBreadcrumb.h"
+@import Sentry;
+
+@interface RNSentryBreadcrumbTests : XCTestCase
+
+@end
+
+@implementation RNSentryBreadcrumbTests
+
+- (void)testGeneratesSentryBreadcrumbFromNSDictionary
+{
+  SentryBreadcrumb* actualCrumb = [RNSentryBreadcrumb from:@{
+    @"level": @"error",
+    @"category": @"testCategory",
+    @"type": @"testType",
+    @"message": @"testMessage",
+    @"data": @{
+      @"test": @"data"
+    }
+  }];
+
+  XCTAssertEqual(actualCrumb.level, kSentryLevelError);
+  XCTAssertEqual(actualCrumb.category, @"testCategory");
+  XCTAssertEqual(actualCrumb.type, @"testType");
+  XCTAssertEqual(actualCrumb.message, @"testMessage");
+  XCTAssertTrue([actualCrumb.data isKindOfClass:[NSDictionary class]]);
+  XCTAssertEqual(actualCrumb.data[@"test"], @"data");
+}
+
+- (void)testUsesInfoAsDefaultSentryLevel
+{
+  SentryBreadcrumb* actualCrumb = [RNSentryBreadcrumb from:@{
+    @"message": @"testMessage",
+  }];
+
+  XCTAssertEqual(actualCrumb.level, kSentryLevelInfo);
+}
+
+@end

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -380,20 +380,24 @@ RCT_EXPORT_METHOD(fetchNativeAppStart:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
 #if SENTRY_HAS_UIKIT
-    NSDictionary<NSString *, id> *measurements = [PrivateSentrySDKOnly appStartMeasurementWithSpans];
-    if (measurements == nil) {
-        resolve(nil);
-        return;
-    }
+    SentryAppStartMeasurement *appStartMeasurement = PrivateSentrySDKOnly.appStartMeasurement;
 
-    NSMutableDictionary<NSString *, id> *mutableMeasurements = [[NSMutableDictionary alloc] initWithDictionary:measurements];
-    [mutableMeasurements setValue:[NSNumber numberWithBool:didFetchAppStart] forKey:@"has_fetched"];
+    if (appStartMeasurement == nil) {
+        resolve(nil);
+    } else {
+        BOOL isColdStart = appStartMeasurement.type == SentryAppStartTypeCold;
+
+        resolve(@{
+            @"isColdStart": [NSNumber numberWithBool:isColdStart],
+            @"appStartTime": [NSNumber numberWithDouble:(appStartMeasurement.appStartTimestamp.timeIntervalSince1970 * 1000)],
+            @"didFetchAppStart": [NSNumber numberWithBool:didFetchAppStart],
+                });
+
+    }
 
     // This is always set to true, as we would only allow an app start fetch to only happen once
     // in the case of a JS bundle reload, we do not want it to be instrumented again.
     didFetchAppStart = true;
-
-    resolve(mutableMeasurements);
 #else
     resolve(nil);
 #endif

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -23,6 +23,7 @@
 #import <Sentry/SentryFormatter.h>
 #import <Sentry/SentryAppStartMeasurement.h>
 #import "RNSentryId.h"
+#import "RNSentryBreadcrumb.h"
 
 // This guard prevents importing Hermes in JSC apps
 #if SENTRY_PROFILING_ENABLED
@@ -379,24 +380,20 @@ RCT_EXPORT_METHOD(fetchNativeAppStart:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
 #if SENTRY_HAS_UIKIT
-    SentryAppStartMeasurement *appStartMeasurement = PrivateSentrySDKOnly.appStartMeasurement;
-
-    if (appStartMeasurement == nil) {
+    NSDictionary<NSString *, id> *measurements = [PrivateSentrySDKOnly appStartMeasurementWithSpans];
+    if (measurements == nil) {
         resolve(nil);
-    } else {
-        BOOL isColdStart = appStartMeasurement.type == SentryAppStartTypeCold;
-
-        resolve(@{
-            @"isColdStart": [NSNumber numberWithBool:isColdStart],
-            @"appStartTime": [NSNumber numberWithDouble:(appStartMeasurement.appStartTimestamp.timeIntervalSince1970 * 1000)],
-            @"didFetchAppStart": [NSNumber numberWithBool:didFetchAppStart],
-                });
-
+        return;
     }
+
+    NSMutableDictionary<NSString *, id> *mutableMeasurements = [[NSMutableDictionary alloc] initWithDictionary:measurements];
+    [mutableMeasurements setValue:[NSNumber numberWithBool:didFetchAppStart] forKey:@"has_fetched"];
 
     // This is always set to true, as we would only allow an app start fetch to only happen once
     // in the case of a JS bundle reload, we do not want it to be instrumented again.
     didFetchAppStart = true;
+
+    resolve(mutableMeasurements);
 #else
     resolve(nil);
 #endif
@@ -557,32 +554,7 @@ RCT_EXPORT_METHOD(setUser:(NSDictionary *)userKeys
 RCT_EXPORT_METHOD(addBreadcrumb:(NSDictionary *)breadcrumb)
 {
     [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
-        SentryBreadcrumb* breadcrumbInstance = [[SentryBreadcrumb alloc] init];
-
-        NSString * levelString = breadcrumb[@"level"];
-        SentryLevel sentryLevel;
-        if ([levelString isEqualToString:@"fatal"]) {
-            sentryLevel = kSentryLevelFatal;
-        } else if ([levelString isEqualToString:@"warning"]) {
-            sentryLevel = kSentryLevelWarning;
-        } else if ([levelString isEqualToString:@"error"]) {
-            sentryLevel = kSentryLevelError;
-        } else if ([levelString isEqualToString:@"debug"]) {
-            sentryLevel = kSentryLevelDebug;
-        } else {
-            sentryLevel = kSentryLevelInfo;
-        }
-        [breadcrumbInstance setLevel:sentryLevel];
-
-        [breadcrumbInstance setCategory:breadcrumb[@"category"]];
-
-        [breadcrumbInstance setType:breadcrumb[@"type"]];
-
-        [breadcrumbInstance setMessage:breadcrumb[@"message"]];
-
-        [breadcrumbInstance setData:breadcrumb[@"data"]];
-
-        [scope addBreadcrumb:breadcrumbInstance];
+        [scope addBreadcrumb:[RNSentryBreadcrumb from:breadcrumb]];
     }];
 }
 

--- a/ios/RNSentryBreadcrumb.h
+++ b/ios/RNSentryBreadcrumb.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@class SentryBreadcrumb;
+
+@interface RNSentryBreadcrumb : NSObject
+
++ (SentryBreadcrumb *)from: (NSDictionary *) dict;
+
+@end

--- a/ios/RNSentryBreadcrumb.m
+++ b/ios/RNSentryBreadcrumb.m
@@ -1,0 +1,33 @@
+#import "RNSentryBreadcrumb.h"
+@import Sentry;
+
+@implementation RNSentryBreadcrumb
+
++(SentryBreadcrumb*) from: (NSDictionary *) dict
+{
+    SentryBreadcrumb* crumb = [[SentryBreadcrumb alloc] init];
+
+    NSString * levelString = dict[@"level"];
+    SentryLevel sentryLevel;
+    if ([levelString isEqualToString:@"fatal"]) {
+        sentryLevel = kSentryLevelFatal;
+    } else if ([levelString isEqualToString:@"warning"]) {
+        sentryLevel = kSentryLevelWarning;
+    } else if ([levelString isEqualToString:@"error"]) {
+        sentryLevel = kSentryLevelError;
+    } else if ([levelString isEqualToString:@"debug"]) {
+        sentryLevel = kSentryLevelDebug;
+    } else {
+        sentryLevel = kSentryLevelInfo;
+    }
+
+    [crumb setLevel:sentryLevel];
+    [crumb setCategory:dict[@"category"]];
+    [crumb setType:dict[@"type"]];
+    [crumb setMessage:dict[@"message"]];
+    [crumb setData:dict[@"data"]];
+
+    return crumb;
+}
+
+@end


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
SentryLevel was moved to Swift in https://github.com/getsentry/sentry-cocoa/pull/3963 and we can't use Swift code in `RNSentry.mm`, so I've moved breadcrumb conversion to pure Objective-C implementation.

The current implementation works until updating to a release which includes https://github.com/getsentry/sentry-cocoa/pull/3963 changes.

This PR makes RN implementation ready for the future release.

## :green_heart: How did you test it?
added unit tests, sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 