### PR TITLE
Use `install_modules_dependencies` for React iOS dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use `install_modules_dependencies` for React iOS dependencies ([#4040](https://github.com/getsentry/sentry-react-native/pull/4040))
+
 ## 5.30.0
 
 ### Features

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -32,17 +32,32 @@ Pod::Spec.new do |s|
 
   s.preserve_paths = '*.js'
 
-  s.dependency 'Sentry/HybridSDK', '8.34.0'
-
   s.source_files = 'ios/**/*.{h,m,mm}'
   s.public_header_files = 'ios/RNSentry.h'
 
   s.compiler_flags = other_cflags
 
+  s.dependency 'Sentry/HybridSDK', '8.34.0'
+
   if defined? install_modules_dependencies
-     install_modules_dependencies(s)
-   else
-     s.dependency 'React-Core'
+    # Default React Native dependencies for 0.71 and above (new and legacy architecture)
+    install_modules_dependencies(s)
+  else
+    s.dependency 'React-Core'
+
+    if is_new_arch_enabled then
+      # New Architecture on React Native 0.70 and older
+      s.pod_target_xcconfig = {
+          "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
+          "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
+      }
+
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    end
   end
 
   if is_using_hermes then

--- a/RNSentry.podspec
+++ b/RNSentry.podspec
@@ -32,25 +32,17 @@ Pod::Spec.new do |s|
 
   s.preserve_paths = '*.js'
 
-  s.dependency 'React-Core'
   s.dependency 'Sentry/HybridSDK', '8.34.0'
 
   s.source_files = 'ios/**/*.{h,m,mm}'
   s.public_header_files = 'ios/RNSentry.h'
 
   s.compiler_flags = other_cflags
-  # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
-  if is_new_arch_enabled then
-    s.pod_target_xcconfig = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
 
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+  if defined? install_modules_dependencies
+     install_modules_dependencies(s)
+   else
+     s.dependency 'React-Core'
   end
 
   if is_using_hermes then


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Fixes https://github.com/getsentry/sentry-react-native/issues/4035

## :bulb: Motivation and Context

`install_modules_dependencies` helper have been [available since 0.71](https://reactnative.dev/blog/2023/01/12/version-071#new-architecture) that determines what react dependencies to add depending on new arch flags etc. This is preferred and would make sure it's forwards and backwards compatible. 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
