### PR TITLE
feat(tracing): Add native application start spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 
   Note that the `Sentry.BrowserIntegrations`, `Sentry.Integration` and the Class style integrations will be removed in the next major version of the SDK.
 
+- Add native application start spans ([#3855](https://github.com/getsentry/sentry-react-native/pull/3855))
+  - This doesn't change the app start measurement length, but add child spans (more detail) into the existing app start span
+
 ### Fixes
 
 - Remove unused `rnpm` config ([#3811](https://github.com/getsentry/sentry-react-native/pull/3811))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Features
+
+- Add native application start spans ([#3855](https://github.com/getsentry/sentry-react-native/pull/3855))
+  - This doesn't change the app start measurement length, but add child spans (more detail) into the existing app start span
+
 ### Fix
 
 - Add missing logs to dropped App Start spans ([#3861](https://github.com/getsentry/sentry-react-native/pull/3861))
@@ -49,9 +54,6 @@
   ```
 
   Note that the `Sentry.BrowserIntegrations`, `Sentry.Integration` and the Class style integrations will be removed in the next major version of the SDK.
-
-- Add native application start spans ([#3855](https://github.com/getsentry/sentry-react-native/pull/3855))
-  - This doesn't change the app start measurement length, but add child spans (more detail) into the existing app start span
 
 ### Fixes
 

--- a/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -334,28 +334,17 @@ public class RNSentryModuleImpl {
     }
 
     public void fetchNativeAppStart(Promise promise) {
-        final AppStartMetrics appStartInstance = AppStartMetrics.getInstance();
-        final SentryDate appStartTime = appStartInstance.getAppStartTimeSpan().getStartTimestamp();
-        final boolean isColdStart = appStartInstance.getAppStartType() == AppStartMetrics.AppStartType.COLD;
+        final Map<String, Object> measurement = InternalSentrySdk.getAppStartMeasurement();
 
-        if (appStartTime == null) {
-            logger.log(SentryLevel.WARNING, "App start won't be sent due to missing appStartTime.");
-            promise.resolve(null);
-        } else {
-            final double appStartTimestampMs = DateUtils.nanosToMillis(appStartTime.nanoTimestamp());
+        WritableMap mutableMeasurement = (WritableMap) RNSentryMapConverter.convertToWritable(measurement);
+        mutableMeasurement.putBoolean("has_fetched", didFetchAppStart);
 
-            WritableMap appStart = Arguments.createMap();
-
-            appStart.putDouble("appStartTime", appStartTimestampMs);
-            appStart.putBoolean("isColdStart", isColdStart);
-            appStart.putBoolean("didFetchAppStart", didFetchAppStart);
-
-            promise.resolve(appStart);
-        }
         // This is always set to true, as we would only allow an app start fetch to only
         // happen once in the case of a JS bundle reload, we do not want it to be
         // instrumented again.
         didFetchAppStart = true;
+
+        promise.resolve(mutableMeasurement);
     }
 
     /**

--- a/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -103,7 +103,7 @@ public class RNSentryModuleImpl {
     private FrameMetricsAggregator frameMetricsAggregator = null;
     private boolean androidXAvailable;
 
-    private static boolean didFetchAppStart;
+    private static boolean hasFetchedAppStart;
 
     // 700ms to constitute frozen frames.
     private static final int FROZEN_FRAME_THRESHOLD = 700;
@@ -337,12 +337,12 @@ public class RNSentryModuleImpl {
         final Map<String, Object> measurement = InternalSentrySdk.getAppStartMeasurement();
 
         WritableMap mutableMeasurement = (WritableMap) RNSentryMapConverter.convertToWritable(measurement);
-        mutableMeasurement.putBoolean("has_fetched", didFetchAppStart);
+        mutableMeasurement.putBoolean("has_fetched", hasFetchedAppStart);
 
         // This is always set to true, as we would only allow an app start fetch to only
         // happen once in the case of a JS bundle reload, we do not want it to be
         // instrumented again.
-        didFetchAppStart = true;
+        hasFetchedAppStart = true;
 
         promise.resolve(mutableMeasurement);
     }

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -379,24 +379,20 @@ RCT_EXPORT_METHOD(fetchNativeAppStart:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
 #if SENTRY_HAS_UIKIT
-    SentryAppStartMeasurement *appStartMeasurement = PrivateSentrySDKOnly.appStartMeasurement;
-
-    if (appStartMeasurement == nil) {
+    NSDictionary<NSString *, id> *measurements = [PrivateSentrySDKOnly appStartMeasurementWithSpans];
+    if (measurements == nil) {
         resolve(nil);
-    } else {
-        BOOL isColdStart = appStartMeasurement.type == SentryAppStartTypeCold;
-
-        resolve(@{
-            @"isColdStart": [NSNumber numberWithBool:isColdStart],
-            @"appStartTime": [NSNumber numberWithDouble:(appStartMeasurement.appStartTimestamp.timeIntervalSince1970 * 1000)],
-            @"didFetchAppStart": [NSNumber numberWithBool:didFetchAppStart],
-                });
-
+        return;
     }
+
+    NSMutableDictionary<NSString *, id> *mutableMeasurements = [[NSMutableDictionary alloc] initWithDictionary:measurements];
+    [mutableMeasurements setValue:[NSNumber numberWithBool:didFetchAppStart] forKey:@"has_fetched"];
 
     // This is always set to true, as we would only allow an app start fetch to only happen once
     // in the case of a JS bundle reload, we do not want it to be instrumented again.
     didFetchAppStart = true;
+
+    resolve(mutableMeasurements);
 #else
     resolve(nil);
 #endif

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -55,7 +55,7 @@
 
 @end
 
-static bool didFetchAppStart;
+static bool hasFetchedAppStart;
 
 static NSString* const nativeSdkName = @"sentry.cocoa.react-native";
 
@@ -387,11 +387,11 @@ RCT_EXPORT_METHOD(fetchNativeAppStart:(RCTPromiseResolveBlock)resolve
     }
 
     NSMutableDictionary<NSString *, id> *mutableMeasurements = [[NSMutableDictionary alloc] initWithDictionary:measurements];
-    [mutableMeasurements setValue:[NSNumber numberWithBool:didFetchAppStart] forKey:@"has_fetched"];
+    [mutableMeasurements setValue:[NSNumber numberWithBool:hasFetchedAppStart] forKey:@"has_fetched"];
 
     // This is always set to true, as we would only allow an app start fetch to only happen once
     // in the case of a JS bundle reload, we do not want it to be instrumented again.
-    didFetchAppStart = true;
+    hasFetchedAppStart = true;
 
     resolve(mutableMeasurements);
 #else

--- a/src/js/NativeRNSentry.ts
+++ b/src/js/NativeRNSentry.ts
@@ -90,9 +90,14 @@ export type NativeStackFrames = {
 };
 
 export type NativeAppStartResponse = {
-  isColdStart: boolean;
-  appStartTime: number;
-  didFetchAppStart: boolean;
+  type: 'cold' | 'warm' | 'unknown';
+  has_fetched: boolean;
+  app_start_timestamp_ms?: number;
+  spans: {
+    description: string;
+    start_timestamp_ms: number;
+    end_timestamp_ms: number;
+  }[];
 };
 
 export type NativeFramesResponse = {

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -503,6 +503,7 @@ export class ReactNativeTracing implements Integration {
   private _addNativeSpansTo(appStartSpan: Span, nativeSpans: NativeAppStartResponse['spans']): void {
     nativeSpans.forEach(span => {
       appStartSpan.startChild({
+        op: appStartSpan.op,
         description: span.description,
         startTimestamp: span.start_timestamp_ms / 1000,
         endTimestamp: span.end_timestamp_ms / 1000,

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -269,9 +269,10 @@ describe('ReactNativeTracing', () => {
         const timeOriginMilliseconds = Date.now();
         const appStartTimeMilliseconds = timeOriginMilliseconds - 65000;
         const mockAppStartResponse: NativeAppStartResponse = {
-          isColdStart: false,
-          appStartTime: appStartTimeMilliseconds,
-          didFetchAppStart: false,
+          type: 'warm',
+          app_start_timestamp_ms: appStartTimeMilliseconds,
+          has_fetched: false,
+          spans: [],
         };
 
         mockFunction(getTimeOriginMilliseconds).mockReturnValue(timeOriginMilliseconds);
@@ -295,9 +296,10 @@ describe('ReactNativeTracing', () => {
         const timeOriginMilliseconds = Date.now();
         const appStartTimeMilliseconds = timeOriginMilliseconds - 65000;
         const mockAppStartResponse: NativeAppStartResponse = {
-          isColdStart: false,
-          appStartTime: appStartTimeMilliseconds,
-          didFetchAppStart: false,
+          type: 'warm',
+          app_start_timestamp_ms: appStartTimeMilliseconds,
+          has_fetched: false,
+          spans: [],
         };
 
         mockFunction(getTimeOriginMilliseconds).mockReturnValue(timeOriginMilliseconds);
@@ -918,9 +920,10 @@ function mockAppStartResponse({ cold, didFetchAppStart }: { cold: boolean; didFe
   const timeOriginMilliseconds = Date.now();
   const appStartTimeMilliseconds = timeOriginMilliseconds - 100;
   const mockAppStartResponse: NativeAppStartResponse = {
-    isColdStart: cold,
-    appStartTime: appStartTimeMilliseconds,
-    didFetchAppStart: didFetchAppStart ?? false,
+    type: cold ? 'cold' : 'warm',
+    app_start_timestamp_ms: appStartTimeMilliseconds,
+    has_fetched: didFetchAppStart ?? false,
+    spans: [],
   };
 
   mockFunction(getTimeOriginMilliseconds).mockReturnValue(timeOriginMilliseconds);

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -317,10 +317,10 @@ describe('ReactNativeTracing', () => {
         expect(transaction?.start_timestamp).toBeGreaterThanOrEqual(timeOriginMilliseconds / 1000);
       });
 
-      it('Does not create app start transaction if didFetchAppStart == true', async () => {
+      it('Does not create app start transaction if has_fetched == true', async () => {
         const integration = new ReactNativeTracing();
 
-        mockAppStartResponse({ cold: false, didFetchAppStart: true });
+        mockAppStartResponse({ cold: false, has_fetched: true });
 
         setup(integration);
 
@@ -480,14 +480,14 @@ describe('ReactNativeTracing', () => {
         expect(span!.timestamp).toBe(timeOriginMilliseconds / 1000);
       });
 
-      it('Does not update route transaction if didFetchAppStart == true', async () => {
+      it('Does not update route transaction if has_fetched == true', async () => {
         const routingInstrumentation = new RoutingInstrumentation();
         const integration = new ReactNativeTracing({
           enableStallTracking: false,
           routingInstrumentation,
         });
 
-        const [, appStartTimeMilliseconds] = mockAppStartResponse({ cold: false, didFetchAppStart: true });
+        const [, appStartTimeMilliseconds] = mockAppStartResponse({ cold: false, has_fetched: true });
 
         setup(integration);
         // wait for internal promises to resolve, fetch app start data from mocked native
@@ -958,11 +958,11 @@ describe('ReactNativeTracing', () => {
 
 function mockAppStartResponse({
   cold,
-  didFetchAppStart,
+  has_fetched,
   enableNativeSpans,
 }: {
   cold: boolean;
-  didFetchAppStart?: boolean;
+  has_fetched?: boolean;
   enableNativeSpans?: boolean;
 }) {
   const timeOriginMilliseconds = Date.now();
@@ -970,7 +970,7 @@ function mockAppStartResponse({
   const mockAppStartResponse: NativeAppStartResponse = {
     type: cold ? 'cold' : 'warm',
     app_start_timestamp_ms: appStartTimeMilliseconds,
-    has_fetched: didFetchAppStart ?? false,
+    has_fetched: has_fetched ?? false,
     spans: enableNativeSpans
       ? [
           {

--- a/test/tracing/reactnavigation.ttid.test.tsx
+++ b/test/tracing/reactnavigation.ttid.test.tsx
@@ -36,9 +36,10 @@ describe('React Navigation - TTID', () => {
       (isHermesEnabled as jest.Mock).mockReturnValue(true);
 
       mockWrapper.NATIVE.fetchNativeAppStart.mockResolvedValue({
-        appStartTime: mockedAppStartTimeSeconds * 1000,
-        didFetchAppStart: false,
-        isColdStart: true,
+        app_start_timestamp_ms: mockedAppStartTimeSeconds * 1000,
+        has_fetched: false,
+        type: 'cold',
+        spans: [],
       });
 
       mockedEventEmitter = mockedSentryEventEmitter.createMockedSentryEventEmitter();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature

## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds native application start spans as children of the root app start span reported by RN today. 

## Example from iOS

![Screenshot 2024-06-04 at 17 50 47](https://github.com/getsentry/sentry-react-native/assets/31292499/7647ef6c-91c9-4437-b722-e108d9dddf1a)


## Example from Android

![Screenshot 2024-06-04 at 17 52 28](https://github.com/getsentry/sentry-react-native/assets/31292499/685db2d2-968b-4540-977f-250b54f11d18)


##  ✅  Waiting for native releases

- https://github.com/getsentry/sentry-cocoa/pull/4021
- https://github.com/getsentry/sentry-java/pull/3454

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Doesn't close https://github.com/getsentry/sentry-react-native/issues/3445 as also RN specifics spans needs to be added. That will be separate PR.

- https://github.com/getsentry/sentry-react-native/issues/3445

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- Release `sentry-cocoa` with https://github.com/getsentry/sentry-cocoa/pull/4021
- Release `sentry-android` with https://github.com/getsentry/sentry-java/pull/3454
