### PR TITLE
chore: Bump E2E RN 0.65 to macos-13

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
         platform: ["ios", "android"]
         include:
           - platform: ios
-            runs-on: macos-12
+            runs-on: macos-13
             name: iOS
             appPlain: performance-tests/test-app-plain.ipa
           - platform: android
@@ -181,7 +181,7 @@ jobs:
             device: 'iPhone 14'
           - platform: ios
             rn-version: '0.65.3'
-            runs-on: macos-12
+            runs-on: macos-13
             runtime: 'latest'
             device: 'iPhone 14'
           - platform: android


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->
Starting in Nov 24 macos-12 will be removed.

I moved the 0.65 test only to macos-13 because RN 0.65 template is by default not compatible with building on ARM. We would have to change the E2E test to add the fix for ARM to bump to macos-14 and higher. 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/actions/runner-images/issues/10721

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

#skip-changelog 
