### PR TITLE
fix(replay): Add missing properties to android nav breadcrumbs

### DIFF
--- a/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReplayBreadcrumbConverterTest.kt
+++ b/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReplayBreadcrumbConverterTest.kt
@@ -1,8 +1,10 @@
 package io.sentry.rnsentryandroidtester
 
 import io.sentry.Breadcrumb
+import io.sentry.SentryLevel
 import io.sentry.react.RNSentryReplayBreadcrumbConverter
 import io.sentry.rrweb.RRWebBreadcrumbEvent
+import io.sentry.rrweb.RRWebEventType
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,7 +14,42 @@ import org.junit.runners.JUnit4
 class RNSentryReplayBreadcrumbConverterTest {
 
     @Test
-    fun testConvertForegroundBreadcrumb() {
+    fun convertNavigationBreadcrumb() {
+        val converter = RNSentryReplayBreadcrumbConverter()
+        val testBreadcrumb = Breadcrumb()
+        testBreadcrumb.level = SentryLevel.INFO
+        testBreadcrumb.type = "navigation"
+        testBreadcrumb.category = "navigation"
+        testBreadcrumb.setData("from", "HomeScreen")
+        testBreadcrumb.setData("to", "ProfileScreen")
+        val actual = converter.convert(testBreadcrumb) as RRWebBreadcrumbEvent
+
+        assertRRWebBreadcrumbDefaults(actual)
+        assertEquals(SentryLevel.INFO, actual.level)
+        assertEquals("navigation", actual.category)
+        assertEquals("HomeScreen", actual.data?.get("from"))
+        assertEquals("ProfileScreen", actual.data?.get("to"))
+    }
+
+    @Test
+    fun convertNavigationBreadcrumbWithOnlyTo() {
+        val converter = RNSentryReplayBreadcrumbConverter()
+        val testBreadcrumb = Breadcrumb()
+        testBreadcrumb.level = SentryLevel.INFO
+        testBreadcrumb.type = "navigation"
+        testBreadcrumb.category = "navigation"
+        testBreadcrumb.setData("to", "ProfileScreen")
+        val actual = converter.convert(testBreadcrumb) as RRWebBreadcrumbEvent
+
+        assertRRWebBreadcrumbDefaults(actual)
+        assertEquals(SentryLevel.INFO, actual.level)
+        assertEquals("navigation", actual.category)
+        assertEquals(null, actual.data?.get("from"))
+        assertEquals("ProfileScreen", actual.data?.get("to"))
+    }
+
+    @Test
+    fun convertForegroundBreadcrumb() {
         val converter = RNSentryReplayBreadcrumbConverter()
         val testBreadcrumb = Breadcrumb()
         testBreadcrumb.type = "navigation"
@@ -20,11 +57,12 @@ class RNSentryReplayBreadcrumbConverterTest {
         testBreadcrumb.setData("state", "foreground");
         val actual = converter.convert(testBreadcrumb) as RRWebBreadcrumbEvent
 
+        assertRRWebBreadcrumbDefaults(actual)
         assertEquals("app.foreground", actual.category)
     }
 
     @Test
-    fun testConvertBackgroundBreadcrumb() {
+    fun convertBackgroundBreadcrumb() {
         val converter = RNSentryReplayBreadcrumbConverter()
         val testBreadcrumb = Breadcrumb()
         testBreadcrumb.type = "navigation"
@@ -32,6 +70,7 @@ class RNSentryReplayBreadcrumbConverterTest {
         testBreadcrumb.setData("state", "background");
         val actual = converter.convert(testBreadcrumb) as RRWebBreadcrumbEvent
 
+        assertRRWebBreadcrumbDefaults(actual)
         assertEquals("app.background", actual.category)
     }
 
@@ -51,6 +90,32 @@ class RNSentryReplayBreadcrumbConverterTest {
         testBreadcrumb.category = "sentry.transaction"
         val actual = converter.convert(testBreadcrumb)
         assertEquals(null, actual)
+    }
+
+    @Test
+    fun convertTouchBreadcrumb() {
+        val converter = RNSentryReplayBreadcrumbConverter()
+        val testBreadcrumb = Breadcrumb()
+        testBreadcrumb.level = SentryLevel.INFO
+        testBreadcrumb.type = "user"
+        testBreadcrumb.category = "touch"
+        testBreadcrumb.message = "this won't be used for replay"
+        testBreadcrumb.setData(
+            "path",
+            arrayListOf(mapOf(
+                "element" to "element4",
+                "file" to "file4")))
+        val actual = converter.convert(testBreadcrumb) as RRWebBreadcrumbEvent
+
+        assertRRWebBreadcrumbDefaults(actual)
+        assertEquals(SentryLevel.INFO, actual.level)
+        assertEquals("ui.tap", actual.category)
+        assertEquals(1, actual.data?.keys?.size)
+        assertEquals(
+            arrayListOf(mapOf(
+                "element" to "element4",
+                "file" to "file4")),
+            actual.data?.get("path"))
     }
 
     @Test
@@ -95,5 +160,11 @@ class RNSentryReplayBreadcrumbConverterTest {
             mapOf("label" to "label6"),
             mapOf("name" to "name7")))
         assertEquals("label5(element5, file5) > label4(file4) > label3(element3) > label2", actual)
+    }
+
+    private fun assertRRWebBreadcrumbDefaults(actual: RRWebBreadcrumbEvent) {
+        assertEquals("default", actual.breadcrumbType)
+        assertEquals(actual.breadcrumbTimestamp * 1000, actual.timestamp.toDouble(), 0.05)
+        assert(actual.breadcrumbTimestamp > 0)
     }
 }

--- a/android/src/main/java/io/sentry/react/RNSentryReplayBreadcrumbConverter.java
+++ b/android/src/main/java/io/sentry/react/RNSentryReplayBreadcrumbConverter.java
@@ -38,10 +38,7 @@ public final class RNSentryReplayBreadcrumbConverter extends DefaultReplayBreadc
       return convertTouchBreadcrumb(breadcrumb);
     }
     if (breadcrumb.getCategory().equals("navigation")) {
-      final RRWebBreadcrumbEvent rrWebBreadcrumb = new RRWebBreadcrumbEvent();
-      rrWebBreadcrumb.setCategory(breadcrumb.getCategory());
-      rrWebBreadcrumb.setData(breadcrumb.getData());
-      return rrWebBreadcrumb;
+      return convertNavigationBreadcrumb(breadcrumb);
     }
     if (breadcrumb.getCategory().equals("xhr")) {
       return convertNetworkBreadcrumb(breadcrumb);
@@ -61,6 +58,14 @@ public final class RNSentryReplayBreadcrumbConverter extends DefaultReplayBreadc
   }
 
   @TestOnly
+  public @NotNull RRWebEvent convertNavigationBreadcrumb(final @NotNull Breadcrumb breadcrumb) {
+    final RRWebBreadcrumbEvent rrWebBreadcrumb = new RRWebBreadcrumbEvent();
+    rrWebBreadcrumb.setCategory(breadcrumb.getCategory());
+    setRRWebEventDefaultsFrom(rrWebBreadcrumb, breadcrumb);
+    return rrWebBreadcrumb;
+  }
+
+  @TestOnly
   public @NotNull RRWebEvent convertTouchBreadcrumb(final @NotNull Breadcrumb breadcrumb) {
     final RRWebBreadcrumbEvent rrWebBreadcrumb = new RRWebBreadcrumbEvent();
 
@@ -69,11 +74,7 @@ public final class RNSentryReplayBreadcrumbConverter extends DefaultReplayBreadc
       rrWebBreadcrumb.setMessage(RNSentryReplayBreadcrumbConverter
               .getTouchPathMessage(breadcrumb.getData("path")));
 
-    rrWebBreadcrumb.setLevel(breadcrumb.getLevel());
-    rrWebBreadcrumb.setData(breadcrumb.getData());
-    rrWebBreadcrumb.setTimestamp(breadcrumb.getTimestamp().getTime());
-    rrWebBreadcrumb.setBreadcrumbTimestamp(breadcrumb.getTimestamp().getTime() / 1000.0);
-    rrWebBreadcrumb.setBreadcrumbType("default");
+    setRRWebEventDefaultsFrom(rrWebBreadcrumb, breadcrumb);
     return rrWebBreadcrumb;
   }
 
@@ -174,5 +175,13 @@ public final class RNSentryReplayBreadcrumbConverter extends DefaultReplayBreadc
     rrWebSpanEvent.setDescription(url);
     rrWebSpanEvent.setData(data);
     return rrWebSpanEvent;
+  }
+
+  private void setRRWebEventDefaultsFrom(final @NotNull RRWebBreadcrumbEvent rrWebBreadcrumb, final @NotNull Breadcrumb breadcrumb) {
+    rrWebBreadcrumb.setLevel(breadcrumb.getLevel());
+    rrWebBreadcrumb.setData(breadcrumb.getData());
+    rrWebBreadcrumb.setTimestamp(breadcrumb.getTimestamp().getTime());
+    rrWebBreadcrumb.setBreadcrumbTimestamp(breadcrumb.getTimestamp().getTime() / 1000.0);
+    rrWebBreadcrumb.setBreadcrumbType("default");
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes missing properties on nav breadcrumbs on RN Android.

Introduced in https://github.com/getsentry/sentry-react-native/pull/3912

This PR adds test for Android and iOS to prevent this in the future.

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 