### PR TITLE
chore: Extends the Android metrics diffMin similar to iOS

### DIFF
--- a/test/perf/metrics-android.yml
+++ b/test/perf/metrics-android.yml
@@ -8,7 +8,7 @@ apps:
 
 startupTimeTest:
   runs: 50
-  diffMin: 0
+  diffMin: -20
   diffMax: 150
 
 binarySizeTest:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Extends the Android metrics `diffMin` [similar to iOS](https://github.com/getsentry/sentry-react-native/blob/main/test/perf/metrics-ios.yml#L9) to increase failure tolerance. This should prevent most failures [due to negative results in the check](https://github.com/getsentry/action-app-sdk-overhead-metrics/blob/main/src/test/kotlin/StartupTimeTest.kt#L91) indicating that the app with Sentry starts faster that the app without the SDK. Note that [the root cause](https://github.com/getsentry/sentry-react-native/issues/3413#issuecomment-2399340289) of the issue is not covered by this PR.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partially https://github.com/getsentry/sentry-react-native/issues/3413

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog