### PR TITLE
fix(logs): Add missing App Start logs when the span is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fix
 
-- Add missing logs to dropped App Start spans ([#3860](https://github.com/getsentry/sentry-react-native/pull/3860))
+- Add missing logs to dropped App Start spans ([#3861](https://github.com/getsentry/sentry-react-native/pull/3861))
 
 ## 5.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fix
+
+- Add missing logs to dropped App Start spans ([#3860](https://github.com/getsentry/sentry-react-native/pull/3860))
+
 ## 5.23.0
 
 ### Features

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -422,11 +422,18 @@ export class ReactNativeTracing implements Integration {
 
     const appStart = await NATIVE.fetchNativeAppStart();
 
-    if (!appStart || appStart.didFetchAppStart) {
+    if (!appStart) {
+      logger.warn('[ReactNativeTracing] Not instrumenting App Start because native returned null.');
+      return;
+    }
+
+    if (appStart.didFetchAppStart) {
+      logger.warn('[ReactNativeTracing] Not instrumenting App Start because this start was already reported.');
       return;
     }
 
     if (!this.useAppStartWithProfiler) {
+      logger.warn('[ReactNativeTracing] `Sentry.wrap` not detected, using JS context init as app start end.');
       this._appStartFinishTimestamp = getTimeOriginMilliseconds() / 1000;
     }
 
@@ -450,7 +457,7 @@ export class ReactNativeTracing implements Integration {
   private _addAppStartData(transaction: IdleTransaction, appStart: NativeAppStartResponse): void {
     const appStartDurationMilliseconds = this._getAppStartDurationMilliseconds(appStart);
     if (!appStartDurationMilliseconds) {
-      logger.warn('App start was never finished.');
+      logger.warn('[ReactNativeTracing] App start end has not been recorded, not adding app start span.');
       return;
     }
 
@@ -458,6 +465,7 @@ export class ReactNativeTracing implements Integration {
     // this could be due to many different reasons.
     // we've seen app starts with hours, days and even months.
     if (appStartDurationMilliseconds >= ReactNativeTracing._maxAppStart) {
+      logger.warn('[ReactNativeTracing] App start duration is over minute long, not adding app start span.');
       return;
     }
 

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -465,7 +465,7 @@ export class ReactNativeTracing implements Integration {
     // this could be due to many different reasons.
     // we've seen app starts with hours, days and even months.
     if (appStartDurationMilliseconds >= ReactNativeTracing._maxAppStart) {
-      logger.warn('[ReactNativeTracing] App start duration is over minute long, not adding app start span.');
+      logger.warn('[ReactNativeTracing] App start duration is over a minute long, not adding app start span.');
       return;
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
Adds warning logs when `debug: true` to places in the SDK code where it's decided that App Start span won't be added.

This will makes it easier for our customer to see why their transactions are missing app start spans as well for us when debugging the SDK.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes