### PR TITLE
misc: Remove deprecated Spotlight options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+- Remove deprecated `enableSpotlight` and `spotlightSidecarUrl` ([#4086](https://github.com/getsentry/sentry-react-native/pull/4086))
 - `tracePropagationTargets` defaults to all targets on mobile and same origin on the web ([#4083](https://github.com/getsentry/sentry-react-native/pull/4083))
 - Move `_experiments.profilesSampleRate` to `profilesSampleRate` root options object [#3851](https://github.com/getsentry/sentry-react-native/pull/3851))
 - Add Android Logger when new frame event is not emitted ([#4081](https://github.com/getsentry/sentry-react-native/pull/4081))

--- a/packages/core/src/js/integrations/default.ts
+++ b/packages/core/src/js/integrations/default.ts
@@ -127,8 +127,8 @@ export function getDefaultIntegrations(options: ReactNativeClientOptions): Integ
     integrations.push(expoContextIntegration());
   }
 
-  if (options.spotlight || options.enableSpotlight) {
-    const sidecarUrl = (typeof options.spotlight === 'string' && options.spotlight) || options.spotlightSidecarUrl;
+  if (options.spotlight) {
+    const sidecarUrl = typeof options.spotlight === 'string' ? options.spotlight : undefined;
     integrations.push(spotlightIntegration({ sidecarUrl }));
   }
 

--- a/packages/core/src/js/options.ts
+++ b/packages/core/src/js/options.ts
@@ -165,31 +165,6 @@ export interface BaseReactNativeOptions {
   enableCaptureFailedRequests?: boolean;
 
   /**
-   * This option will enable forwarding captured Sentry events to Spotlight.
-   *
-   * More details: https://spotlightjs.com/
-   *
-   * IMPORTANT: Only set this option to `true` while developing, not in production!
-   *
-   * @deprecated Use `spotlight` instead.
-   */
-  enableSpotlight?: boolean;
-
-  /**
-   * This option changes the default Spotlight Sidecar URL.
-   *
-   * By default, the SDK expects the Sidecar to be running
-   * on the same host as React Native Metro Dev Server.
-   *
-   * More details: https://spotlightjs.com/
-   *
-   * @default "http://localhost:8969/stream"
-   *
-   * @deprecated Use `spotlight` instead.
-   */
-  spotlightSidecarUrl?: string;
-
-  /**
    * If you use Spotlight by Sentry during development, use
    * this option to forward captured Sentry events to Spotlight.
    *

--- a/packages/core/test/sdk.test.ts
+++ b/packages/core/test/sdk.test.ts
@@ -404,14 +404,6 @@ describe('Tests the SDK functionality', () => {
       expectNotIntegration('Spotlight');
     });
 
-    it('adds spotlight integration with enableSpotlight', () => {
-      init({
-        enableSpotlight: true,
-      });
-
-      expectIntegration('Spotlight');
-    });
-
     it('no app start integration by default', () => {
       init({});
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Clean up deprecated options.
 please link to the issue here. -->

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [ ] No breaking changes

