### PR TITLE
feat: Add `parentSpanIsAlwaysRootSpan` is `true` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+- Set `parentSpanIsAlwaysRootSpan` to `true` to make parent of network requests predictable ([#4084](https://github.com/getsentry/sentry-react-native/pull/4084))
 - Move `_experiments.profilesSampleRate` to `profilesSampleRate` root options object [#3851](https://github.com/getsentry/sentry-react-native/pull/3851))
 - Add Android Logger when new frame event is not emitted ([#4081](https://github.com/getsentry/sentry-react-native/pull/4081))
 - React Native Tracing Deprecations ([#4073](https://github.com/getsentry/sentry-react-native/pull/4073))

--- a/packages/core/src/js/client.ts
+++ b/packages/core/src/js/client.ts
@@ -40,6 +40,9 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
     ignoreRequireCycleLogs();
     options._metadata = options._metadata || {};
     options._metadata.sdk = options._metadata.sdk || defaultSdkInfo;
+    // We default this to true, as it is the safer scenario
+    options.parentSpanIsAlwaysRootSpan =
+      options.parentSpanIsAlwaysRootSpan === undefined ? true : options.parentSpanIsAlwaysRootSpan;
     super(options);
 
     this._outcomesBuffer = [];

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -356,6 +356,25 @@ describe('Tests ReactNativeClient', () => {
     });
   });
 
+  describe('parentSpanIsAlwaysRootSpan', () => {
+    it('default is true', () => {
+      const client = new ReactNativeClient({
+        ...DEFAULT_OPTIONS,
+        dsn: EXAMPLE_DSN,
+      });
+      expect(client.getOptions().parentSpanIsAlwaysRootSpan).toBe(true);
+    });
+
+    it('can be set to false', () => {
+      const client = new ReactNativeClient({
+        ...DEFAULT_OPTIONS,
+        dsn: EXAMPLE_DSN,
+        parentSpanIsAlwaysRootSpan: false,
+      });
+      expect(client.getOptions().parentSpanIsAlwaysRootSpan).toBe(false);
+    });
+  });
+
   describe('envelopeHeader SdkInfo', () => {
     let mockTransportSend: jest.Mock;
     let client: ReactNativeClient;

--- a/packages/core/test/trace.test.ts
+++ b/packages/core/test/trace.test.ts
@@ -1,0 +1,47 @@
+import { setCurrentClient, spanToJSON, startSpan } from '@sentry/core';
+
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
+
+describe('parentSpanIsAlwaysRootSpan', () => {
+  let client: TestClient;
+
+  it('creates a span as child of root span if parentSpanIsAlwaysRootSpan=true', () => {
+    const options = getDefaultTestClientOptions({
+      tracesSampleRate: 1,
+      parentSpanIsAlwaysRootSpan: true,
+    });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    startSpan({ name: 'parent span' }, span => {
+      expect(spanToJSON(span).parent_span_id).toBe(undefined);
+      startSpan({ name: 'child span' }, childSpan => {
+        expect(spanToJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
+        startSpan({ name: 'grand child span' }, grandChildSpan => {
+          expect(spanToJSON(grandChildSpan).parent_span_id).toBe(span.spanContext().spanId);
+        });
+      });
+    });
+  });
+
+  it('does not creates a span as child of root span if parentSpanIsAlwaysRootSpan=false', () => {
+    const options = getDefaultTestClientOptions({
+      tracesSampleRate: 1,
+      parentSpanIsAlwaysRootSpan: false,
+    });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+
+    startSpan({ name: 'parent span' }, span => {
+      expect(spanToJSON(span).parent_span_id).toBe(undefined);
+      startSpan({ name: 'child span' }, childSpan => {
+        expect(spanToJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
+        startSpan({ name: 'grand child span' }, grandChildSpan => {
+          expect(spanToJSON(grandChildSpan).parent_span_id).toBe(childSpan.spanContext().spanId);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
Add `parentSpanIsAlwaysRootSpan` default `true` to align with JS v8 browser client.

https://github.com/getsentry/sentry-javascript/blob/d265d927ee87d5c50fdebc62da926ddea3c95912/packages/browser/src/client.ts#L57

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
