### PR TITLE
fix(xcode): Xcode command line builds fail with `--allow-failure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   - This doesn't change the app start measurement length, but add child spans (more detail) into the existing app start span
 - Added JS Bundle Execution start information to the application start measurements ([#3857](https://github.com/getsentry/sentry-react-native/pull/3857))
 
+### Fixes
+
+- Ensure `sentry-cli` doesn't trigger Xcode `error:` prefix ([#3887](https://github.com/getsentry/sentry-react-native/pull/3887))
+  - Fixes `--allow-failure` failing Xcode builds
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.27.0 to v8.28.0 ([#3866](https://github.com/getsentry/sentry-react-native/pull/3866))

--- a/scripts/sentry-xcode-debug-files.sh
+++ b/scripts/sentry-xcode-debug-files.sh
@@ -36,13 +36,13 @@ elif echo "$XCODE_BUILD_CONFIGURATION" | grep -iq "debug"; then # case insensiti
   echo "Skipping debug files upload for *Debug* configuration"
 else
   # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
-  set +x # disable printing commands otherwise we might print `error:` by accident
+  set +x +e # disable printing commands otherwise we might print `error:` by accident and allow continuing on error
   SENTRY_UPLOAD_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $UPLOAD_DEBUG_FILES" 2>&1)
   if [ $? -eq 0 ]; then
     echo "$SENTRY_UPLOAD_COMMAND_OUTPUT" | awk '{print "output: sentry-cli - " $0}'
-    set -x # re-enable printing commands
   else
-    echo "message: sentry-cli - To disable native debug files auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
+    echo "error: sentry-cli - To disable native debug files auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
     echo "error: sentry-cli - $SENTRY_UPLOAD_COMMAND_OUTPUT"
   fi
+  set -x -e # re-enable
 fi

--- a/scripts/sentry-xcode-debug-files.sh
+++ b/scripts/sentry-xcode-debug-files.sh
@@ -36,9 +36,11 @@ elif echo "$XCODE_BUILD_CONFIGURATION" | grep -iq "debug"; then # case insensiti
   echo "Skipping debug files upload for *Debug* configuration"
 else
   # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
-  SENTRY_UPLOAD_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $UPLOAD_DEBUG_FILES")
+  set +x # disable printing commands otherwise we might print `error:` by accident
+  SENTRY_UPLOAD_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $UPLOAD_DEBUG_FILES" 2>&1)
   if [ $? -eq 0 ]; then
-    echo "output: sentry-cli - $SENTRY_UPLOAD_COMMAND_OUTPUT"
+    echo "$SENTRY_UPLOAD_COMMAND_OUTPUT" | awk '{print "output: sentry-cli - " $0}'
+    set -x # re-enable printing commands
   else
     echo "message: sentry-cli - To disable native debug files auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
     echo "error: sentry-cli - $SENTRY_UPLOAD_COMMAND_OUTPUT"

--- a/scripts/sentry-xcode-debug-files.sh
+++ b/scripts/sentry-xcode-debug-files.sh
@@ -35,5 +35,12 @@ if [ "$SENTRY_DISABLE_AUTO_UPLOAD" == true ]; then
 elif echo "$XCODE_BUILD_CONFIGURATION" | grep -iq "debug"; then # case insensitive check for "debug"
   echo "Skipping debug files upload for *Debug* configuration"
 else
-  /bin/sh -c "\"$LOCAL_NODE_BINARY\" $UPLOAD_DEBUG_FILES"
+  # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
+  SENTRY_UPLOAD_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $UPLOAD_DEBUG_FILES")
+  if [ $? -eq 0 ]; then
+    echo "output: sentry-cli - $SENTRY_UPLOAD_COMMAND_OUTPUT"
+  else
+    echo "message: sentry-cli - To disable native debug files auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
+    echo "error: sentry-cli - $SENTRY_UPLOAD_COMMAND_OUTPUT"
+  fi
 fi

--- a/scripts/sentry-xcode.sh
+++ b/scripts/sentry-xcode.sh
@@ -23,7 +23,14 @@ ARGS="$NO_AUTO_RELEASE $SENTRY_CLI_EXTRA_ARGS $SENTRY_CLI_RN_XCODE_EXTRA_ARGS"
 REACT_NATIVE_XCODE_WITH_SENTRY="\"$SENTRY_CLI_EXECUTABLE\" react-native xcode $ARGS \"$REACT_NATIVE_XCODE\""
 
 if [ "$SENTRY_DISABLE_AUTO_UPLOAD" != true ]; then
-  /bin/sh -c "\"$LOCAL_NODE_BINARY\" $REACT_NATIVE_XCODE_WITH_SENTRY"
+  # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
+  SENTRY_XCODE_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $REACT_NATIVE_XCODE_WITH_SENTRY")
+  if [ $? -eq 0 ]; then
+    echo "output: sentry-cli - $SENTRY_XCODE_COMMAND_OUTPUT"
+  else
+    echo "message: sentry-cli - To disable source maps auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
+    echo "error: sentry-cli - $SENTRY_XCODE_COMMAND_OUTPUT"
+  fi
 else
   echo "SENTRY_DISABLE_AUTO_UPLOAD=true, skipping sourcemaps upload"
   /bin/sh -c "$REACT_NATIVE_XCODE"

--- a/scripts/sentry-xcode.sh
+++ b/scripts/sentry-xcode.sh
@@ -24,15 +24,15 @@ REACT_NATIVE_XCODE_WITH_SENTRY="\"$SENTRY_CLI_EXECUTABLE\" react-native xcode $A
 
 if [ "$SENTRY_DISABLE_AUTO_UPLOAD" != true ]; then
   # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
-  set +x # disable printing commands otherwise we might print `error:` by accident
+  set +x +e # disable printing commands otherwise we might print `error:` by accident and allow continuing on error
   SENTRY_XCODE_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $REACT_NATIVE_XCODE_WITH_SENTRY" 2>&1)
   if [ $? -eq 0 ]; then
     echo "$SENTRY_XCODE_COMMAND_OUTPUT" | awk '{print "output: sentry-cli - " $0}'
-    set -x # re-enable printing commands
   else
-    echo "message: sentry-cli - To disable source maps auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
+    echo "error: sentry-cli - To disable source maps auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
     echo "error: sentry-cli - $SENTRY_XCODE_COMMAND_OUTPUT"
   fi
+  set -x -e # re-enable
 else
   echo "SENTRY_DISABLE_AUTO_UPLOAD=true, skipping sourcemaps upload"
   /bin/sh -c "$REACT_NATIVE_XCODE"

--- a/scripts/sentry-xcode.sh
+++ b/scripts/sentry-xcode.sh
@@ -24,9 +24,11 @@ REACT_NATIVE_XCODE_WITH_SENTRY="\"$SENTRY_CLI_EXECUTABLE\" react-native xcode $A
 
 if [ "$SENTRY_DISABLE_AUTO_UPLOAD" != true ]; then
   # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
-  SENTRY_XCODE_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $REACT_NATIVE_XCODE_WITH_SENTRY")
+  set +x # disable printing commands otherwise we might print `error:` by accident
+  SENTRY_XCODE_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $REACT_NATIVE_XCODE_WITH_SENTRY" 2>&1)
   if [ $? -eq 0 ]; then
-    echo "output: sentry-cli - $SENTRY_XCODE_COMMAND_OUTPUT"
+    echo "$SENTRY_XCODE_COMMAND_OUTPUT" | awk '{print "output: sentry-cli - " $0}'
+    set -x # re-enable printing commands
   else
     echo "message: sentry-cli - To disable source maps auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true"
     echo "error: sentry-cli - $SENTRY_XCODE_COMMAND_OUTPUT"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR ensures sentry-cli doesn't print out `error:` into console during Xcode builds with `--allow-failure`.

The prefix `error:` triggers Xcode to mark builds as failed.

- fixes: https://github.com/getsentry/sentry-react-native/issues/3677

## :green_heart: How did you test it?
sample apps

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes