### PR TITLE
fix: Remove unused `spanName` from `TimeToDisplayProps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Emits Bridge log only in debug mode ([#4145](https://github.com/getsentry/sentry-react-native/pull/4145))
+- Remove unused `spanName` from `TimeToDisplayProps` ([#4150](https://github.com/getsentry/sentry-react-native/pull/4150))
 
 ### Dependencies
 

--- a/src/js/tracing/timetodisplay.tsx
+++ b/src/js/tracing/timetodisplay.tsx
@@ -21,7 +21,6 @@ const fullDisplayBeforeInitialDisplay = new WeakMap<Span, true>();
 
 export type TimeToDisplayProps = {
   children?: React.ReactNode;
-  spanName?: string;
   record?: boolean;
 };
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This prop was never used and we are not planning adding such a functionality.

Span name can be change by using methods  `startTimeToFullDisplaySpan` and `startTimeToInitialDisplaySpan`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/getsentry/sentry-react-native/issues/4108

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [ ] No breaking changes - Technically it's a breaking change in the interface but this prop was never implemented and so no one could ever use it.