### PR TITLE
misc(replay): Add Mobile Replay Public Beta changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.26.0-alpha.3
+## Unreleased
 
 ### Features
 
@@ -60,6 +60,37 @@
   ```
 
   To learn more visit [Sentry's Mobile Session Replay](https://docs.sentry.io/product/explore/session-replay/) documentation page.
+
+### Dependencies
+
+- Bump Android SDK from v7.11.0-alpha.2 to v7.12.0-alpha.4 ([#3830](https://github.com/getsentry/sentry-react-native/pull/3830))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/7.12.0-alpha.3/CHANGELOG.md#7120-alpha4)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.11.0-alpha.2...7.12.0-alpha.4)
+- Bump Cocoa SDK from v8.30.0 to v8.30.1 ([#3936](https://github.com/getsentry/sentry-react-native/pull/3936))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8301)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.30.0...8.30.1)
+
+## 5.26.0-alpha.3
+
+### Features
+
+- Redact `react-native-svg` SVGs when `maskAllVectors` ([#3930](https://github.com/getsentry/sentry-react-native/pull/3930))
+- Add `annotateReactComponents` option to `@sentry/react-native/metro` ([#3916](https://github.com/getsentry/sentry-react-native/pull/3916))
+
+  ```js
+  // For Expo
+  const { getSentryExpoConfig } = require("@sentry/react-native/metro");
+  const config = getSentryExpoConfig(__dirname, { annotateReactComponents: true });
+
+  // For RN
+  const { getDefaultConfig } = require('@react-native/metro-config');
+  const { withSentryConfig } = require('@sentry/react-native/metro');
+  module.exports = withSentryConfig(getDefaultConfig(__dirname), { annotateReactComponents: true });
+  ```
+
+### Fixes
+
+- Add `app.foreground/background` breadcrumbs to iOS Replays ([#3932](https://github.com/getsentry/sentry-react-native/pull/3932))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,29 @@
 
 ### Features
 
-- Redact `react-native-svg` SVGs when `maskAllVectors` ([#3930](https://github.com/getsentry/sentry-react-native/pull/3930))
-- Add `annotateReactComponents` option to `@sentry/react-native/metro` ([#3916](https://github.com/getsentry/sentry-react-native/pull/3916))
+- Session Replay Public Beta ([#3830](https://github.com/getsentry/sentry-react-native/pull/3830))
+
+  To enable Replay use the `replaysSessionSampleRate` or `replaysOnErrorSampleRate` options.
+
+  ```js
+  import * as Sentry from '@sentry/react-native';
+
+  Sentry.init({
+    _experiments: {
+      replaysSessionSampleRate: 1.0,
+      replaysOnErrorSampleRate: 1.0,
+    },
+    integrations: [
+      Sentry.mobileReplayIntegration({
+        maskAllImages: true,
+        maskAllVectors: true,
+        maskAllText: true,
+      }),
+    ],
+  });
+  ```
+
+  To add React Component Names use `annotateReactComponents` in `metro.config.js`.
 
   ```js
   // For Expo
@@ -18,9 +39,27 @@
   module.exports = withSentryConfig(getDefaultConfig(__dirname), { annotateReactComponents: true });
   ```
 
-### Fixes
+  To change default redaction behavior add the `mobileReplayIntegration`.
 
-- Add `app.foreground/background` breadcrumbs to iOS Replays ([#3932](https://github.com/getsentry/sentry-react-native/pull/3932))
+  ```js
+  import * as Sentry from '@sentry/react-native';
+
+  Sentry.init({
+    _experiments: {
+      replaysSessionSampleRate: 1.0,
+      replaysOnErrorSampleRate: 1.0,
+    },
+    integrations: [
+      Sentry.mobileReplayIntegration({
+        maskAllImages: true,
+        maskAllVectors: true,
+        maskAllText: true,
+      }),
+    ],
+  });
+  ```
+
+  To learn more visit [Sentry's Mobile Session Replay](https://docs.sentry.io/product/explore/session-replay/) documentation page.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,6 @@
       replaysSessionSampleRate: 1.0,
       replaysOnErrorSampleRate: 1.0,
     },
-    integrations: [
-      Sentry.mobileReplayIntegration({
-        maskAllImages: true,
-        maskAllVectors: true,
-        maskAllText: true,
-      }),
-    ],
   });
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
   });
   ```
 
-  To learn more visit [Sentry's Mobile Session Replay](https://docs.sentry.io/product/explore/session-replay/) documentation page.
+  To learn more visit [Sentry's Mobile Session Replay](https://docs.sentry.io/product/explore/session-replay/mobile/) documentation page.
 
 ### Dependencies
 


### PR DESCRIPTION
This PR add the mobile replay public beta changelog.

#skip-changelog 

### [Rendered Changelog](https://github.com/getsentry/sentry-react-native/blob/kw/add-public-replay-changelog/CHANGELOG.md#features)