### PR TITLE
Refactor: use exported Node binary on Sample

### DIFF
--- a/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
+++ b/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nLOCAL_NODE_BINARY=node\n\nWITH_ENVIRONMENT=`$LOCAL_NODE_BINARY --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/xcode/with-environment.sh'\"`\nREACT_NATIVE_XCODE=`\"$LOCAL_NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\nSENTRY_XCODE=`\"$LOCAL_NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"`\nBUNDLE_REACT_NATIVE=\"/bin/sh $SENTRY_XCODE $REACT_NATIVE_XCODE\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT '$BUNDLE_REACT_NATIVE'\"\n";
+			shellScript = "set -e\n\nLOCAL_NODE_BINARY=${NODE_BINARY:-node}\n\nWITH_ENVIRONMENT=`$LOCAL_NODE_BINARY --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/xcode/with-environment.sh'\"`\nREACT_NATIVE_XCODE=`\"$LOCAL_NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\nSENTRY_XCODE=`\"$LOCAL_NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"`\nBUNDLE_REACT_NATIVE=\"/bin/sh $SENTRY_XCODE $REACT_NATIVE_XCODE\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT '$BUNDLE_REACT_NATIVE'\"\n";
 		};
 		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -328,7 +328,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "LOCAL_NODE_BINARY=node\n\n/bin/sh `\"$LOCAL_NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode-debug-files.sh'\"`\n";
+			shellScript = "LOCAL_NODE_BINARY=${NODE_BINARY:-node}\n\n/bin/sh `\"$LOCAL_NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode-debug-files.sh'\"`\n";
 		};
 		A55EABD7B0C7F3A422A6CC61 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Our samples were using the following code
```
LOCAL_NODE_BINARY=node
```
but our SDK sets the following code on the client codebase:
```
LOCAL_NODE_BINARY=${NODE_BINARY:-node}
```

This fix makes the sample to behave like the user codebase, and also fixes issues when node isn't exposed for xCode.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Build errors on the sample locally.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog