### PR TITLE
Misc: CONTRIBUTING: Moves the Optional section above the macOS section for consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,21 +91,6 @@ yarn react-native run-ios --mode=Release
 yarn react-native run-android --mode=Release
 ```
 
-### Optional
-
-You can optionally start the Metro bundler if you want to control where it runs:
-
-```sh
-yarn start --reset-cache
-```
-
-Run the emulators:
-
-```sh
-yarn react-native run-ios
-yarn react-native run-android
-```
-
 ## Running the macOS sample
 
 Head to the macOS sample root directory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,26 +91,6 @@ yarn react-native run-ios --mode=Release
 yarn react-native run-android --mode=Release
 ```
 
-## Running the macOS sample
-
-Head to the macOS sample root directory:
-
-```sh
-cd samples/react-native-macos/
-yarn
-bundle install
-yarn pod-install-legacy
-```
-
-You can now build and run the project from command line:
-```sh
-yarn react-native run-macos
-```
-
-or by openning the `samples/react-native-macos/macos/sentry-react-native-sample.xcworkspace`.
-
-_Note that the new architecture is not supported for the macOS sample at this point._
-
 ### Optional
 
 You can optionally start the Metro bundler if you want to control where it runs:
@@ -125,6 +105,27 @@ Run the emulators:
 yarn react-native run-ios
 yarn react-native run-android
 ```
+
+## Running the macOS sample
+
+Head to the macOS sample root directory:
+
+```sh
+cd samples/react-native-macos/
+yarn
+bundle install
+yarn pod-install-legacy
+yarn start
+```
+
+You can now build and run the project from command line:
+```sh
+yarn react-native run-macos
+```
+
+or by openning the `samples/react-native-macos/macos/sentry-react-native-sample.xcworkspace`.
+
+_Note that the new architecture is not supported for the macOS sample at this point._
 
 ## Develop with sentry-cocoa
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Moves the Optional section above the macOS section for consistency in the CONTRIBUTING doc `v6`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The macOS section was merged in the middle of the `Running the sample` section (see below). This PR fixes the structure moving the optional section above.
![Screenshot 2024-10-02 at 2 25 34 PM](https://github.com/user-attachments/assets/f1b5c080-3239-4e13-b6a1-23ec99fbe2c8)


## :green_heart: How did you test it?
Checked the doc

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog