### PR TITLE
fix(replay): Add app lifecycle breadcrumbs conversion tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   module.exports = withSentryConfig(getDefaultConfig(__dirname), { annotateReactComponents: true });
   ```
 
+### Fixes
+
+- Add `app.foreground/background` breadcrumbs to iOS Replays ([#3932](https://github.com/getsentry/sentry-react-native/pull/3932))
+
 ## 5.25.0-alpha.2
 
 ### Features

--- a/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReplayBreadcrumbConverterTest.kt
+++ b/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReplayBreadcrumbConverterTest.kt
@@ -2,6 +2,7 @@ package io.sentry.rnsentryandroidtester
 
 import io.sentry.Breadcrumb
 import io.sentry.react.RNSentryReplayBreadcrumbConverter
+import io.sentry.rrweb.RRWebBreadcrumbEvent
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -9,6 +10,30 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class RNSentryReplayBreadcrumbConverterTest {
+
+    @Test
+    fun testConvertForegroundBreadcrumb() {
+        val converter = RNSentryReplayBreadcrumbConverter()
+        val testBreadcrumb = Breadcrumb()
+        testBreadcrumb.type = "navigation"
+        testBreadcrumb.category = "app.lifecycle"
+        testBreadcrumb.setData("state", "foreground");
+        val actual = converter.convert(testBreadcrumb) as RRWebBreadcrumbEvent
+
+        assertEquals("app.foreground", actual.category)
+    }
+
+    @Test
+    fun testConvertBackgroundBreadcrumb() {
+        val converter = RNSentryReplayBreadcrumbConverter()
+        val testBreadcrumb = Breadcrumb()
+        testBreadcrumb.type = "navigation"
+        testBreadcrumb.category = "app.lifecycle"
+        testBreadcrumb.setData("state", "background");
+        val actual = converter.convert(testBreadcrumb) as RRWebBreadcrumbEvent
+
+        assertEquals("app.background", actual.category)
+    }
 
     @Test
     fun doesNotConvertSentryEventBreadcrumb() {

--- a/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayBreadcrumbConverterTests.swift
+++ b/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayBreadcrumbConverterTests.swift
@@ -2,6 +2,34 @@ import XCTest
 
 final class RNSentryReplayBreadcrumbConverterTests: XCTestCase {
 
+    func testConvertForegroundBreadcrumb() {
+        let converter = RNSentryReplayBreadcrumbConverter()
+        let testBreadcrumb = Breadcrumb()
+        testBreadcrumb.type = "navigation"
+        testBreadcrumb.category = "app.lifecycle"
+        testBreadcrumb.data = ["state": "foreground"]
+        let actual = converter.convert(from: testBreadcrumb)
+
+        XCTAssertNotNil(actual)
+        let data = actual!.serialize()["data"] as! [String: Any?];
+        let payload = data["payload"] as! [String: Any?];
+        XCTAssertEqual(payload["category"] as! String, "app.foreground")
+    }
+
+    func testConvertBackgroundBreadcrumb() {
+        let converter = RNSentryReplayBreadcrumbConverter()
+        let testBreadcrumb = Breadcrumb()
+        testBreadcrumb.type = "navigation"
+        testBreadcrumb.category = "app.lifecycle"
+        testBreadcrumb.data = ["state": "background"]
+        let actual = converter.convert(from: testBreadcrumb)
+
+        XCTAssertNotNil(actual)
+        let data = actual!.serialize()["data"] as! [String: Any?];
+        let payload = data["payload"] as! [String: Any?];
+        XCTAssertEqual(payload["category"] as! String, "app.background")
+    }
+
     func testNotConvertSentryEventBreadcrumb() {
         let converter = RNSentryReplayBreadcrumbConverter()
         let testBreadcrumb = Breadcrumb()

--- a/android/src/main/java/io/sentry/react/RNSentryReplayBreadcrumbConverter.java
+++ b/android/src/main/java/io/sentry/react/RNSentryReplayBreadcrumbConverter.java
@@ -29,6 +29,10 @@ public final class RNSentryReplayBreadcrumbConverter extends DefaultReplayBreadc
       breadcrumb.getCategory().equals("sentry.transaction")) {
       return null;
     }
+    if (breadcrumb.getCategory().equals("http")) {
+      // Drop native http breadcrumbs to avoid duplicates
+      return null;
+    }
 
     if (breadcrumb.getCategory().equals("touch")) {
       return convertTouchBreadcrumb(breadcrumb);
@@ -41,10 +45,6 @@ public final class RNSentryReplayBreadcrumbConverter extends DefaultReplayBreadc
     }
     if (breadcrumb.getCategory().equals("xhr")) {
       return convertNetworkBreadcrumb(breadcrumb);
-    }
-    if (breadcrumb.getCategory().equals("http")) {
-      // Drop native http breadcrumbs to avoid duplicates
-      return null;
     }
 
     RRWebEvent nativeBreadcrumb = super.convert(breadcrumb);

--- a/ios/RNSentryReplayBreadcrumbConverter.m
+++ b/ios/RNSentryReplayBreadcrumbConverter.m
@@ -25,13 +25,9 @@
     // Do not add Sentry Event breadcrumbs to replay
     return nil;
   }
-  
+
   if ([breadcrumb.category isEqualToString:@"http"]) {
     // Drop native network breadcrumbs to avoid duplicates
-    return nil;
-  }
-  if ([breadcrumb.type isEqualToString:@"navigation"] && ![breadcrumb.category isEqualToString:@"navigation"]) {
-    // Drop native navigation breadcrumbs to avoid duplicates
     return nil;
   }
 
@@ -71,7 +67,7 @@
   if (breadcrumb.data == nil) {
     return nil;
   }
-  
+
   NSMutableArray *path = [breadcrumb.data valueForKey:@"path"];
   NSString* message = [RNSentryReplayBreadcrumbConverter getTouchPathMessageFrom:path];
 
@@ -87,7 +83,7 @@
   if (path == nil) {
     return nil;
   }
-  
+
   NSInteger pathCount = [path count];
   if (pathCount <= 0) {
     return nil;
@@ -129,7 +125,7 @@
       [message appendString:@" > "];
     }
   }
-  
+
   return message;
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR add tests for foreground and background breadcrumbs conversion.

This PR fixes missing these breadcrumbs on iOS.

This PR does not fix missing app foreground breadcrumbs which are dropped by iOS replay segments.

## :green_heart: How did you test it?
unit tests, sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
