### PR TITLE
misc(samples): Add console anything examples for replay testing

### DIFF
--- a/samples/expo/utils/setScopeProperties.ts
+++ b/samples/expo/utils/setScopeProperties.ts
@@ -76,5 +76,12 @@ export const setScopeProperties = () => {
     category: 'TEST-CATEGORY',
   });
 
+  console.log('This is a console log message.');
+  console.info('This is a console info message.');
+  console.warn('This is a console warn message.');
+  console.error('This is a console error message.');
+  console.debug('This is a console debug message.');
+  console.trace('This is a console trace message.');
+
   console.log('Test scope properties were set.');
 };

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -32,6 +32,7 @@ import { LogBox, Platform, StyleSheet, View } from 'react-native';
 import { HttpClient } from '@sentry/integrations';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import PlaygroundScreen from './Screens/PlaygroundScreen';
+import { logWithoutTracing } from './utils';
 
 LogBox.ignoreAllLogs();
 
@@ -49,16 +50,19 @@ Sentry.init({
   debug: true,
   environment: 'dev',
   beforeSend: (event: Sentry.Event) => {
-    console.log('Event beforeSend:', event.event_id);
+    logWithoutTracing('Event beforeSend:', event.event_id);
     return event;
   },
   beforeSendTransaction(event) {
-    console.log('Transaction beforeSend:', event.event_id);
+    logWithoutTracing('Transaction beforeSend:', event.event_id);
     return event;
   },
   // This will be called with a boolean `didCallNativeInit` when the native SDK has been contacted.
   onReady: ({ didCallNativeInit }) => {
-    console.log('onReady called with didCallNativeInit:', didCallNativeInit);
+    logWithoutTracing(
+      'onReady called with didCallNativeInit:',
+      didCallNativeInit,
+    );
   },
   integrations(integrations) {
     integrations.push(

--- a/samples/react-native/src/Screens/TrackerScreen.tsx
+++ b/samples/react-native/src/Screens/TrackerScreen.tsx
@@ -69,8 +69,6 @@ const TrackerScreen = () => {
     (state === 'loaded' && 'Loaded') ||
     'Unknown';
   const shouldRecordFullDisplay = state === 'loaded' || state === 'error';
-  console.log('shouldRecordFullDisplay', shouldRecordFullDisplay);
-  console.log('statusText', statusText);
 
   return (
     <View style={styles.screen}>

--- a/samples/react-native/src/setScopeProperties.ts
+++ b/samples/react-native/src/setScopeProperties.ts
@@ -76,5 +76,12 @@ export const setScopeProperties = () => {
     category: 'TEST-CATEGORY',
   });
 
+  console.log('This is a console log message.');
+  console.info('This is a console info message.');
+  console.warn('This is a console warn message.');
+  console.error('This is a console error message.');
+  console.debug('This is a console debug message.');
+  console.trace('This is a console trace message.');
+
   console.log('Test scope properties were set.');
 };

--- a/samples/react-native/src/utils.ts
+++ b/samples/react-native/src/utils.ts
@@ -1,0 +1,7 @@
+export function logWithoutTracing(...args: unknown[]) {
+  if ('__sentry_original__' in console.log) {
+    console.log.__sentry_original__(...args);
+  } else {
+    console.log(...args);
+  }
+}


### PR DESCRIPTION
Adds console.anything example for testing mobile replay.

![Screenshot 2024-07-02 at 13 29 12](https://github.com/getsentry/sentry-react-native/assets/31292499/5ae47d65-a6a8-4e80-8934-1bc13cace3ee)

#skip-changelog 

[example link](https://sentry-sdks.sentry.io/replays/b09b1f5148ab4c5aabe94204e64d056a/?project=5428561&query=&referrer=%2Freplays%2F&statsPeriod=30d&t_main=console&yAxis=count%28%29)