### PR TITLE
fix(ci): Remove JS V8 dropped packages from the update CI

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -7,6 +7,7 @@ on:
   # And on on every PR merge so we get the updated dependencies ASAP, and to make sure the changelog doesn't conflict.
   push:
     branches:
+      - '**'
       - main
 
 jobs:

--- a/scripts/update-javascript.sh
+++ b/scripts/update-javascript.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 tagPrefix=''
 repo="https://github.com/getsentry/sentry-javascript.git"
-packages=('@sentry/browser' '@sentry/core' '@sentry/hub' '@sentry/integrations' '@sentry/react' '@sentry/types' '@sentry/utils' '@sentry-internal/typescript')
+packages=('@sentry/browser' '@sentry/core' '@sentry/react' '@sentry/types' '@sentry/utils' '@sentry-internal/typescript')
 packages+=('@sentry-internal/eslint-config-sdk' '@sentry-internal/eslint-plugin-sdk')
 
 . $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
JS V8 removed some packages used in RN V5.

The use of these packages is removed in RN V6.

We have to update the CI on main, otherwise the updater job keeps failing.