### PR TITLE
fix(sessions): `mechanism.handled:false` should crash current session

### DIFF
--- a/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -398,7 +398,7 @@ public class RNSentryModuleImpl {
         byte[] bytes = Base64.decode(rawBytes, Base64.DEFAULT);
 
         try {
-            InternalSentrySdk.captureEnvelope(bytes);
+            InternalSentrySdk.captureEnvelope(bytes, !options.hasKey("hardCrashed") || !options.getBoolean("hardCrashed"));
         } catch (Throwable e) {
             logger.log(SentryLevel.ERROR, "Error while capturing envelope");
             promise.resolve(false);

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -456,7 +456,7 @@ RCT_EXPORT_METHOD(captureEnvelope:(NSString * _Nonnull)rawBytes
     #if DEBUG
         [PrivateSentrySDKOnly captureEnvelope:envelope];
     #else
-        if ([[options objectForKey:@"store"] boolValue]) {
+        if ([[options objectForKey:@"hardCrashed"] boolValue]) {
             // Storing to disk happens asynchronously with captureEnvelope
             [PrivateSentrySDKOnly storeEnvelope:envelope];
         } else {

--- a/src/js/NativeRNSentry.ts
+++ b/src/js/NativeRNSentry.ts
@@ -13,7 +13,7 @@ export interface Spec extends TurboModule {
   captureEnvelope(
     bytes: string,
     options: {
-      store: boolean;
+      hardCrashed: boolean;
     },
   ): Promise<boolean>;
   captureScreenshot(): Promise<NativeScreenshot[] | undefined | null>;

--- a/src/js/misc.ts
+++ b/src/js/misc.ts
@@ -5,12 +5,14 @@ type EnvelopeItemPayload = EnvelopeItem[1];
 /**
  * Extracts the hard crash information from the event exceptions.
  * No exceptions or undefined handled are not hard crashes.
+ *
+ * Hard crashes are only unhandled error, not user set unhandled mechanisms.
  */
 export function isHardCrash(payload: EnvelopeItemPayload): boolean {
   const values: Exception[] =
     typeof payload !== 'string' && 'exception' in payload && payload.exception?.values ? payload.exception.values : [];
   for (const exception of values) {
-    if (!(exception.mechanism?.handled !== false)) {
+    if (exception.mechanism && exception.mechanism.handled === false && exception.mechanism.type === 'onerror') {
       return true;
     }
   }

--- a/src/js/wrapper.ts
+++ b/src/js/wrapper.ts
@@ -186,7 +186,7 @@ export const NATIVE: SentryNativeWrapper = {
       envelopeBytes = newBytes;
     }
 
-    await RNSentry.captureEnvelope(base64StringFromByteArray(envelopeBytes), { store: hardCrashed });
+    await RNSentry.captureEnvelope(base64StringFromByteArray(envelopeBytes), { hardCrashed });
   },
 
   /**

--- a/test/misc.test.ts
+++ b/test/misc.test.ts
@@ -30,6 +30,22 @@ describe('misc', () => {
         }),
       ).toBe(false);
     });
+    test('handled false outside of onerror is not a hard crash', () => {
+      expect(
+        isHardCrash({
+          exception: {
+            values: [
+              {
+                mechanism: {
+                  handled: false,
+                  type: 'test',
+                },
+              },
+            ],
+          },
+        }),
+      ).toBe(false);
+    });
     test('any handled false is a hard crash', () => {
       expect(
         isHardCrash({
@@ -39,7 +55,7 @@ describe('misc', () => {
               {
                 mechanism: {
                   handled: false,
-                  type: 'test',
+                  type: 'onerror',
                 },
               },
               {

--- a/test/wrapper.test.ts
+++ b/test/wrapper.test.ts
@@ -276,7 +276,7 @@ describe('Tests Native Wrapper', () => {
               '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
           ),
         ),
-        { store: false },
+        { hardCrashed: false },
       );
     });
     test('serializes class instances', async () => {
@@ -308,7 +308,7 @@ describe('Tests Native Wrapper', () => {
               '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
           ),
         ),
-        { store: false },
+        { hardCrashed: false },
       );
     });
     test('does not call RNSentry at all if enableNative is false', async () => {
@@ -345,7 +345,7 @@ describe('Tests Native Wrapper', () => {
               '{"event_id":"event0","message":{"message":"test"}}\n',
           ),
         ),
-        { store: false },
+        { hardCrashed: false },
       );
     });
     test('Keeps breadcrumbs on Android if mechanism.handled is true', async () => {
@@ -384,7 +384,7 @@ describe('Tests Native Wrapper', () => {
               '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
           ),
         ),
-        { store: false },
+        { hardCrashed: false },
       );
     });
     test('Keeps breadcrumbs on Android if there is no exception', async () => {
@@ -413,7 +413,7 @@ describe('Tests Native Wrapper', () => {
               '{"event_id":"event0","breadcrumbs":[{"message":"crumb!"}]}\n',
           ),
         ),
-        { store: false },
+        { hardCrashed: false },
       );
     });
     test('Keeps breadcrumbs on Android if mechanism.handled is false', async () => {
@@ -426,7 +426,7 @@ describe('Tests Native Wrapper', () => {
             {
               mechanism: {
                 handled: false,
-                type: '',
+                type: 'onerror',
               },
             },
           ],
@@ -448,11 +448,11 @@ describe('Tests Native Wrapper', () => {
         base64StringFromByteArray(
           utf8ToBytes(
             '{"event_id":"event0","sent_at":"123"}\n' +
-              '{"type":"event","content_type":"application/json","length":125}\n' +
-              '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
+              '{"type":"event","content_type":"application/json","length":132}\n' +
+              '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":"onerror"}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
           ),
         ),
-        { store: true },
+        { hardCrashed: true },
       );
     });
   });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR updates the session handling, so native SDK can correctly handle crashing, ending and creating a new session.

Session will be crashed and no new session is started if `{ handled: false, type: 'onerror' }`. Type `onerror` means the error is from the RN Global Handle => the native application is going to crash.

Session will be crashed and new session is started if `{ handled: false, type: '!onerror' }`. Other types `genetic...` and others mean the exception is not from RN Global Handled (can be user set) and the native application is not going to crash.

Session will be crashed as no new session is started for native crashed.

## 🛑  Blocked by
- [ ] https://github.com/getsentry/sentry-java/pull/3480
- [ ] https://github.com/getsentry/sentry-cocoa/pull/4073

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes https://github.com/getsentry/sentry-react-native/issues/3614

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes