### PR TITLE
fix(breadcrumbs): Crash when passing array as data to `addBreadcrumb`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix crash when passing array as data to `Sentry.addBreadcrumb({ data: [] })` ([#4021](https://github.com/getsentry/sentry-react-native/pull/4021))
+  - The expected `data` type is plain JS object, otherwise the data might be lost.
+
 ## 5.28.0
 
 ### Fixes

--- a/src/js/utils/normalize.ts
+++ b/src/js/utils/normalize.ts
@@ -8,12 +8,17 @@ const KEY = 'value';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function convertToNormalizedObject(data: unknown): Record<string, any> {
   const normalized: unknown = normalize(data);
-  if (normalized === null || typeof normalized !== 'object') {
+  if (
+    normalized !== null &&
+    typeof normalized === 'object' &&
+    !Array.isArray(normalized) &&
+    normalized.constructor === Object
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return normalized as Record<string, any>;
+  } else {
     return {
       [KEY]: normalized,
     };
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return normalized as Record<string, any>;
   }
 }

--- a/test/utils/normalize.test.ts
+++ b/test/utils/normalize.test.ts
@@ -21,5 +21,18 @@ describe('normalize', () => {
       const actualResult = convertToNormalizedObject(null);
       expect(actualResult).toEqual({ value: null });
     });
+
+    test('converts array to an object', () => {
+      const actualResult = convertToNormalizedObject([]);
+      expect(actualResult).toEqual({ value: [] });
+    });
+
+    test('converts custom class to an object', () => {
+      class TestClass {
+        test: string = 'foo';
+      }
+      const actualResult = convertToNormalizedObject(new TestClass());
+      expect(actualResult).toEqual({ test: 'foo' });
+    });
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
The expected `data` type is plain JS object, otherwise the data might be lost.

fixes: https://github.com/getsentry/sentry-react-native/issues/4013

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
