### PR TITLE
feat: touch breadcrumbs info improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2687,7 +2687,7 @@ We are looking into ways making this more stable and plan to re-enable it again 
 
 ## v0.23.2
 
-- Fixed #228 again ¯\\*(ツ)*/¯
+- Fixed #228 again ¯\\_(ツ)_/¯
 
 ## v0.23.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Improve touch event component info if annotated with [`@sentry/babel-plugin-component-annotate`](https://www.npmjs.com/package/@sentry/babel-plugin-component-annotate) ([#3899](https://github.com/getsentry/sentry-react-native/pull/3899))
+
 ## 5.24.1
 
 ### Fixes
@@ -642,7 +648,7 @@ This release is compatible with `expo@50.0.0-preview.6` and newer.
   });
   ```
 
-  Read more at https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7690
+  Read more at <https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7690>
 
 - Report current screen in `contexts.app.view_names` ([#3339](https://github.com/getsentry/sentry-react-native/pull/3339))
 
@@ -1033,6 +1039,7 @@ This has been fixed in [version `5.9.1`](https://github.com/getsentry/sentry-rea
 ## 5.4.0
 
 ### Features
+
 - Add TS 4.1 typings ([#2995](https://github.com/getsentry/sentry-react-native/pull/2995))
   - TS 3.8 are present and work automatically with older projects
 - Add CPU Info to Device Context ([#2984](https://github.com/getsentry/sentry-react-native/pull/2984))
@@ -2680,7 +2687,7 @@ We are looking into ways making this more stable and plan to re-enable it again 
 
 ## v0.23.2
 
-- Fixed #228 again ¯\\_(ツ)_/¯
+- Fixed #228 again ¯\\*(ツ)*/¯
 
 ## v0.23.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -648,7 +648,7 @@ This release is compatible with `expo@50.0.0-preview.6` and newer.
   });
   ```
 
-  Read more at <https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7690>
+  Read more at https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#7690
 
 - Report current screen in `contexts.app.view_names` ([#3339](https://github.com/getsentry/sentry-react-native/pull/3339))
 

--- a/samples/expo/babel.config.js
+++ b/samples/expo/babel.config.js
@@ -1,4 +1,6 @@
-module.exports = function(api) {
+const componentAnnotatePlugin = require('@sentry/babel-plugin-component-annotate');
+
+module.exports = function (api) {
   api.cache(false);
   return {
     presets: ['babel-preset-expo'],
@@ -11,6 +13,7 @@ module.exports = function(api) {
           },
         },
       ],
+      componentAnnotatePlugin,
     ],
   };
 };

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/preset-env": "7.1.6",
+    "@sentry/babel-plugin-component-annotate": "^2.18.0",
     "@types/node": "20.10.4"
   },
   "overrides": {

--- a/samples/expo/yarn.lock
+++ b/samples/expo/yarn.lock
@@ -2413,6 +2413,11 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
+"@sentry/babel-plugin-component-annotate@^2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.18.0.tgz#3bee98f94945643b0762ceed1f6cca60db52bdbd"
+  integrity sha512-9L4RbhS3WNtc/SokIhc0dwgcvs78YSQPakZejsrIgnzLzCi8mS6PeT+BY0+QCtsXxjd1egM8hqcJeB0lukBkXA==
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"

--- a/samples/react-native/babel.config.js
+++ b/samples/react-native/babel.config.js
@@ -1,3 +1,5 @@
+const componentAnnotatePlugin = require('@sentry/babel-plugin-component-annotate');
+
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
   plugins: [
@@ -9,5 +11,6 @@ module.exports = {
         },
       },
     ],
+    componentAnnotatePlugin,
   ],
 };

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -43,6 +43,7 @@
     "@react-native/eslint-config": "^0.73.1",
     "@react-native/metro-config": "^0.73.1",
     "@react-native/typescript-config": "^0.73.1",
+    "@sentry/babel-plugin-component-annotate": "^2.18.0",
     "@types/react": "^18.2.65",
     "@types/react-native-vector-icons": "^6.4.18",
     "@types/react-test-renderer": "^18.0.0",

--- a/samples/react-native/yarn.lock
+++ b/samples/react-native/yarn.lock
@@ -3127,6 +3127,11 @@
     color "^4.2.3"
     warn-once "^0.1.0"
 
+"@sentry/babel-plugin-component-annotate@^2.18.0":
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.18.0.tgz#3bee98f94945643b0762ceed1f6cca60db52bdbd"
+  integrity sha512-9L4RbhS3WNtc/SokIhc0dwgcvs78YSQPakZejsrIgnzLzCi8mS6PeT+BY0+QCtsXxjd1egM8hqcJeB0lukBkXA==
+
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -191,16 +191,19 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
 
       const props = currentInst.memoizedProps ?? {};
       const info: TouchedComponentInfo = {};
-      if (typeof props[SENTRY_COMPONENT_PROP_KEY] === 'string' && props[SENTRY_COMPONENT_PROP_KEY].length > 0) {
+
+      // provided by @sentry/babel-plugin-component-annotate
+      if (typeof props[SENTRY_COMPONENT_PROP_KEY] === 'string' && props[SENTRY_COMPONENT_PROP_KEY].length > 0 && props[SENTRY_COMPONENT_PROP_KEY] !== 'unknown') {
         info.name = props[SENTRY_COMPONENT_PROP_KEY];
       }
-      if (typeof props[SENTRY_ELEMENT_PROP_KEY] === 'string' && props[SENTRY_ELEMENT_PROP_KEY].length > 0) {
+      if (typeof props[SENTRY_ELEMENT_PROP_KEY] === 'string' && props[SENTRY_ELEMENT_PROP_KEY].length > 0 && props[SENTRY_ELEMENT_PROP_KEY] !== 'unknown') {
         info.element = props[SENTRY_ELEMENT_PROP_KEY];
       }
-      if (typeof props[SENTRY_FILE_PROP_KEY] === 'string' && props[SENTRY_FILE_PROP_KEY].length > 0) {
+      if (typeof props[SENTRY_FILE_PROP_KEY] === 'string' && props[SENTRY_FILE_PROP_KEY].length > 0 && props[SENTRY_FILE_PROP_KEY] !== 'unknown') {
         info.file = props[SENTRY_FILE_PROP_KEY];
       }
 
+      // use custom label if provided by the user, or displayName if available
       const labelValue =
         typeof props[SENTRY_LABEL_PROP_KEY] === 'string'
           ? props[SENTRY_LABEL_PROP_KEY]
@@ -247,6 +250,12 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
     if (value.label && this._isNameIgnored(value.label)) {
       return false;
     }
+
+    // Deduplicate same subsequent items.
+    if (touchPath.length > 0 && JSON.stringify(touchPath[touchPath.length - 1]) === JSON.stringify(value)) {
+      return false;
+    }
+
     touchPath.push(value);
     return true;
   }

--- a/src/js/touchevents.tsx
+++ b/src/js/touchevents.tsx
@@ -2,7 +2,7 @@ import { addBreadcrumb, getCurrentHub } from '@sentry/core';
 import type { SeverityLevel } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import * as React from 'react';
-import type { GestureResponderEvent} from 'react-native';
+import type { GestureResponderEvent } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 
 import { createIntegration } from './integrations/factory';
@@ -53,6 +53,9 @@ const DEFAULT_BREADCRUMB_TYPE = 'user';
 const DEFAULT_MAX_COMPONENT_TREE_SIZE = 20;
 
 const SENTRY_LABEL_PROP_KEY = 'sentry-label';
+const SENTRY_COMPONENT_PROP_KEY = 'data-sentry-component';
+const SENTRY_ELEMENT_PROP_KEY = 'data-sentry-element';
+const SENTRY_FILE_PROP_KEY = 'data-sentry-source-file';
 
 interface ElementInstance {
   elementType?: {
@@ -63,6 +66,13 @@ interface ElementInstance {
   return?: ElementInstance;
 }
 
+interface TouchedComponentInfo {
+  name?: string;
+  label?: string;
+  element?: string;
+  file?: string;
+}
+
 interface PrivateGestureResponderEvent extends GestureResponderEvent {
   _targetInst?: ElementInstance;
 }
@@ -71,7 +81,6 @@ interface PrivateGestureResponderEvent extends GestureResponderEvent {
  * Boundary to log breadcrumbs for interaction events.
  */
 class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
-
   public static displayName: string = '__Sentry.TouchEventBoundary';
   public static defaultProps: Partial<TouchEventBoundaryProps> = {
     breadcrumbCategory: DEFAULT_BREADCRUMB_CATEGORY,
@@ -113,18 +122,17 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
   /**
    * Logs the touch event given the component tree names and a label.
    */
-  private _logTouchEvent(
-    componentTreeNames: string[],
-    activeLabel?: string
-  ): void {
+  private _logTouchEvent(touchPath: TouchedComponentInfo[], label?: string): void {
     const level = 'info' as SeverityLevel;
+
+    const root = touchPath[0];
+    const detail = label ? label : `${root.name}${root.file ? ` (${root.file})` : ''}`;
+
     const crumb = {
       category: this.props.breadcrumbCategory,
-      data: { componentTree: componentTreeNames },
+      data: { path: touchPath },
       level: level,
-      message: activeLabel
-        ? `Touch event within element: ${activeLabel}`
-        : 'Touch event within component tree',
+      message: `Touch event within element: ${detail}`,
       type: this.props.breadcrumbType,
     };
     addBreadcrumb(crumb);
@@ -147,7 +155,7 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
     return ignoreNames.some(
       (ignoreName: string | RegExp) =>
         (typeof ignoreName === 'string' && name === ignoreName) ||
-        (ignoreName instanceof RegExp && name.match(ignoreName))
+        (ignoreName instanceof RegExp && name.match(ignoreName)),
     );
   }
 
@@ -166,64 +174,62 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
     }
 
     let currentInst: ElementInstance | undefined = e._targetInst;
-
-    let activeLabel: string | undefined;
-    let activeDisplayName: string | undefined;
-    const componentTreeNames: string[] = [];
+    const touchPath: TouchedComponentInfo[] = [];
 
     while (
       currentInst &&
       // maxComponentTreeSize will always be defined as we have a defaultProps. But ts needs a check so this is here.
       this.props.maxComponentTreeSize &&
-      componentTreeNames.length < this.props.maxComponentTreeSize
+      touchPath.length < this.props.maxComponentTreeSize
     ) {
       if (
         // If the loop gets to the boundary itself, break.
-        currentInst.elementType?.displayName ===
-        TouchEventBoundary.displayName
+        currentInst.elementType?.displayName === TouchEventBoundary.displayName
       ) {
         break;
       }
 
-      const props = currentInst.memoizedProps;
-      const labelValue =
-        typeof props?.[SENTRY_LABEL_PROP_KEY] !== 'undefined'
-          ? `${props[SENTRY_LABEL_PROP_KEY]}`
-        // For some reason type narrowing doesn't work as expected with indexing when checking it all in one go in
-        // the "check-label" if sentence, so we have to assign it to a variable here first
-          : (typeof this.props.labelName === 'string') ? props?.[this.props.labelName] : undefined;
-
-      // Check the label first
-      if (labelValue && typeof labelValue === 'string') {
-        if (this._pushIfNotIgnored(componentTreeNames, labelValue)) {
-          if (!activeLabel) {
-            activeLabel = labelValue;
-          }
-        }
-      } else if (currentInst.elementType) {
-        const { elementType } = currentInst;
-
-        // Check display name
-        if (elementType.displayName) {
-          if (this._pushIfNotIgnored(componentTreeNames, elementType.displayName)) {
-            if (!activeDisplayName) {
-              activeDisplayName = elementType.displayName;
-            }
-          }
-        }
+      const props = currentInst.memoizedProps ?? {};
+      const info: TouchedComponentInfo = {};
+      if (typeof props[SENTRY_COMPONENT_PROP_KEY] === 'string' && props[SENTRY_COMPONENT_PROP_KEY].length > 0) {
+        info.name = props[SENTRY_COMPONENT_PROP_KEY];
       }
+      if (typeof props[SENTRY_ELEMENT_PROP_KEY] === 'string' && props[SENTRY_ELEMENT_PROP_KEY].length > 0) {
+        info.element = props[SENTRY_ELEMENT_PROP_KEY];
+      }
+      if (typeof props[SENTRY_FILE_PROP_KEY] === 'string' && props[SENTRY_FILE_PROP_KEY].length > 0) {
+        info.file = props[SENTRY_FILE_PROP_KEY];
+      }
+
+      const labelValue =
+        typeof props[SENTRY_LABEL_PROP_KEY] === 'string'
+          ? props[SENTRY_LABEL_PROP_KEY]
+          : // For some reason type narrowing doesn't work as expected with indexing when checking it all in one go in
+          // the "check-label" if sentence, so we have to assign it to a variable here first
+          typeof this.props.labelName === 'string'
+          ? props[this.props.labelName]
+          : undefined;
+
+      if (typeof labelValue === 'string' && labelValue.length > 0) {
+        info.label = labelValue;
+      }
+
+      if (!info.name && currentInst.elementType?.displayName) {
+        info.name = currentInst.elementType?.displayName;
+      }
+
+      this._pushIfNotIgnored(touchPath, info);
 
       currentInst = currentInst.return;
     }
 
-    const finalLabel = activeLabel ?? activeDisplayName;
-
-    if (componentTreeNames.length > 0 || finalLabel) {
-      this._logTouchEvent(componentTreeNames, finalLabel);
+    const label = touchPath.find(info => info.label)?.label;
+    if (touchPath.length > 0) {
+      this._logTouchEvent(touchPath, label);
     }
 
     this._tracingIntegration?.startUserInteractionTransaction({
-      elementId: activeLabel,
+      elementId: label,
       op: UI_ACTION_TOUCH,
     });
   }
@@ -231,12 +237,17 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
   /**
    * Pushes the name to the componentTreeNames array if it is not ignored.
    */
-  private _pushIfNotIgnored(componentTreeNames: string[], name: string, file?: string): boolean {
-    const value = file ? `${name} (${file})` : name;
-    if (this._isNameIgnored(value)) {
+  private _pushIfNotIgnored(touchPath: TouchedComponentInfo[], value: TouchedComponentInfo): boolean {
+    if (!value.name && !value.label) {
       return false;
     }
-    componentTreeNames.push(value);
+    if (value.name && this._isNameIgnored(value.name)) {
+      return false;
+    }
+    if (value.label && this._isNameIgnored(value.label)) {
+      return false;
+    }
+    touchPath.push(value);
     return true;
   }
 }
@@ -249,9 +260,9 @@ class TouchEventBoundary extends React.Component<TouchEventBoundaryProps> {
 const withTouchEventBoundary = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   InnerComponent: React.ComponentType<any>,
-  boundaryProps?: TouchEventBoundaryProps
+  boundaryProps?: TouchEventBoundaryProps,
 ): React.FunctionComponent => {
-  const WrappedComponent: React.FunctionComponent = (props) => (
+  const WrappedComponent: React.FunctionComponent = props => (
     <TouchEventBoundary {...(boundaryProps ?? {})}>
       <InnerComponent {...props} />
     </TouchEventBoundary>

--- a/test/touchevents.test.tsx
+++ b/test/touchevents.test.tsx
@@ -238,23 +238,29 @@ describe('TouchEventBoundary._onTouchStart', () => {
             displayName: 'Text',
           },
           return: {
-            memoizedProps: {
-              'custom-sentry-label-name': 'Connect(View)',
-              'data-sentry-component': 'MyView',
-              'data-sentry-source-file': 'myview.tsx',
+            elementType: {
+              displayName: 'Text',
             },
             return: {
-              elementType: {
-                displayName: 'Styled(View)',
+              memoizedProps: {
+                'custom-sentry-label-name': 'Connect(View)',
+                'data-sentry-component': 'MyView',
+                'data-sentry-element': 'unknown', // should be ignored
+                'data-sentry-source-file': 'myview.tsx',
               },
               return: {
-                memoizedProps: {
-                  'data-sentry-component': 'Happy',
-                  'data-sentry-element': 'View',
-                  'data-sentry-source-file': 'happyview.js',
+                elementType: {
+                  displayName: 'Styled(View)',
+                },
+                return: {
+                  memoizedProps: {
+                    'data-sentry-component': 'Happy',
+                    'data-sentry-element': 'View',
+                    'data-sentry-source-file': 'happyview.js',
+                  },
                 },
               },
-            },
+            }
           },
         },
       },

--- a/test/touchevents.test.tsx
+++ b/test/touchevents.test.tsx
@@ -5,7 +5,7 @@ import * as core from '@sentry/core';
 import type { SeverityLevel } from '@sentry/types';
 
 import { TouchEventBoundary } from '../src/js/touchevents';
-import { getDefaultTestClientOptions,TestClient } from './mocks/client';
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
 
 describe('TouchEventBoundary._onTouchStart', () => {
   let addBreadcrumb: jest.SpyInstance;
@@ -101,7 +101,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
     expect(addBreadcrumb).toBeCalledWith({
       category: defaultProps.breadcrumbCategory,
       data: {
-        componentTree: ['View', 'Connect(View)', 'LABEL!'],
+        path: [{ name: 'View' }, { name: 'Connect(View)' }, { label: 'LABEL!' }],
       },
       level: 'info' as SeverityLevel,
       message: 'Touch event within element: LABEL!',
@@ -160,7 +160,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
     expect(addBreadcrumb).toBeCalledWith({
       category: defaultProps.breadcrumbCategory,
       data: {
-        componentTree: ['Styled(View2)', 'Styled(View)'],
+        path: [{ name: 'Styled(View)' }],
       },
       level: 'info' as SeverityLevel,
       message: 'Touch event within element: Styled(View)',
@@ -168,7 +168,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
     });
   });
 
-  it('maxComponentTreeSize', () => {
+  it('maxpathSize', () => {
     const { defaultProps } = TouchEventBoundary;
     const boundary = new TouchEventBoundary({
       ...defaultProps,
@@ -210,10 +210,72 @@ describe('TouchEventBoundary._onTouchStart', () => {
     expect(addBreadcrumb).toBeCalledWith({
       category: defaultProps.breadcrumbCategory,
       data: {
-        componentTree: ['Connect(View)', 'Styled(View)'],
+        path: [{ label: 'Connect(View)' }, { name: 'Styled(View)' }],
       },
       level: 'info' as SeverityLevel,
       message: 'Touch event within element: Connect(View)',
+      type: defaultProps.breadcrumbType,
+    });
+  });
+
+  // see https://docs.sentry.io/platforms/javascript/guides/react/features/component-names/
+  it('uses custom names provided by babel plugin', () => {
+    const { defaultProps } = TouchEventBoundary;
+    const boundary = new TouchEventBoundary(defaultProps);
+
+    const event = {
+      _targetInst: {
+        elementType: {
+          displayName: 'View',
+        },
+        memoizedProps: {
+          'data-sentry-component': 'Screen',
+          'data-sentry-element': 'AnimatedNativeScreen',
+          'data-sentry-source-file': 'screen.tsx',
+        },
+        return: {
+          elementType: {
+            displayName: 'Text',
+          },
+          return: {
+            memoizedProps: {
+              'custom-sentry-label-name': 'Connect(View)',
+              'data-sentry-component': 'MyView',
+              'data-sentry-source-file': 'myview.tsx',
+            },
+            return: {
+              elementType: {
+                displayName: 'Styled(View)',
+              },
+              return: {
+                memoizedProps: {
+                  'data-sentry-component': 'Happy',
+                  'data-sentry-element': 'View',
+                  'data-sentry-source-file': 'happyview.js',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // @ts-expect-error Calling private member
+    boundary._onTouchStart(event);
+
+    expect(addBreadcrumb).toBeCalledWith({
+      category: defaultProps.breadcrumbCategory,
+      data: {
+        path: [
+          { element: 'AnimatedNativeScreen', file: 'screen.tsx', name: 'Screen' },
+          { name: 'Text' },
+          { file: 'myview.tsx', name: 'MyView' },
+          { name: 'Styled(View)' },
+          { element: 'View', file: 'happyview.js', name: 'Happy' },
+        ],
+      },
+      level: 'info' as SeverityLevel,
+      message: 'Touch event within element: Screen (screen.tsx)',
       type: defaultProps.breadcrumbType,
     });
   });

--- a/test/touchevents.test.tsx
+++ b/test/touchevents.test.tsx
@@ -163,7 +163,7 @@ describe('TouchEventBoundary._onTouchStart', () => {
         componentTree: ['Styled(View2)', 'Styled(View)'],
       },
       level: 'info' as SeverityLevel,
-      message: 'Touch event within element: Styled(View2)',
+      message: 'Touch event within element: Styled(View)',
       type: defaultProps.breadcrumbType,
     });
   });

--- a/test/touchevents.test.tsx
+++ b/test/touchevents.test.tsx
@@ -238,29 +238,24 @@ describe('TouchEventBoundary._onTouchStart', () => {
             displayName: 'Text',
           },
           return: {
-            elementType: {
-              displayName: 'Text',
+            memoizedProps: {
+              'custom-sentry-label-name': 'Connect(View)',
+              'data-sentry-component': 'MyView',
+              'data-sentry-element': 'unknown', // should be ignored
+              'data-sentry-source-file': 'myview.tsx',
             },
             return: {
-              memoizedProps: {
-                'custom-sentry-label-name': 'Connect(View)',
-                'data-sentry-component': 'MyView',
-                'data-sentry-element': 'unknown', // should be ignored
-                'data-sentry-source-file': 'myview.tsx',
+              elementType: {
+                displayName: 'Styled(View)',
               },
               return: {
-                elementType: {
-                  displayName: 'Styled(View)',
-                },
-                return: {
-                  memoizedProps: {
-                    'data-sentry-component': 'Happy',
-                    'data-sentry-element': 'View',
-                    'data-sentry-source-file': 'happyview.js',
-                  },
+                memoizedProps: {
+                  'data-sentry-component': 'Happy',
+                  'data-sentry-element': 'View',
+                  'data-sentry-source-file': 'happyview.js',
                 },
               },
-            }
+            },
           },
         },
       },
@@ -282,6 +277,37 @@ describe('TouchEventBoundary._onTouchStart', () => {
       },
       level: 'info' as SeverityLevel,
       message: 'Touch event within element: Screen (screen.tsx)',
+      type: defaultProps.breadcrumbType,
+    });
+  });
+
+  it('deduplicates', () => {
+    const { defaultProps } = TouchEventBoundary;
+    const boundary = new TouchEventBoundary(defaultProps);
+
+    const event = {
+      _targetInst: {
+        elementType: {
+          displayName: 'Text',
+        },
+        return: {
+          elementType: {
+            displayName: 'Text',
+          },
+        },
+      },
+    };
+
+    // @ts-expect-error Calling private member
+    boundary._onTouchStart(event);
+
+    expect(addBreadcrumb).toBeCalledWith({
+      category: defaultProps.breadcrumbCategory,
+      data: {
+        path: [{ name: 'Text' }],
+      },
+      level: 'info' as SeverityLevel,
+      message: 'Touch event within element: Text',
       type: defaultProps.breadcrumbType,
     });
   });


### PR DESCRIPTION
- cleanup & fix touchevent ignore behaviour
- feat: support annotated components in touch events
- deduplicate subsequent items in the component tree/path

Example event: https://sentry-sdks.sentry.io/issues/5502756331/events/13026ba7f65a4eab8ec5dfd835c11888/
<img width="878" alt="image" src="https://github.com/getsentry/sentry-react-native/assets/6349682/e745ca21-5d72-406c-9677-23374418e317">


## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
