### PR TITLE
fix(tests): Android native connected tests were failing due to missing disk space

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -86,36 +86,6 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-aosp-atd-30
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@77986be26589807b8ebab3fde7bbf5c60dabec32 #pin@v2.31.0
-        with:
-          api-level: 30
-          force-avd-creation: false
-          disable-animations: true
-          disable-spellchecker: true
-          target: 'aosp_atd'
-          channel: canary # Necessary for ATDs
-          emulator-options: >
-            -no-window
-            -no-snapshot-save
-            -gpu swiftshader_indirect
-            -noaudio
-            -no-boot-anim
-            -camera-back none
-            -camera-front none
-            -timezone US/Pacific
-          script: echo "Generated AVD snapshot for caching."
-
       - name: Run connected tests
         uses: reactivecircus/android-emulator-runner@77986be26589807b8ebab3fde7bbf5c60dabec32 #pin@v2.31.0
         with:


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes the CI Android Native Tests failures. The AVD cache was too large and there was not enough space to runt the device. Since we are using `aosp` device optimalized for automatized test, we might drop the cache now.

The error: 
```
  /usr/bin/sh -c \printf 'hw.cpu.ncore=2
  ' >> /home/runner/.android/avd/test.avd/config.ini
  Starting emulator.
  /usr/bin/sh -c \/usr/local/lib/android/sdk/emulator/emulator -avd test -no-window -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -camera-front none -timezone US/Pacific &
  INFO    | Storing crashdata in: /tmp/android-runner/emu-crash-35.2.4.db, detection is enabled for process: 2631
  INFO    | Android emulator version 35.2.4.0 (build_id 12141100) (CL:N/A)
  INFO    | Graphics backend: gfxstream
  INFO    | Found systemPath /usr/local/lib/android/sdk/system-images/android-30/aosp_atd/x86/
  WARNING | Please update the emulator to one that supports the feature(s): Vulkan
  ERROR   | Not enough disk space to run AVD 'test'. Exiting...
  INFO    | Storing crashdata in: /tmp/android-runner/emu-crash-35.2.4.db, detection is enabled for process: 2631
  INFO    | Duplicate loglines will be removed, if you wish to see each individual line launch with the -log-nofilter flag.
  INFO    | Increasing RAM size to 2048MB
  /usr/local/lib/android/sdk/platform-tools/adb shell getprop sys.boot_completed
  * daemon not running; starting now at tcp:5037
  * daemon started successfully
  adb: no devices/emulators found
```

## :green_heart: How did you test it?
ci

#skip-changelog 