### PR TITLE
ci(ios): allow larger app size diff (up to 1 MiB) 

### DIFF
--- a/test/perf/metrics-ios.yml
+++ b/test/perf/metrics-ios.yml
@@ -10,5 +10,5 @@ startupTimeTest:
   diffMax: 150
 
 binarySizeTest:
-  diffMin: 200 KiB
-  diffMax: 600 KiB
+  diffMin: 600 KiB
+  diffMax: 1000 KiB


### PR DESCRIPTION
bumps the expected size after recent sentry-cocoa update

#skip-changelog 