### PR TITLE
ref: Change native frames from `traceId` to `spanId` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.29.0
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@
   - Fixes possible missing TTID measurements and spans
 - Fix crash when passing array as data to `Sentry.addBreadcrumb({ data: [] })` ([#4021](https://github.com/getsentry/sentry-react-native/pull/4021))
   - The expected `data` type is plain JS object, otherwise the data might be lost.
-- Fix requireNativeComponent missing in react-native-web #3823 ([#3958](https://github.com/getsentry/sentry-react-native/pull/3958))
+- Fix `requireNativeComponent` missing in `react-native-web` ([#3958](https://github.com/getsentry/sentry-react-native/pull/3958))
 
 ### Dependencies
 
 - Bump JavaScript SDK from v7.117.0 to v7.118.0 ([#4018](https://github.com/getsentry/sentry-react-native/pull/4018))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/v7/CHANGELOG.md#71180)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/7.117.0...7.118.0)
+- Bump Android SDK from v7.13.0 to v7.14.0 ([#4022](https://github.com/getsentry/sentry-react-native/pull/4022))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7140)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.13.0...7.14.0)
 
 ## 5.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Add `spotlight` option ([#4023](https://github.com/getsentry/sentry-react-native/pull/4023))
+  - Deprecating `enableSpotlight` and `spotlightSidecarUrl`
+
 ## 5.29.0
 
 ### Features

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:7.13.0'
+    api 'io.sentry:sentry-android:7.14.0'
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/react-native",
   "homepage": "https://github.com/getsentry/sentry-react-native",
   "repository": "https://github.com/getsentry/sentry-react-native",
-  "version": "5.28.0",
+  "version": "5.29.0",
   "description": "Official Sentry SDK for react-native",
   "typings": "dist/js/index.d.ts",
   "types": "dist/js/index.d.ts",

--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -4,7 +4,7 @@
     "slug": "sentry-react-native-expo-sample",
     "jsEngine": "hermes",
     "scheme": "sentry-expo-sample",
-    "version": "5.28.0",
+    "version": "5.29.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "io.sentry.expo.sample",
-      "buildNumber": "16"
+      "buildNumber": "17"
     },
     "android": {
       "adaptiveIcon": {
@@ -27,7 +27,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "io.sentry.expo.sample",
-      "versionCode": 16
+      "versionCode": 17
     },
     "web": {
       "bundler": "metro",

--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -84,7 +84,7 @@ process.env.EXPO_SKIP_DURING_EXPORT !== 'true' && Sentry.init({
     // replaysOnErrorSampleRate: 1.0,
     replaysSessionSampleRate: 1.0,
   },
-  enableSpotlight: true,
+  spotlight: true,
 });
 
 function RootLayout() {

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-react-native-expo-sample",
-  "version": "5.28.0",
+  "version": "5.29.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/samples/react-native/android/app/build.gradle
+++ b/samples/react-native/android/app/build.gradle
@@ -134,8 +134,8 @@ android {
         applicationId "io.sentry.reactnative.sample"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 19
-        versionName "5.28.0"
+        versionCode 20
+        versionName "5.29.0"
     }
 
     signingConfigs {

--- a/samples/react-native/ios/sentryreactnativesample/Info.plist
+++ b/samples/react-native/ios/sentryreactnativesample/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.28.0</string>
+	<string>5.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>24</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>

--- a/samples/react-native/ios/sentryreactnativesampleTests/Info.plist
+++ b/samples/react-native/ios/sentryreactnativesampleTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.28.0</string>
+	<string>5.29.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>23</string>
+	<string>24</string>
 </dict>
 </plist>

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-react-native-sample",
-  "version": "5.28.0",
+  "version": "5.29.0",
   "private": true,
   "scripts": {
     "postinstall": "patch-package",

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -123,7 +123,7 @@ Sentry.init({
     // replaysSessionSampleRate: 1.0,
     replaysOnErrorSampleRate: 1.0,
   },
-  enableSpotlight: true,
+  spotlight: true,
   // This should be disabled when manually initializing the native SDK
   // Note that options from JS are not passed to the native SDKs when initialized manually
   autoInitializeNativeSdk: true,

--- a/src/js/integrations/default.ts
+++ b/src/js/integrations/default.ts
@@ -108,12 +108,9 @@ export function getDefaultIntegrations(options: ReactNativeClientOptions): Integ
     integrations.push(expoContextIntegration());
   }
 
-  if (options.enableSpotlight) {
-    integrations.push(
-      spotlightIntegration({
-        sidecarUrl: options.spotlightSidecarUrl,
-      }),
-    );
+  if (options.spotlight || options.enableSpotlight) {
+    const sidecarUrl = (typeof options.spotlight === 'string' && options.spotlight) || options.spotlightSidecarUrl;
+    integrations.push(spotlightIntegration({ sidecarUrl }));
   }
 
   if (

--- a/src/js/options.ts
+++ b/src/js/options.ts
@@ -166,6 +166,8 @@ export interface BaseReactNativeOptions {
    * More details: https://spotlightjs.com/
    *
    * IMPORTANT: Only set this option to `true` while developing, not in production!
+   *
+   * @deprecated Use `spotlight` instead.
    */
   enableSpotlight?: boolean;
 
@@ -178,8 +180,22 @@ export interface BaseReactNativeOptions {
    * More details: https://spotlightjs.com/
    *
    * @default "http://localhost:8969/stream"
+   *
+   * @deprecated Use `spotlight` instead.
    */
   spotlightSidecarUrl?: string;
+
+  /**
+   * If you use Spotlight by Sentry during development, use
+   * this option to forward captured Sentry events to Spotlight.
+   *
+   * Either set it to true, or provide a specific Spotlight Sidecar URL.
+   *
+   * More details: https://spotlightjs.com/
+   *
+   * IMPORTANT: Only set this option to `true` while developing, not in production!
+   */
+  spotlight?: boolean | string;
 
   /**
    * Sets a callback which is executed before capturing screenshots. Only

--- a/src/js/version.ts
+++ b/src/js/version.ts
@@ -1,3 +1,3 @@
 export const SDK_PACKAGE_NAME = 'npm:@sentry/react-native';
 export const SDK_NAME = 'sentry.javascript.react-native';
-export const SDK_VERSION = '5.28.0';
+export const SDK_VERSION = '5.29.0';

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -432,9 +432,29 @@ describe('Tests the SDK functionality', () => {
       expect(actualIntegrations).toEqual(expect.not.arrayContaining([expect.objectContaining({ name: 'Spotlight' })]));
     });
 
-    it('adds spotlight integration', () => {
+    it('adds spotlight integration with enableSpotlight', () => {
       init({
         enableSpotlight: true,
+      });
+
+      const actualOptions = usedOptions();
+      const actualIntegrations = actualOptions?.integrations;
+      expect(actualIntegrations).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'Spotlight' })]));
+    });
+
+    it('adds spotlight integration with spotlight bool', () => {
+      init({
+        spotlight: true,
+      });
+
+      const actualOptions = usedOptions();
+      const actualIntegrations = actualOptions?.integrations;
+      expect(actualIntegrations).toEqual(expect.arrayContaining([expect.objectContaining({ name: 'Spotlight' })]));
+    });
+
+    it('adds spotlight integration with direct url', () => {
+      init({
+        spotlight: 'http://localhost:8969/stream',
       });
 
       const actualOptions = usedOptions();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR changes the native frames from attaching to `traceId` which can be the same for multiple spans to `spanId`. 

- This fixes potencial situations when multiple root spans share the same trace id. This is possible since JS v8, before Transaction (now Root Spans) would always have unique trace id. 
- This is needed for attaching the native frames as span level measurements. 

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
