### PR TITLE
Remove fetchNativeRelease test

### DIFF
--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -22,13 +22,6 @@ jest.mock('react-native', () => {
         },
       }),
     ),
-    fetchNativeRelease: jest.fn(() =>
-      Promise.resolve({
-        build: '1.0.0.1',
-        id: 'test-mock',
-        version: '1.0.0',
-      }),
-    ),
     setContext: jest.fn(),
     setExtra: jest.fn(),
     setTag: jest.fn(),
@@ -454,16 +447,6 @@ describe('Tests Native Wrapper', () => {
         ),
         { store: true },
       );
-    });
-  });
-
-  describe('fetchRelease', () => {
-    test('fetches the release from native', async () => {
-      await expect(NATIVE.fetchNativeRelease()).resolves.toMatchObject({
-        build: '1.0.0.1',
-        id: 'test-mock',
-        version: '1.0.0',
-      });
     });
   });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [X] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
 fetchNativeRelease is just a mock test and it was only testing the same mocked value if it's true, no implementation of fetchNativeRelease was found on either native and javascript layers.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It just removes a mocked test that wasn't testing any code from the SDK

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog