### PR TITLE
feat: `tracePropagationTargets` to all targets on mobile and same origin on the web 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+- `tracePropagationTargets` defaults to all targets on mobile and same origin on the web ([#4083](https://github.com/getsentry/sentry-react-native/pull/4083))
 - Move `_experiments.profilesSampleRate` to `profilesSampleRate` root options object [#3851](https://github.com/getsentry/sentry-react-native/pull/3851))
 - Add Android Logger when new frame event is not emitted ([#4081](https://github.com/getsentry/sentry-react-native/pull/4081))
 - React Native Tracing Deprecations ([#4073](https://github.com/getsentry/sentry-react-native/pull/4073))

--- a/packages/core/src/js/tracing/reactnativetracing.ts
+++ b/packages/core/src/js/tracing/reactnativetracing.ts
@@ -3,6 +3,7 @@ import { instrumentOutgoingRequests } from '@sentry/browser';
 import { getClient } from '@sentry/core';
 import type { Client, Event, Integration, StartSpanOptions } from '@sentry/types';
 
+import { isWeb } from '../utils/environment';
 import { addDefaultOpForSpanFrom, defaultIdleOptions } from './span';
 
 export const INTEGRATION_NAME = 'ReactNativeTracing';
@@ -60,7 +61,12 @@ export interface ReactNativeTracingOptions {
   shouldCreateSpanForRequest?(this: void, url: string): boolean;
 }
 
-const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\/(?!\/)/];
+function getDefaultTracePropagationTargets(): RegExp[] | undefined {
+  if (isWeb()) {
+    return undefined;
+  }
+  return [/.*/];
+}
 
 export const defaultReactNativeTracingOptions: ReactNativeTracingOptions = {
   traceFetch: true,
@@ -98,7 +104,7 @@ export const reactNativeTracingIntegration = (
       traceFetch: finalOptions.traceFetch,
       traceXHR: finalOptions.traceXHR,
       shouldCreateSpanForRequest: finalOptions.shouldCreateSpanForRequest,
-      tracePropagationTargets: client.getOptions().tracePropagationTargets || DEFAULT_TRACE_PROPAGATION_TARGETS,
+      tracePropagationTargets: client.getOptions().tracePropagationTargets || getDefaultTracePropagationTargets(),
     });
   };
 

--- a/packages/core/src/js/utils/environment.ts
+++ b/packages/core/src/js/utils/environment.ts
@@ -53,6 +53,11 @@ export function getExpoSdkVersion(): string | undefined {
   return expoSdkVersion;
 }
 
+/** Checks if the current platform is web */
+export function isWeb(): boolean {
+  return Platform.OS === 'web';
+}
+
 /** Checks if the current platform is not web */
 export function notWeb(): boolean {
   return Platform.OS !== 'web';


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature
- [x] Enhancement


## :scroll: Description
<!--- Describe your changes in detail -->
Matches `tracePropagationTargets` with the rest of mobile SDKs and JS v8 web defaults.

We can switch to all targets on mobiles, as RN doesn't check CORS headers.

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
