### PR TITLE
misc(sample): Add manual init options to the sample rn app

### DIFF
--- a/samples/react-native/android/app/src/main/java/io/sentry/reactnative/sample/MainApplication.kt
+++ b/samples/react-native/android/app/src/main/java/io/sentry/reactnative/sample/MainApplication.kt
@@ -11,6 +11,12 @@ import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.flipper.ReactNativeFlipper
 import com.facebook.soloader.SoLoader
+import io.sentry.Hint
+import io.sentry.SentryEvent
+import io.sentry.SentryLevel
+import io.sentry.SentryOptions.BeforeSendCallback
+import io.sentry.android.core.SentryAndroid
+
 
 class MainApplication() : Application(), ReactApplication {
     override val reactNativeHost: ReactNativeHost =
@@ -32,11 +38,37 @@ class MainApplication() : Application(), ReactApplication {
 
     override fun onCreate() {
         super.onCreate()
+        // When the native init is enabled the `autoInitializeNativeSdk`
+        // in JS has to be set to `false`
+        // this.initializeSentry()
         SoLoader.init(this, false)
         if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
             // If you opted-in for the New Architecture, we load the native entry point for this app.
             load()
         }
         ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
+    }
+
+    private fun initializeSentry() {
+        SentryAndroid.init(this) { options ->
+            options.dsn = "https://1df17bd4e543fdb31351dee1768bb679@o447951.ingest.sentry.io/5428561"
+            options.isDebug = true
+
+            options.beforeSend = BeforeSendCallback { event: SentryEvent, hint: Hint? ->
+                // React native internally throws a JavascriptException
+                // Since we catch it before that, we don't want to send this one
+                // because we would send it twice
+                try {
+                    val ex = event.exceptions!![0]
+                    if (null != ex && ex.type!!.contains("JavascriptException")) {
+                        return@BeforeSendCallback null
+                    }
+                } catch (ignored: Throwable) {
+                    // We do nothing
+                }
+
+                event
+            }
+        }
     }
 }

--- a/samples/react-native/android/app/src/main/java/io/sentry/reactnative/sample/MainApplication.kt
+++ b/samples/react-native/android/app/src/main/java/io/sentry/reactnative/sample/MainApplication.kt
@@ -51,6 +51,8 @@ class MainApplication() : Application(), ReactApplication {
 
     private fun initializeSentry() {
         SentryAndroid.init(this) { options ->
+            // Only options set here will apply to the Android SDK
+            // Options from JS are not passed to the Android SDK when initialized manually
             options.dsn = "https://1df17bd4e543fdb31351dee1768bb679@o447951.ingest.sentry.io/5428561"
             options.isDebug = true
 

--- a/samples/react-native/ios/sentryreactnativesample/AppDelegate.mm
+++ b/samples/react-native/ios/sentryreactnativesample/AppDelegate.mm
@@ -19,6 +19,8 @@
 - (void) initializeSentry
 {
   [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    // Only options set here will apply to the iOS SDK
+    // Options from JS are not passed to the iOS SDK when initialized manually
     options.dsn = @"https://1df17bd4e543fdb31351dee1768bb679@o447951.ingest.sentry.io/5428561";
     options.debug = YES; // Enabled debug when first installing is always helpful
 

--- a/samples/react-native/ios/sentryreactnativesample/AppDelegate.mm
+++ b/samples/react-native/ios/sentryreactnativesample/AppDelegate.mm
@@ -8,13 +8,48 @@
 #import <NativeSampleModule.h>
 #endif
 
+#import <Sentry/Sentry.h>
+#import <Sentry/PrivateSentrySDKOnly.h>
+
 @interface AppDelegate () <RCTTurboModuleManagerDelegate> {}
 @end
 
 @implementation AppDelegate
 
+- (void) initializeSentry
+{
+  [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+    options.dsn = @"https://1df17bd4e543fdb31351dee1768bb679@o447951.ingest.sentry.io/5428561";
+    options.debug = YES; // Enabled debug when first installing is always helpful
+
+    options.beforeSend = ^SentryEvent*(SentryEvent *event) {
+      // We don't want to send an event after startup that came from a Unhandled JS Exception of react native
+      // Because we sent it already before the app crashed.
+      if (nil != event.exceptions.firstObject.type &&
+          [event.exceptions.firstObject.type rangeOfString:@"Unhandled JS Exception"].location != NSNotFound) {
+        NSLog(@"Unhandled JS Exception");
+        return nil;
+      }
+
+      return event;
+    };
+
+    // Enable the App start and Frames tracking measurements
+    // If this is disabled the app start and frames tracking
+    // won't be passed from native to JS transactions
+    PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true;
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+    PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = true;
+#endif
+  }];
+}
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  // When the native init is enabled the `autoInitializeNativeSdk`
+  // in JS has to be set to `false`
+  // [self initializeSentry];
+
   self.moduleName = @"sentry-react-native-sample";
   // You can add your custom initial props in the dictionary below.
   // They will be passed down to the ViewController used by React

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -104,6 +104,8 @@ Sentry.init({
     profilesSampleRate: 1.0,
   },
   enableSpotlight: true,
+  // This should be disabled when manually initializing the native SDK
+  autoInitializeNativeSdk: true,
 });
 
 const Stack = isMobileOs

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -105,6 +105,7 @@ Sentry.init({
   },
   enableSpotlight: true,
   // This should be disabled when manually initializing the native SDK
+  // Note that options from JS are not passed to the native SDKs when initialized manually
   autoInitializeNativeSdk: true,
 });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds an example of how to setup React Native SDK with manually initializing the native Android and iOS SDKs. 

## :green_heart: How did you test it?
sample app

[Example](https://sentry-sdks.sentry.io/issues/5105068805/events/35feb7bc06a947f38f77f85b8564c0f1/?project=5428561) JS Error from the manual init

[Example](https://sentry-sdks.sentry.io/issues/5249385673/events/3ff4c8f502ac4eb5989ce3ef9b67378d/?project=5428561) Android crash from the manual init

[Example](https://sentry-sdks.sentry.io/issues/5598917176/events/ba8c40e77e0547ad815bf03565bdef74/?project=5428561) iOS crash from the manual init

[Example](https://sentry-sdks.sentry.io/performance/trace/db583c30f23b473bb20edbb451812fe2) iOS Transaction from the manual init

<img width="962" alt="Screenshot 2024-07-12 at 16 24 45" src="https://github.com/user-attachments/assets/6973937d-0456-44e3-b92a-08e239e6d22c">

[Example](https://sentry-sdks.sentry.io/performance/trace/7167096b54614c159a32a7e5ae782884) Android Transaction from the manual init

<img width="973" alt="Screenshot 2024-07-12 at 17 05 38" src="https://github.com/user-attachments/assets/cf96d2cd-4f3b-449e-8e55-50e71fbf7f30">

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog 