### PR TITLE
Fixes run samples scripts for iOS and Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "lerna run test",
     "fix": "lerna run fix",
     "lint": "lerna run lint",
-    "run-ios": "run-s cd samples/react-native yarn react-native run-ios",
-    "run-android": "run-s cd samples/react-native yarn react-native run-android",
+    "run-ios": "cd samples/react-native && yarn react-native run-ios",
+    "run-android": "cd samples/react-native && yarn react-native run-android",
     "set-version-samples": "lerna run set-version"
   },
   "devDependencies": {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This changes the `run-ios` and `run-android` scripts to use sequential commands instead of `run-s`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've run into the following error while trying to run the samples on `v6`
```
$ yarn run-ios
ERROR: Task not found: "cd", samples/react-native", yarn", react-native"
$ yarn run-android
ERROR: Task not found: "cd", samples/react-native", yarn", react-native"
```

## :green_heart: How did you test it?
Run the following commands from `sentry-react-native` project root:
```
yarn run-ios
yarn run-android
```

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog
