### PR TITLE
fix(client): Keep captureMessage stack trace in exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- `Sentry.captureMessage` stack trace is in `event.exception` (moved from `event.threads`) ([#3635](https://github.com/getsentry/sentry-react-native/pull/3635), [#3988](https://github.com/getsentry/sentry-react-native/pull/3988))
+  - To revert to the old behavior (causing the stack to be unsymbolicated) use `useThreadsForMessageStack` option
+
 ## 5.27.0
 
 ### Fixes
@@ -7,8 +14,6 @@
 - Pass `sampleRate` option to the Android SDK ([#3979](https://github.com/getsentry/sentry-react-native/pull/3979))
 - Drop app start data older than one minute ([#3974](https://github.com/getsentry/sentry-react-native/pull/3974))
 - Use `Platform.constants.reactNativeVersion` instead of `react-native` internal export ([#3949](https://github.com/getsentry/sentry-react-native/pull/3949))
-- `Sentry.captureMessage` stack trace is in `event.exception` (moved from `event.threads`) ([#3635](https://github.com/getsentry/sentry-react-native/pull/3635), [#3988](https://github.com/getsentry/sentry-react-native/pull/3988))
-  - To revert to the old behavior (causing the stack to be unsymbolicated) use `useThreadsForMessageStack` option
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Pass `sampleRate` option to the Android SDK ([#3979](https://github.com/getsentry/sentry-react-native/pull/3979))
 - Drop app start data older than one minute ([#3974](https://github.com/getsentry/sentry-react-native/pull/3974))
 - Use `Platform.constants.reactNativeVersion` instead of `react-native` internal export ([#3949](https://github.com/getsentry/sentry-react-native/pull/3949))
+- `Sentry.captureMessage` stack trace is in `event.exception` (moved from `event.threads`) ([#3635](https://github.com/getsentry/sentry-react-native/pull/3635), [#3988](https://github.com/getsentry/sentry-react-native/pull/3988))
+  - To revert to the old behavior (causing the stack to be unsymbolicated) use `useThreadsForMessageStack` option
 
 ### Dependencies
 

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -6,10 +6,8 @@ import type {
   Envelope,
   Event,
   EventHint,
-  Exception,
   Outcome,
   SeverityLevel,
-  Thread,
   UserFeedback,
 } from '@sentry/types';
 import { dateTimestampInSeconds, logger, SentryError } from '@sentry/utils';
@@ -59,22 +57,7 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
    * @inheritDoc
    */
   public eventFromMessage(message: string, level?: SeverityLevel, hint?: EventHint): PromiseLike<Event> {
-    return eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace).then(
-      (event: Event) => {
-        // TMP! Remove this function once JS SDK uses threads for messages
-        if (!event.exception?.values || event.exception.values.length <= 0) {
-          return event;
-        }
-        const values = event.exception.values.map(
-          (exception: Exception): Thread => ({
-            stacktrace: exception.stacktrace,
-          }),
-        );
-        (event as { threads?: { values: Thread[] } }).threads = { values };
-        delete event.exception;
-        return event;
-      },
-    );
+    return eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace);
   }
 
   /**

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -6,8 +6,10 @@ import type {
   Envelope,
   Event,
   EventHint,
+  Exception,
   Outcome,
   SeverityLevel,
+  Thread,
   UserFeedback,
 } from '@sentry/types';
 import { dateTimestampInSeconds, logger, SentryError } from '@sentry/utils';
@@ -57,6 +59,25 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
    * @inheritDoc
    */
   public eventFromMessage(message: string, level?: SeverityLevel, hint?: EventHint): PromiseLike<Event> {
+    if (this._options.useThreadsForMessageStack) {
+      return eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace).then(
+        (event: Event) => {
+          // TMP! Remove this function once JS SDK uses threads for messages
+          if (!event.exception?.values || event.exception.values.length <= 0) {
+            return event;
+          }
+          const values = event.exception.values.map(
+            (exception: Exception): Thread => ({
+              stacktrace: exception.stacktrace,
+            }),
+          );
+          (event as { threads?: { values: Thread[] } }).threads = { values };
+          delete event.exception;
+          return event;
+        },
+      );
+    }
+
     return eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace);
   }
 

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -213,6 +213,14 @@ export interface BaseReactNativeOptions {
      */
     replaysOnErrorSampleRate?: number;
   };
+
+  /**
+   * This options changes the placement of the attached stacktrace of `captureMessage` in the event.
+   *
+   * @default false
+   * @deprecated This option will be removed in the next major version. Use `beforeSend` instead.
+   */
+  useThreadsForMessageStack?: boolean;
 }
 
 export interface ReactNativeTransportOptions extends BrowserTransportOptions {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -368,11 +368,12 @@ describe('Tests ReactNativeClient', () => {
     const getMessageEventFrom = (func: jest.Mock) =>
       func.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload];
 
-    test('captureMessage contains stack trace in threads', async () => {
+    test('captureMessage contains stack trace in exception', async () => {
       const mockSyntheticExceptionFromHub = new Error();
       client.captureMessage('test message', 'error', { syntheticException: mockSyntheticExceptionFromHub });
-      expect(getMessageEventFrom(mockTransportSend).threads.values.length).toBeGreaterThan(0);
-      expect(getMessageEventFrom(mockTransportSend).exception).toBeUndefined();
+      expect(getMessageEventFrom(mockTransportSend).exception.values.length).toBeGreaterThan(0);
+      expect(getMessageEventFrom(mockTransportSend).exception).toBeDefined();
+      expect(getMessageEventFrom(mockTransportSend).threads).toBeUndefined();
     });
   });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -349,16 +349,6 @@ describe('Tests ReactNativeClient', () => {
 
     beforeEach(() => {
       mockTransportSend = jest.fn(() => Promise.resolve());
-      client = new ReactNativeClient({
-        ...DEFAULT_OPTIONS,
-        attachStacktrace: true,
-        stackParser: defaultStackParser,
-        dsn: EXAMPLE_DSN,
-        transport: () => ({
-          send: mockTransportSend,
-          flush: jest.fn(),
-        }),
-      } as ReactNativeClientOptions);
     });
 
     afterEach(() => {
@@ -369,11 +359,41 @@ describe('Tests ReactNativeClient', () => {
       func.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload];
 
     test('captureMessage contains stack trace in exception', async () => {
+      client = new ReactNativeClient({
+        ...DEFAULT_OPTIONS,
+        attachStacktrace: true,
+        stackParser: defaultStackParser,
+        dsn: EXAMPLE_DSN,
+        transport: () => ({
+          send: mockTransportSend,
+          flush: jest.fn(),
+        }),
+      } as ReactNativeClientOptions);
+
       const mockSyntheticExceptionFromHub = new Error();
       client.captureMessage('test message', 'error', { syntheticException: mockSyntheticExceptionFromHub });
       expect(getMessageEventFrom(mockTransportSend).exception.values.length).toBeGreaterThan(0);
       expect(getMessageEventFrom(mockTransportSend).exception).toBeDefined();
       expect(getMessageEventFrom(mockTransportSend).threads).toBeUndefined();
+    });
+
+    test('captureMessage contains stack trace in exception', async () => {
+      client = new ReactNativeClient({
+        ...DEFAULT_OPTIONS,
+        attachStacktrace: true,
+        stackParser: defaultStackParser,
+        dsn: EXAMPLE_DSN,
+        transport: () => ({
+          send: mockTransportSend,
+          flush: jest.fn(),
+        }),
+        useThreadsForMessageStack: true,
+      } as ReactNativeClientOptions);
+
+      const mockSyntheticExceptionFromHub = new Error();
+      client.captureMessage('test message', 'error', { syntheticException: mockSyntheticExceptionFromHub });
+      expect(getMessageEventFrom(mockTransportSend).threads.values.length).toBeGreaterThan(0);
+      expect(getMessageEventFrom(mockTransportSend).exception).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
- This PR backports https://github.com/getsentry/sentry-react-native/pull/3635 from prepared RN SDK v6 to v5.
- As this change is technically breaking for code using `threads` I added `useThreadsForMessageStack` which enables the old behavior.
- We should release this as non breaking fix, because `threads` are breaking symbolication for `captureMessage` and we are seeing large amount of reports.

- fixes https://github.com/getsentry/sentry-react-native/issues/3963
- fixes https://github.com/getsentry/sentry-react-native/issues/3967
- fixes https://github.com/getsentry/sentry-react-native/issues/3097

- [Example event ](https://sentry-sdks.sentry.io/issues/5678391709/events/a73290cc74bb4124a0507b6bad01ce17/)

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes