### PR TITLE
chore(test): Bump RN E2E tests to 0.76.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.65.3', '0.75.4']
+        rn-version: ['0.65.3', '0.76.0']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -165,7 +165,7 @@ jobs:
         engine: ['hermes', 'jsc']
         include:
           - platform: ios
-            rn-version: '0.75.4'
+            rn-version: '0.76.0'
             runs-on: macos-14 # uses m1 https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
             runtime: 'latest'
             device: 'iPhone 14'
@@ -178,7 +178,7 @@ jobs:
             runs-on: ubuntu-latest
         exclude:
           # exclude JSC for new RN versions (keeping the matrix manageable)
-          - rn-version: '0.75.4'
+          - rn-version: '0.76.0'
             engine: 'jsc'
           # exclude all rn versions lower than 0.70.0 for new architecture
           - rn-version: '0.65.3'
@@ -297,7 +297,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.65.3', '0.75.4']
+        rn-version: ['0.65.3', '0.76.0']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -305,7 +305,7 @@ jobs:
         engine: ['hermes', 'jsc']
         include:
           - platform: ios
-            rn-version: '0.75.4'
+            rn-version: '0.76.0'
             runs-on: macos-14 # uses m1 https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
             runtime: 'latest'
             device: 'iPhone 14'
@@ -323,10 +323,10 @@ jobs:
           # e2e test only the default combinations
           - rn-version: '0.65.3'
             engine: 'hermes'
-          - rn-version: '0.75.4'
+          - rn-version: '0.76.0'
             engine: 'jsc'
           # E2E timeout due to a race condition https://github.com/facebook/react-native/issues/42123#issuecomment-1881203719
-          - rn-version: '0.75.4'
+          - rn-version: '0.76.0'
             platform: 'ios'
             rn-architecture: 'new'
     env:


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

0.76 was released yesterday

https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here


## :green_heart: How did you test it?
ci

#skip-changelog 