### PR TITLE
feat(tracing): Add JS Bundle Execution to the App Start span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add native application start spans ([#3855](https://github.com/getsentry/sentry-react-native/pull/3855))
   - This doesn't change the app start measurement length, but add child spans (more detail) into the existing app start span
+- Added JS Bundle Execution start information to the application start measurements ([#3857](https://github.com/getsentry/sentry-react-native/pull/3857))
 
 ### Dependencies
 
@@ -62,8 +63,6 @@ This release does *not* build on iOS. Please use `5.23.1` or newer.
   ```
 
   Note that the `Sentry.BrowserIntegrations`, `Sentry.Integration` and the Class style integrations will be removed in the next major version of the SDK.
-
-- Added JS Bundle Execution start information to the application start measurements ([#3857](https://github.com/getsentry/sentry-react-native/pull/3857))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
   Note that the `Sentry.BrowserIntegrations`, `Sentry.Integration` and the Class style integrations will be removed in the next major version of the SDK.
 
+- Added JS Bundle Execution start information to the application start measurements ([#3857](https://github.com/getsentry/sentry-react-native/pull/3857))
+
 ### Fixes
 
 - Remove unused `rnpm` config ([#3811](https://github.com/getsentry/sentry-react-native/pull/3811))

--- a/src/js/tracing/reactnativeprofiler.tsx
+++ b/src/js/tracing/reactnativeprofiler.tsx
@@ -1,4 +1,5 @@
-import { getCurrentHub, Profiler } from '@sentry/react';
+import { getClient, getCurrentHub, Profiler } from '@sentry/react';
+import { timestampInSeconds } from '@sentry/utils';
 
 import { createIntegration } from '../integrations/factory';
 import { ReactNativeTracing } from './reactnativetracing';
@@ -12,6 +13,13 @@ const ReactNativeProfilerGlobalState = {
  */
 export class ReactNativeProfiler extends Profiler {
   public readonly name: string = 'ReactNativeProfiler';
+
+  public constructor(props: ConstructorParameters<typeof Profiler>[0]) {
+    const client = getClient();
+    const integration = client && client.getIntegrationByName && client.getIntegrationByName<ReactNativeTracing>('ReactNativeTracing');
+    integration && integration.setRootComponentFirstConstructorCallTimestampMs(timestampInSeconds() * 1000);
+    super(props);
+  }
 
   /**
    * Get the app root mount time.

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -501,31 +501,21 @@ export class ReactNativeTracing implements Integration {
       setSpanDurationAsMeasurement('time_to_full_display', maybeTtfdSpan);
     }
 
-<<<<<<< kw/add-bundle-execution-start-span -- Incoming Change
-    const op = appStart.isColdStart ? APP_START_COLD_OP : APP_START_WARM_OP;
-    const appStartSpan = transaction.startChild({
-      description: appStart.isColdStart ? 'Cold App Start' : 'Warm App Start',
-=======
     const op = appStart.type === 'cold' ? APP_START_COLD_OP : APP_START_WARM_OP;
     const appStartSpan = transaction.startChild({
       description: appStart.type === 'cold' ? 'Cold App Start' : 'Warm App Start',
->>>>>>> main -- Current Change
       op,
       startTimestamp: appStartTimeSeconds,
       endTimestamp: this._appStartFinishTimestamp,
     });
-<<<<<<< kw/add-bundle-execution-start-span -- Incoming Change
     this._addJSExecutionBeforeRoot(appStartSpan);
-=======
     this._addNativeSpansTo(appStartSpan, appStart.spans);
->>>>>>> main -- Current Change
 
     const measurement = appStart.type === 'cold' ? APP_START_COLD : APP_START_WARM;
     transaction.setMeasurement(measurement, appStartDurationMilliseconds, 'millisecond');
   }
 
   /**
-<<<<<<< kw/add-bundle-execution-start-span -- Incoming Change
    * Adds JS Execution before React Root. If `Sentry.wrap` is not used, create a span for the start of JS Bundle execution.
    */
   private _addJSExecutionBeforeRoot(appStartSpan: Span): void {
@@ -550,7 +540,10 @@ export class ReactNativeTracing implements Integration {
       op: appStartSpan.op,
       startTimestamp: bundleStartTimestampMs / 1000,
       endTimestamp: this._firstConstructorCallTimestampMs / 1000,
-=======
+    });
+  }
+
+  /**
    * Adds native spans to the app start span.
    */
   private _addNativeSpansTo(appStartSpan: Span, nativeSpans: NativeAppStartResponse['spans']): void {
@@ -561,7 +554,6 @@ export class ReactNativeTracing implements Integration {
         startTimestamp: span.start_timestamp_ms / 1000,
         endTimestamp: span.end_timestamp_ms / 1000,
       });
->>>>>>> main -- Current Change
     });
   }
 

--- a/src/js/utils/worldwide.ts
+++ b/src/js/utils/worldwide.ts
@@ -22,6 +22,8 @@ export interface ReactNativeInternalGlobal extends InternalGlobal {
       ___SENTRY_METRO_DEV_SERVER___?: string;
     };
   };
+  __BUNDLE_START_TIME__?: number;
+  nativePerformanceNow?: () => number;
 }
 
 /** Get's the global object for the current JavaScript runtime */

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -438,7 +438,7 @@ describe('ReactNativeTracing', () => {
           );
         });
       });
-      
+
       it('adds native spans as a child of the main app start span', async () => {
         const integration = new ReactNativeTracing();
 

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -348,8 +348,7 @@ describe('ReactNativeTracing', () => {
 
           const bundleStartSpan = transaction!.spans!.find(
             ({ description }) =>
-              description === 'JS Bundle Execution Start'
-              || description === 'JS Bundle Execution Before React Root'
+              description === 'JS Bundle Execution Start' || description === 'JS Bundle Execution Before React Root',
           );
 
           expect(bundleStartSpan).toBeUndefined();
@@ -370,7 +369,9 @@ describe('ReactNativeTracing', () => {
           const transaction = client.event;
 
           const appStartRootSpan = transaction!.spans!.find(({ description }) => description === 'Cold App Start');
-          const bundleStartSpan = transaction!.spans!.find(({ description }) => description === 'JS Bundle Execution Start');
+          const bundleStartSpan = transaction!.spans!.find(
+            ({ description }) => description === 'JS Bundle Execution Start',
+          );
           const appStartRootSpanJSON = spanToJSON(appStartRootSpan!);
           const bundleStartSpanJSON = spanToJSON(bundleStartSpan!);
 
@@ -409,7 +410,9 @@ describe('ReactNativeTracing', () => {
           const transaction = client.event;
 
           const appStartRootSpan = transaction!.spans!.find(({ description }) => description === 'Cold App Start');
-          const bundleStartSpan = transaction!.spans!.find(({ description }) => description === 'JS Bundle Execution Before React Root');
+          const bundleStartSpan = transaction!.spans!.find(
+            ({ description }) => description === 'JS Bundle Execution Before React Root',
+          );
           const appStartRootSpanJSON = spanToJSON(appStartRootSpan!);
           const bundleStartSpanJSON = spanToJSON(bundleStartSpan!);
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
This PR uses bundle start timestamp provided by RN, to create JS bundle execution start spans.

With `Sentry.wrap()`
![Screenshot 2024-06-04 at 18 51 52](https://github.com/getsentry/sentry-react-native/assets/31292499/95f3f9e7-eb75-49ce-8be6-f90aa8e28375)

Without `Sentry.wrap()`
![Screenshot 2024-06-04 at 18 52 40](https://github.com/getsentry/sentry-react-native/assets/31292499/d26aa486-72e7-44f1-a127-d027743a64fb)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- closes: https://github.com/getsentry/sentry-react-native/issues/2915

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
