### PR TITLE
misc(gitignore): Add new monorepo setup gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,8 +73,18 @@ wheelhouse
 yalc.lock
 
 # E2E tests
+/dev-packages/e2e-tests/react-native-versions
 test/react-native/versions
 node_modules.bak
 
 # Created by Sentry Metro Plugin
 .sentry/
+
+# Yarn
+.yarn/*
+!.yarn/releases
+!.yarn/plugins
+.pnp.*
+
+# Sentry React Native Monorepo
+/packages/core/README.md


### PR DESCRIPTION
This PR adds path from the new monorepo setup to gitignore to make switching between the branches easier.

- https://github.com/getsentry/sentry-react-native/pull/4057

#skip-changelog 