### PR TITLE
fix(ttfd): Use TTID end timestamp when TTFD should be updated with an earlier timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fix
 
 - Add missing logs to dropped App Start spans ([#3861](https://github.com/getsentry/sentry-react-native/pull/3861))
+- Use TTID end timestamp when TTFD should be updated with an earlier timestamp ([#3869](https://github.com/getsentry/sentry-react-native/pull/3869))
 
 ## 5.23.0
 

--- a/src/js/tracing/timetodisplay.tsx
+++ b/src/js/tracing/timetodisplay.tsx
@@ -262,7 +262,12 @@ function updateFullDisplaySpan(frameTimestampSeconds: number, passedInitialDispl
     return;
   }
 
-  span.end(frameTimestampSeconds);
+  if (initialDisplayEndTimestamp > frameTimestampSeconds) {
+    logger.warn(`[TimeToDisplay] Using initial display end. Full display end frame timestamp is before initial display end.`);
+    span.end(initialDisplayEndTimestamp);
+  } else {
+    span.end(frameTimestampSeconds);
+  }
 
   span.setStatus('ok');
   logger.debug(`[TimeToDisplay] ${spanToJSON(span).description} span updated with end timestamp.`);

--- a/test/tracing/timetodisplay.test.tsx
+++ b/test/tracing/timetodisplay.test.tsx
@@ -241,6 +241,42 @@ describe('TimeToDisplay', () => {
     expect(spanToJSON(fullDisplaySpan!).timestamp).toEqual(initialDisplayEndTimestampMs / 1_000);
   });
 
+  test('full display which ended before but processed after initial display is extended to initial display end', async () => {
+    const fullDisplayEndTimestampMs = secondInFutureTimestampMs();
+    const initialDisplayEndTimestampMs = secondInFutureTimestampMs() + 500;
+    const [initialDisplaySpan, fullDisplaySpan, activeSpan] = startSpanManual(
+      {
+        name: 'Root Manual Span',
+        startTime: secondAgoTimestampMs(),
+      },
+      (activeSpan: Span | undefined) => {
+        const initialDisplaySpan = startTimeToInitialDisplaySpan();
+        const fullDisplaySpan = startTimeToFullDisplaySpan();
+
+        const timeToDisplayComponent = TestRenderer.create(<><TimeToInitialDisplay record={false} /><TimeToFullDisplay record={true}/></>);
+        timeToDisplayComponent.update(<><TimeToInitialDisplay record={true} /><TimeToFullDisplay record={true} /></>);
+
+        emitNativeInitialDisplayEvent(initialDisplayEndTimestampMs);
+        emitNativeFullDisplayEvent(fullDisplayEndTimestampMs);
+
+        activeSpan?.end();
+        return [initialDisplaySpan, fullDisplaySpan, activeSpan];
+      },
+    );
+
+    await jest.runOnlyPendingTimersAsync();
+    await client.flush();
+
+    expectFinishedInitialDisplaySpan(initialDisplaySpan, activeSpan);
+    expectFinishedFullDisplaySpan(fullDisplaySpan, activeSpan);
+
+    expectInitialDisplayMeasurementOnSpan(client.event!);
+    expectFullDisplayMeasurementOnSpan(client.event!);
+
+    expect(spanToJSON(initialDisplaySpan!).timestamp).toEqual(initialDisplayEndTimestampMs / 1_000);
+    expect(spanToJSON(fullDisplaySpan!).timestamp).toEqual(initialDisplayEndTimestampMs / 1_000);
+  });
+
   test('consequent renders do not update display end', async () => {
     const initialDisplayEndTimestampMs = secondInFutureTimestampMs();
     const fullDisplayEndTimestampMs = secondInFutureTimestampMs() + 500;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes a race condition when TTFD update would be called after TTID, but the provided timestamp was set to earlier point in time than TTID end timestamp.

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes