### PR TITLE
fix(performance): UIKit can't end after JS execution starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add native application start spans ([#3855](https://github.com/getsentry/sentry-react-native/pull/3855))
+- Add native application start spans ([#3855](https://github.com/getsentry/sentry-react-native/pull/3855), [#3884](https://github.com/getsentry/sentry-react-native/pull/3884))
   - This doesn't change the app start measurement length, but add child spans (more detail) into the existing app start span
 - Added JS Bundle Execution start information to the application start measurements ([#3857](https://github.com/getsentry/sentry-react-native/pull/3857))
 

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -580,13 +580,7 @@ export class ReactNativeTracing implements Integration {
     if (bundleStart && bundleStart < nativeUIKitSpan.end_timestamp_ms) {
       parentSpan.startChild({
         op: parentSpan.op,
-        description: 'UIKit Init Start',
-        startTimestamp: nativeUIKitSpan.start_timestamp_ms / 1000,
-        endTimestamp: nativeUIKitSpan.start_timestamp_ms / 1000,
-      });
-      parentSpan.startChild({
-        op: parentSpan.op,
-        description: 'Native Runtime Init',
+        description: 'UIKit Init to JS Exec Start',
         startTimestamp: nativeUIKitSpan.start_timestamp_ms / 1000,
         endTimestamp: bundleStart / 1000,
       });

--- a/src/js/tracing/reactnativetracing.ts
+++ b/src/js/tracing/reactnativetracing.ts
@@ -568,9 +568,9 @@ export class ReactNativeTracing implements Integration {
   private _createUIKitSpan(parentSpan: Span, nativeUIKitSpan: NativeAppStartResponse['spans'][number]): Span {
     const bundleStart = getBundleStartTimestampMs();
 
-    // If UIKit init ends after the bundle start the native SDK was auto initialize
-    // and so the end timestamp is incorrect
-    // The timestamps can't equal as after UIKit RN initializes
+    // If UIKit init ends after the bundle start, the native SDK was auto-initialized
+    // and so the end timestamp is incorrect.
+    // The timestamps can't equal, as RN initializes after UIKit.
     if (bundleStart && bundleStart < nativeUIKitSpan.end_timestamp_ms) {
       return parentSpan.startChild({
         op: parentSpan.op,

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -540,25 +540,15 @@ describe('ReactNativeTracing', () => {
 
         const transaction = client.event;
 
-        const uiKitInitMarkSpan = transaction!.spans!.find(({ description }) => description?.startsWith('UIKit Init'));
         const nativeRuntimeInitSpan = transaction!.spans!.find(({ description }) =>
-          description?.startsWith('Native Runtime Init'),
+          description?.startsWith('UIKit Init to JS Exec Start'),
         );
-        const uiKitInitMarkSpanJSON = spanToJSON(uiKitInitMarkSpan!);
         const nativeRuntimeInitSpanJSON = spanToJSON(nativeRuntimeInitSpan!);
 
-        expect(uiKitInitMarkSpan).toBeDefined();
         expect(nativeRuntimeInitSpanJSON).toBeDefined();
-        expect(uiKitInitMarkSpanJSON).toEqual(
-          expect.objectContaining(<SpanJSON>{
-            description: 'UIKit Init Start',
-            start_timestamp: (timeOriginMilliseconds - 100) / 1000,
-            timestamp: (timeOriginMilliseconds - 100) / 1000,
-          }),
-        );
         expect(nativeRuntimeInitSpanJSON).toEqual(
           expect.objectContaining(<SpanJSON>{
-            description: 'Native Runtime Init',
+            description: 'UIKit Init to JS Exec Start',
             start_timestamp: (timeOriginMilliseconds - 100) / 1000,
             timestamp: (timeOriginMilliseconds - 50) / 1000,
           }),

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -503,13 +503,13 @@ describe('ReactNativeTracing', () => {
 
         const transaction = client.event;
 
-        const nativeSpan = transaction!.spans!.find(({ description }) => description?.startsWith('UIKit init'));
+        const nativeSpan = transaction!.spans!.find(({ description }) => description?.startsWith('UIKit Init'));
         const nativeSpanJSON = spanToJSON(nativeSpan!);
 
         expect(nativeSpan).toBeDefined();
         expect(nativeSpanJSON).toEqual(
           expect.objectContaining(<SpanJSON>{
-            description: 'UIKit init',
+            description: 'UIKit Init',
             start_timestamp: (timeOriginMilliseconds - 100) / 1000,
             timestamp: (timeOriginMilliseconds - 60) / 1000,
           }),
@@ -540,15 +540,27 @@ describe('ReactNativeTracing', () => {
 
         const transaction = client.event;
 
-        const nativeSpan = transaction!.spans!.find(({ description }) => description?.startsWith('UIKit init'));
-        const nativeSpanJSON = spanToJSON(nativeSpan!);
+        const uiKitInitMarkSpan = transaction!.spans!.find(({ description }) => description?.startsWith('UIKit Init'));
+        const nativeRuntimeInitSpan = transaction!.spans!.find(({ description }) =>
+          description?.startsWith('Native Runtime Init'),
+        );
+        const uiKitInitMarkSpanJSON = spanToJSON(uiKitInitMarkSpan!);
+        const nativeRuntimeInitSpanJSON = spanToJSON(nativeRuntimeInitSpan!);
 
-        expect(nativeSpan).toBeDefined();
-        expect(nativeSpanJSON).toEqual(
+        expect(uiKitInitMarkSpan).toBeDefined();
+        expect(nativeRuntimeInitSpanJSON).toBeDefined();
+        expect(uiKitInitMarkSpanJSON).toEqual(
           expect.objectContaining(<SpanJSON>{
-            description: 'UIKit init start',
+            description: 'UIKit Init Start',
             start_timestamp: (timeOriginMilliseconds - 100) / 1000,
             timestamp: (timeOriginMilliseconds - 100) / 1000,
+          }),
+        );
+        expect(nativeRuntimeInitSpanJSON).toEqual(
+          expect.objectContaining(<SpanJSON>{
+            description: 'Native Runtime Init',
+            start_timestamp: (timeOriginMilliseconds - 100) / 1000,
+            timestamp: (timeOriginMilliseconds - 50) / 1000,
           }),
         );
       });

--- a/test/tracing/reactnativetracing.test.ts
+++ b/test/tracing/reactnativetracing.test.ts
@@ -478,6 +478,80 @@ describe('ReactNativeTracing', () => {
           }),
         );
       });
+
+      it('adds ui kit init full length as a child of the main app start span', async () => {
+        const integration = new ReactNativeTracing();
+
+        const timeOriginMilliseconds = Date.now();
+        mockAppStartResponse({
+          cold: true,
+          enableNativeSpans: true,
+          customNativeSpans: [
+            {
+              description: 'UIKit init',
+              start_timestamp_ms: timeOriginMilliseconds - 100,
+              end_timestamp_ms: timeOriginMilliseconds - 60,
+            },
+          ],
+        });
+        mockReactNativeBundleExecutionStartTimestamp();
+
+        setup(integration);
+
+        await jest.advanceTimersByTimeAsync(500);
+        await jest.runOnlyPendingTimersAsync();
+
+        const transaction = client.event;
+
+        const nativeSpan = transaction!.spans!.find(({ description }) => description?.startsWith('UIKit init'));
+        const nativeSpanJSON = spanToJSON(nativeSpan!);
+
+        expect(nativeSpan).toBeDefined();
+        expect(nativeSpanJSON).toEqual(
+          expect.objectContaining(<SpanJSON>{
+            description: 'UIKit init',
+            start_timestamp: (timeOriginMilliseconds - 100) / 1000,
+            timestamp: (timeOriginMilliseconds - 60) / 1000,
+          }),
+        );
+      });
+
+      it('adds ui kit init start mark as a child of the main app start span', async () => {
+        const integration = new ReactNativeTracing();
+
+        const timeOriginMilliseconds = Date.now();
+        mockAppStartResponse({
+          cold: true,
+          enableNativeSpans: true,
+          customNativeSpans: [
+            {
+              description: 'UIKit init',
+              start_timestamp_ms: timeOriginMilliseconds - 100,
+              end_timestamp_ms: timeOriginMilliseconds - 20, // After mocked bundle execution start
+            },
+          ],
+        });
+        mockReactNativeBundleExecutionStartTimestamp();
+
+        setup(integration);
+
+        await jest.advanceTimersByTimeAsync(500);
+        await jest.runOnlyPendingTimersAsync();
+
+        const transaction = client.event;
+
+        const nativeSpan = transaction!.spans!.find(({ description }) => description?.startsWith('UIKit init'));
+        const nativeSpanJSON = spanToJSON(nativeSpan!);
+
+        expect(nativeSpan).toBeDefined();
+        expect(nativeSpanJSON).toEqual(
+          expect.objectContaining(<SpanJSON>{
+            description: 'UIKit init start',
+            start_timestamp: (timeOriginMilliseconds - 100) / 1000,
+            timestamp: (timeOriginMilliseconds - 100) / 1000,
+          }),
+        );
+      });
     });
 
     describe('With routing instrumentation', () => {
@@ -1068,10 +1142,12 @@ function mockAppStartResponse({
   cold,
   has_fetched,
   enableNativeSpans,
+  customNativeSpans,
 }: {
   cold: boolean;
   has_fetched?: boolean;
   enableNativeSpans?: boolean;
+  customNativeSpans?: NativeAppStartResponse['spans'];
 }) {
   const timeOriginMilliseconds = Date.now();
   const appStartTimeMilliseconds = timeOriginMilliseconds - 100;
@@ -1086,6 +1162,7 @@ function mockAppStartResponse({
             start_timestamp_ms: timeOriginMilliseconds - 100,
             end_timestamp_ms: timeOriginMilliseconds - 50,
           },
+          ...(customNativeSpans ?? []),
         ]
       : [],
   };


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
UIKit init end when the native `AppDelegate.application` method is called, this is before the JS engine starts.

This PR adds check, which only records the UIKit init start if the end was recorder after JS start. 

This logic will let manual init setups to record the UIKit init end and auto init setup to record only the start.

Before
![Screenshot 2024-06-12 at 11 45 38](https://github.com/getsentry/sentry-react-native/assets/31292499/89603444-19f4-48c3-b340-dbd5806a0695)


After
![Screenshot 2024-06-12 at 11 27 19](https://github.com/getsentry/sentry-react-native/assets/31292499/607ad143-db21-4eed-94b4-78ddb7dc4971)


## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
