### PR TITLE
fix(changelog): Add entry for missing SentryLevel fix on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fix
 
+- Fix failing iOS builds due to missing SentryLevel ([#3854](https://github.com/getsentry/sentry-react-native/pull/3854))
 - Add missing logs to dropped App Start spans ([#3861](https://github.com/getsentry/sentry-react-native/pull/3861))
 - Make all options of `startTimeToInitialDisplaySpan` optional ([#3867](https://github.com/getsentry/sentry-react-native/pull/3867))
 - Add Span IDs to Time to Display debug logs ([#3868](https://github.com/getsentry/sentry-react-native/pull/3868))


### PR DESCRIPTION
https://github.com/getsentry/sentry-react-native/pull/3854 was not in the changelog, because the change should have not affected user as it would be release before the breaking changes from `sentry-cocoa`.

But due to unfortunate order of events and not requiring pass on native builds -> https://github.com/getsentry/sentry-react-native/issues/3871

The release order was opposite. 

#skip-changelog 