### PR TITLE
fix: use full path to metro

### DIFF
--- a/samples/react-native/metro.config.js
+++ b/samples/react-native/metro.config.js
@@ -2,7 +2,8 @@ const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 const path = require('path');
 const blacklist = require('metro-config/src/defaults/exclusionList');
 
-const { withSentryConfig } = require('../../metro');
+const { withSentryConfig } = require('@sentry/react-native/metro');
+
 const parentDir = path.resolve(__dirname, '../..');
 
 /**


### PR DESCRIPTION
## :scroll: Description
Sample code cleanup. Use a full path (instead of a relative path) for
```js
const { withSentryConfig } = require('@sentry/react-native/metro');
```
## :bulb: Motivation and Context
Matches what is in your [docs](https://docs.sentry.io/platforms/react-native/manual-setup/metro/).

#skip-changelog