### PR TITLE
fix(replay): Mask RCTParagraphComponentView when maskAllText enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Use `install_modules_dependencies` for React iOS dependencies ([#4040](https://github.com/getsentry/sentry-react-native/pull/4040))
+- `Replay.maskAllText` masks `RCTParagraphComponentView` ([#4048](https://github.com/getsentry/sentry-react-native/pull/4048))
 
 ### Dependencies
 

--- a/ios/RNSentryReplay.m
+++ b/ios/RNSentryReplay.m
@@ -57,6 +57,10 @@
     if (maybeRCTTextClass != nil) {
       [classesToRedact addObject:maybeRCTTextClass];
     }
+    Class _Nullable maybeRCTParagraphComponentViewClass = NSClassFromString(@"RCTParagraphComponentView");
+    if (maybeRCTParagraphComponentViewClass != nil) {
+        [classesToRedact addObject:maybeRCTParagraphComponentViewClass];
+    }
   }
   [PrivateSentrySDKOnly addReplayRedactClasses:classesToRedact];
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds missing RN text class to array of redacted text classes.

<img width="1625" alt="Screenshot 2024-08-26 at 18 10 54" src="https://github.com/user-attachments/assets/6ca217d7-c086-4521-ae51-4cfa47619f62">

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
