### PR TITLE
feat(native): Set current screen on native scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Improve touch event component info if annotated with [`@sentry/babel-plugin-component-annotate`](https://www.npmjs.com/package/@sentry/babel-plugin-component-annotate) ([#3899](https://github.com/getsentry/sentry-react-native/pull/3899))
+- Set `currentScreen` on native scope ([#3927](https://github.com/getsentry/sentry-react-native/pull/3927))
 
 ### Fixes
 

--- a/android/src/main/java/io/sentry/react/RNSentryBreadcrumb.java
+++ b/android/src/main/java/io/sentry/react/RNSentryBreadcrumb.java
@@ -1,0 +1,84 @@
+package io.sentry.react;
+
+import com.facebook.react.bridge.ReadableMap;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+
+import io.sentry.Breadcrumb;
+import io.sentry.SentryLevel;
+
+public class RNSentryBreadcrumb {
+
+    @Nullable
+    public static String getCurrentScreenFrom(ReadableMap from) {
+        final @Nullable String maybeCategory = from.hasKey("category") ? from.getString("category") : null;
+        if (maybeCategory == null) {
+            return null;
+        }
+
+        final @Nullable ReadableMap maybeData = from.hasKey("data") ? from.getMap("data") : null;
+        if (maybeData == null) {
+            return null;
+        }
+
+        final @Nullable String maybeCurrentScreen = from.hasKey("to") ? from.getString("to") : null;
+
+        return maybeCurrentScreen;
+    }
+
+    @NotNull
+    public static Breadcrumb fromMap(ReadableMap from) {
+        final @NotNull Breadcrumb breadcrumb = new Breadcrumb();
+
+        if (from.hasKey("message")) {
+            breadcrumb.setMessage(from.getString("message"));
+        }
+
+        if (from.hasKey("type")) {
+            breadcrumb.setType(from.getString("type"));
+        }
+
+        if (from.hasKey("category")) {
+            breadcrumb.setCategory(from.getString("category"));
+        }
+
+        if (from.hasKey("level")) {
+            switch (from.getString("level")) {
+                case "fatal":
+                    breadcrumb.setLevel(SentryLevel.FATAL);
+                    break;
+                case "warning":
+                    breadcrumb.setLevel(SentryLevel.WARNING);
+                    break;
+                case "debug":
+                    breadcrumb.setLevel(SentryLevel.DEBUG);
+                    break;
+                case "error":
+                    breadcrumb.setLevel(SentryLevel.ERROR);
+                    break;
+                case "info":
+                default:
+                    breadcrumb.setLevel(SentryLevel.INFO);
+                    break;
+            }
+        }
+
+
+        if (from.hasKey("data")) {
+            final ReadableMap data = from.getMap("data");
+            for (final Map.Entry<String, Object> entry : data.toHashMap().entrySet()) {
+                final Object value = entry.getValue();
+                // data is ConcurrentHashMap and can't have null values
+                if (value != null) {
+                    breadcrumb.setData(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        return breadcrumb;
+    }
+
+}

--- a/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -551,53 +551,12 @@ public class RNSentryModuleImpl {
 
     public void addBreadcrumb(final ReadableMap breadcrumb) {
         Sentry.configureScope(scope -> {
-            Breadcrumb breadcrumbInstance = new Breadcrumb();
+            scope.addBreadcrumb(RNSentryBreadcrumb.fromMap(breadcrumb));
 
-            if (breadcrumb.hasKey("message")) {
-                breadcrumbInstance.setMessage(breadcrumb.getString("message"));
+            final @Nullable String screen = RNSentryBreadcrumb.getCurrentScreenFrom(breadcrumb);
+            if (screen != null) {
+                scope.setScreen(screen);
             }
-
-            if (breadcrumb.hasKey("type")) {
-                breadcrumbInstance.setType(breadcrumb.getString("type"));
-            }
-
-            if (breadcrumb.hasKey("category")) {
-                breadcrumbInstance.setCategory(breadcrumb.getString("category"));
-            }
-
-            if (breadcrumb.hasKey("level")) {
-                switch (breadcrumb.getString("level")) {
-                    case "fatal":
-                        breadcrumbInstance.setLevel(SentryLevel.FATAL);
-                        break;
-                    case "warning":
-                        breadcrumbInstance.setLevel(SentryLevel.WARNING);
-                        break;
-                    case "debug":
-                        breadcrumbInstance.setLevel(SentryLevel.DEBUG);
-                        break;
-                    case "error":
-                        breadcrumbInstance.setLevel(SentryLevel.ERROR);
-                        break;
-                    case "info":
-                    default:
-                        breadcrumbInstance.setLevel(SentryLevel.INFO);
-                        break;
-                }
-            }
-
-            if (breadcrumb.hasKey("data")) {
-                final ReadableMap data = breadcrumb.getMap("data");
-                for (final Map.Entry<String, Object> entry : data.toHashMap().entrySet()) {
-                    final Object value = entry.getValue();
-                    // data is ConcurrentHashMap and can't have null values
-                    if (value != null) {
-                        breadcrumbInstance.setData(entry.getKey(), entry.getValue());
-                    }
-                }
-            }
-
-            scope.addBreadcrumb(breadcrumbInstance);
         });
     }
 

--- a/ios/RNSentry.mm
+++ b/ios/RNSentry.mm
@@ -550,6 +550,13 @@ RCT_EXPORT_METHOD(addBreadcrumb:(NSDictionary *)breadcrumb)
     [SentrySDK configureScope:^(SentryScope * _Nonnull scope) {
         [scope addBreadcrumb:[RNSentryBreadcrumb from:breadcrumb]];
     }];
+
+#if SENTRY_HAS_UIKIT
+    NSString *_Nullable screen = [RNSentryBreadcrumb getCurrentScreenFrom:breadcrumb];
+    if (screen != nil) {
+        [PrivateSentrySDKOnly setCurrentScreen:screen];
+    }
+#endif //SENTRY_HAS_UIKIT
 }
 
 RCT_EXPORT_METHOD(clearBreadcrumbs) {

--- a/ios/RNSentryBreadcrumb.h
+++ b/ios/RNSentryBreadcrumb.h
@@ -1,9 +1,13 @@
 #import <Foundation/Foundation.h>
+#import <Sentry/SentryDefines.h>
+#import <Sentry/SentryScope.h>
 
 @class SentryBreadcrumb;
 
 @interface RNSentryBreadcrumb : NSObject
 
 + (SentryBreadcrumb *)from: (NSDictionary *) dict;
+
++ (NSString *_Nullable) getCurrentScreenFrom: (NSDictionary *) dict;
 
 @end

--- a/ios/RNSentryBreadcrumb.m
+++ b/ios/RNSentryBreadcrumb.m
@@ -30,4 +30,23 @@
     return crumb;
 }
 
++ (NSString *_Nullable) getCurrentScreenFrom: (NSDictionary<NSString*, id> *_Nonnull) dict {
+    NSString *_Nullable maybeCategory = [dict valueForKey:@"category"];
+    if (![maybeCategory isEqualToString:@"navigation"]) {
+        return nil;
+    }
+
+    NSDictionary<NSString*, id> *_Nullable maybeData = [dict valueForKey:@"data"];
+    if (![maybeData isKindOfClass:[NSDictionary class]]) {
+        return nil;
+    }
+
+    NSString *_Nullable maybeCurrentScreen = [maybeData valueForKey:@"to"];
+    if (![maybeCurrentScreen isKindOfClass:[NSString class]]) {
+        return nil;
+    }
+    
+    return maybeCurrentScreen;
+}
+
 @end


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature

## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds current screen on native scopes. This enables native replay integration to track the RN screens and use them them to fill the `urls.field`


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
