### PR TITLE
chore: Add action to warn about potentially risky PR changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,4 +1,19 @@
 # This is used by the action https://github.com/dorny/paths-filter
 
 high_risk_code: &high_risk_code
-  - '.github/file-filters.yml'
+  # React Native Interface
+  - 'src/js/vendor/react-native/index.ts'
+  - 'src/js/utils/rnlibraries.ts'
+  - 'src/js/utils/rnlibrariesinterface.ts'
+
+  # Touch Integration
+  - 'src/js/touchevents.tsx'
+  
+  # Sentry Native Interface
+  - 'src/js/NativeRNSentry.ts'
+
+  # Source Maps and Native Debug Files Autoupload
+  - 'scripts/sentry-xcode.sh'
+  - 'scripts/sentry-xcode-debug-files.sh'
+  - 'sentry.gradle'
+  

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,4 @@
+# This is used by the action https://github.com/dorny/paths-filter
+
+high_risk_code: &high_risk_code
+  - '.github/file-filters.yml'

--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -1,0 +1,49 @@
+name: Changes In High Risk Code
+on:
+  pull_request:
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  files-changed:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      high_risk_code: ${{ steps.changes.outputs.high_risk_code }}
+      high_risk_code_files: ${{ steps.changes.outputs.high_risk_code_files }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+          # Enable listing of files matching each filter.
+          # Paths to files will be available in `${FILTER_NAME}_files` output variable.
+          list-files: csv
+
+  validate-high-risk-code:
+    if: needs.files-changed.outputs.high_risk_code == 'true'
+    needs: files-changed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on PR to notify of changes in high risk files
+        uses: actions/github-script@v7
+        env:
+          high_risk_code: ${{ needs.files-changed.outputs.high_risk_code_files }}
+        with:
+          script: |
+            const highRiskFiles = process.env.high_risk_code;
+            const fileList = highRiskFiles.split(',').map(file => `- [ ] ${file}`).join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### 🚨 Detected changes in high risk code 🚨 \n High-risk code has higher potential to break the SDK and may be hard to test. To prevent severe bugs, apply the rollout process for releasing such changes and be extra careful when changing and reviewing these files:\n ${fileList}`
+            })


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Internal

## :scroll: Description
<!--- Describe your changes in detail -->
Implement a mechanism that automatically adds an "alert" comment to PRs if they include changes to files we think have higher potential to break things than others.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
same as https://github.com/getsentry/sentry-java/pull/3726 and https://github.com/getsentry/sentry-dart/pull/2315

## :green_heart: How did you test it?
✅ by adding the file-filter.yml introduced in this PR to the list of potentially risky changes and ensuring that an alert is shown
![Screenshot 2024-09-30 at 17 25 14](https://github.com/user-attachments/assets/811dd87c-e115-4c68-8f5a-090f568c101f)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] ~I added tests to verify changes~
- [ ] ~No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled~
- [ ] ~All tests passing~
- [ ] ~No breaking changes~

## :crystal_ball: Next steps


#skip-changelog