### PR TITLE
fix(client): use `_setupIntegrations` to extend both `init` and public `setupIntegrations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - This doesn't change the app start measurement length, but add child spans (more detail) into the existing app start span
 - Added JS Bundle Execution start information to the application start measurements ([#3857](https://github.com/getsentry/sentry-react-native/pull/3857))
 
+### Fixes
+
+- Add missing tracing integrations when using `client.init()` ([#3882](https://github.com/getsentry/sentry-react-native/pull/3882))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.27.0 to v8.28.0 ([#3866](https://github.com/getsentry/sentry-react-native/pull/3866))

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -109,8 +109,8 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
   /**
    * Sets up the integrations
    */
-  public setupIntegrations(): void {
-    super.setupIntegrations();
+  protected _setupIntegrations(): void {
+    super._setupIntegrations();
     const tracing = this.getIntegration(ReactNativeTracing);
     const routingName = tracing?.options.routingInstrumentation?.name;
     if (routingName) {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -667,6 +667,22 @@ describe('Tests ReactNativeClient', () => {
       expect(client.getIntegrationById('ReactNativeUserInteractionTracing')).toBeTruthy();
     });
 
+    test('register user interactions tracing - init()', () => {
+      const client = new ReactNativeClient(
+        mockedOptions({
+          dsn: EXAMPLE_DSN,
+          integrations: [
+            new ReactNativeTracing({
+              enableUserInteractionTracing: true,
+            }),
+          ],
+        }),
+      );
+      client.init();
+
+      expect(client.getIntegrationById('ReactNativeUserInteractionTracing')).toBeTruthy();
+    });
+
     test('do not register user interactions tracing', () => {
       const client = new ReactNativeClient(
         mockedOptions({
@@ -679,6 +695,22 @@ describe('Tests ReactNativeClient', () => {
         }),
       );
       client.setupIntegrations();
+
+      expect(client.getIntegrationById('ReactNativeUserInteractionTracing')).toBeUndefined();
+    });
+
+    test('do not register user interactions tracing - init()', () => {
+      const client = new ReactNativeClient(
+        mockedOptions({
+          dsn: EXAMPLE_DSN,
+          integrations: [
+            new ReactNativeTracing({
+              enableUserInteractionTracing: false,
+            }),
+          ],
+        }),
+      );
+      client.init();
 
       expect(client.getIntegrationById('ReactNativeUserInteractionTracing')).toBeUndefined();
     });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes missing RN tracing integrations (these integrations are dummy for telemetry purposes only). They stopped beiing reported when JS core switched from `setupIntegrations` to `init`.  

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes