### PR TITLE
misc: Add easy enabled splits and flavors in RN Android samples

### DIFF
--- a/samples/react-native/android/app/build.gradle
+++ b/samples/react-native/android/app/build.gradle
@@ -146,6 +146,39 @@ android {
             keyPassword 'android'
         }
     }
+
+    if (System.getenv('SENTRY_SAMPLE_ENABLE_ABI_SPLIT') == 'true') {
+      splits {
+          abi {
+              enable true
+              reset()
+              include 'x86', 'arm64-v8a'
+              universalApk true
+          }
+      }
+      project.ext.versionCodes = ['armeabi': 1, 'armeabi-v7a': 2, 'arm64-v8a': 3, 'mips': 5, 'mips64': 6, 'x86': 8, 'x86_64': 9]
+      android.applicationVariants.all { variant ->
+          variant.outputs.each { output ->
+              output.versionCodeOverride =
+                  project.ext.versionCodes.get(output.getFilter(
+                      com.android.build.OutputFile.ABI), 0) * 10000000 + android.defaultConfig.versionCode
+          }
+      }
+    }
+
+    if (System.getenv('SENTRY_SAMPLE_ENABLE_FLAVORS') == 'true') {
+      flavorDimensions "version"
+      productFlavors {
+        regular {
+            dimension "version"
+        }
+        demo {
+            dimension "version"
+            applicationIdSuffix "demo"
+        }
+      }
+    }
+
     buildTypes {
         debug {
             signingConfig signingConfigs.debug

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -17,7 +17,8 @@
     "clean-watchman": "watchman watch-del-all",
     "set-build-number": "npx react-native-version --skip-tag --never-amend --set-build",
     "set-version": "npm version --no-git-tag-version",
-    "postversion": "npx react-native-version --skip-tag --never-amend"
+    "postversion": "npx react-native-version --skip-tag --never-amend",
+    "build-android-release-splits-flavors": "export SENTRY_SAMPLE_ENABLE_ABI_SPLIT=true; export SENTRY_SAMPLE_ENABLE_FLAVORS=true; cd android; ./gradlew assembleRelease; cd .."
   },
   "dependencies": {
     "@react-navigation/bottom-tabs": "^6.5.12",


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement


## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds splits and flavors to the RN Android Sample with easy to run packager script to test issues like https://github.com/getsentry/sentry-react-native/pull/4125

## :green_heart: How did you test it?
local builds

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog 