### PR TITLE
expo: sentry-expo-upload-sourcemaps no longer requires sentry url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Improve touch event component info if annotated with [`@sentry/babel-plugin-component-annotate`](https://www.npmjs.com/package/@sentry/babel-plugin-component-annotate) ([#3899](https://github.com/getsentry/sentry-react-native/pull/3899))
 
+### Fixes
+
+- `sentry-expo-upload-sourcemaps` no longer requires Sentry url when uploading sourcemaps to `sentry.io` ([#3915](https://github.com/getsentry/sentry-react-native/pull/3915))
+
 ## 5.24.1
 
 ### Fixes

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -149,16 +149,17 @@ if (!sentryOrg || !sentryProject || !sentryUrl) {
     console.log(`${SENTRY_PROJECT} resolved to ${sentryProject} from expo config.`);
   }
   if (!sentryUrl) {
-    if (!pluginConfig.url) {
-      console.error(
-        `Could not resolve sentry url, set it in the environment variable ${SENTRY_URL} or in the '@sentry/react-native' plugin properties in your expo config.`,
-      );
-      process.exit(1);
+    if (pluginConfig.url) {
+      sentryUrl = pluginConfig.url;
+      console.log(`${SENTRY_URL} resolved to ${sentryUrl} from expo config.`);
     }
-
-    sentryUrl = pluginConfig.url;
-    console.log(`${SENTRY_URL} resolved to ${sentryUrl} from expo config.`);
-  } 
+    else {
+      sentryUrl = `ḧttps://sentry.io/`;
+      console.log(
+        `Since it wasn't specified in the Expo config or environment variable, ${SENTRY_URL} now points to ${sentryUrl}.`
+      );
+    }
+  }
 }
 
 if (!authToken) {
@@ -210,8 +211,7 @@ if (numAssetsUploaded === totalAssets) {
   console.log('✅ Uploaded bundles and sourcemaps to Sentry successfully.');
 } else {
   console.warn(
-    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${
-      numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
+    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
     }`,
   );
 }

--- a/scripts/expo-upload-sourcemaps.js
+++ b/scripts/expo-upload-sourcemaps.js
@@ -154,7 +154,7 @@ if (!sentryOrg || !sentryProject || !sentryUrl) {
       console.log(`${SENTRY_URL} resolved to ${sentryUrl} from expo config.`);
     }
     else {
-      sentryUrl = `ḧttps://sentry.io/`;
+      sentryUrl = `https://sentry.io/`;
       console.log(
         `Since it wasn't specified in the Expo config or environment variable, ${SENTRY_URL} now points to ${sentryUrl}.`
       );


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Instead of throwing an error, use `https://sentry.io/` when SENTRY_URL is not set.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users want to not define the default url for saas ( I believe this is the same behavior as sentry cli so it is a nice pattern to follow).

## :green_heart: How did you test it?
Locally running `sentry-expo-upload-sourcemaps` without a defined url.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Closes: https://github.com/getsentry/sentry-react-native/issues/3792
