### PR TITLE
ci: release iOS metrics startup test restrictions

### DIFF
--- a/test/perf/metrics-ios.yml
+++ b/test/perf/metrics-ios.yml
@@ -6,7 +6,7 @@ apps:
 
 startupTimeTest:
   runs: 50
-  diffMin: 0
+  diffMin: -20
   diffMax: 150
 
 binarySizeTest:


### PR DESCRIPTION
The startup time doesn't seem to be impacted by the SDK (is that OK or do we measure it wrong?), so it may be lower then without the SDK

#skip-changelog 
