### PR TITLE
fix(tests): Move fetchNativeAppStart from root to package/core

### DIFF
--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryModuleImplTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryModuleImplTest.kt
@@ -1,4 +1,4 @@
-package io.sentry.rnsentryandroidtester
+package io.sentry.react
 
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryModuleImplTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryModuleImplTest.kt
@@ -1,4 +1,4 @@
-package io.sentry.react
+package io.sentry.rnsentryandroidtester
 
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
During the last merge of main to v6. I forgot to move this test.


## :green_heart: How did you test it?
ci

#skip-changelog 