### PR TITLE
Do not ignore require cycle logs for RN > 0.70

### DIFF
--- a/packages/core/src/js/client.ts
+++ b/packages/core/src/js/client.ts
@@ -21,6 +21,7 @@ import { MOBILE_REPLAY_INTEGRATION_NAME } from './replay/mobilereplay';
 import { createUserFeedbackEnvelope, items } from './utils/envelope';
 import { ignoreRequireCycleLogs } from './utils/ignorerequirecyclelogs';
 import { mergeOutcomes } from './utils/outcome';
+import { ReactNativeLibraries } from './utils/rnlibraries';
 import { NATIVE } from './wrapper';
 
 /**
@@ -37,7 +38,7 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
    * @param options Configuration options for this SDK.
    */
   public constructor(options: ReactNativeClientOptions) {
-    ignoreRequireCycleLogs();
+    ignoreRequireCycleLogs(ReactNativeLibraries.ReactNativeVersion?.version);
     options._metadata = options._metadata || {};
     options._metadata.sdk = options._metadata.sdk || defaultSdkInfo;
     // We default this to true, as it is the safer scenario

--- a/packages/core/src/js/utils/ignorerequirecyclelogs.ts
+++ b/packages/core/src/js/utils/ignorerequirecyclelogs.ts
@@ -1,8 +1,17 @@
 import { LogBox } from 'react-native';
 
+interface ReactNativeVersion {
+  major: number;
+  minor: number;
+}
+
 /**
  * This is a workaround for using fetch on RN, this is a known issue in react-native and only generates a warning.
  */
-export function ignoreRequireCycleLogs(): void {
-  LogBox.ignoreLogs(['Require cycle:']);
+export function ignoreRequireCycleLogs(version?: ReactNativeVersion): void {
+  if (version && version.major === 0 && version.minor < 70) {
+    // Do not ignore require cycle logs on React Native versions >= 0.70
+    // https://github.com/getsentry/sentry-react-native/issues/3484#issuecomment-1877034820
+    LogBox.ignoreLogs(['Require cycle:']);
+  }
 }

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -104,7 +104,7 @@ describe('Tests ReactNativeClient', () => {
       });
 
       await expect(client.eventFromMessage('test')).resolves.toBeDefined();
-      await expect(RN.LogBox.ignoreLogs).toBeCalled();
+      await expect(RN.LogBox.ignoreLogs).not.toBeCalled();
     });
 
     test('invalid dsn is thrown', () => {

--- a/packages/core/test/utils/ignorerequirecyclelogs.test.ts
+++ b/packages/core/test/utils/ignorerequirecyclelogs.test.ts
@@ -1,0 +1,35 @@
+import { LogBox } from 'react-native';
+
+import { ignoreRequireCycleLogs } from '../../src/js/utils/ignorerequirecyclelogs';
+
+jest.mock('react-native', () => ({
+  LogBox: {
+    ignoreLogs: jest.fn(),
+  },
+}));
+
+describe('ignoreRequireCycleLogs', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should ignore logs for React Native version < 0.70', () => {
+    ignoreRequireCycleLogs({ major: 0, minor: 69 });
+    expect(LogBox.ignoreLogs).toHaveBeenCalledWith(['Require cycle:']);
+  });
+
+  it('should not ignore logs for React Native version 0.70', () => {
+    ignoreRequireCycleLogs({ major: 0, minor: 70 });
+    expect(LogBox.ignoreLogs).not.toHaveBeenCalled();
+  });
+
+  it('should not ignore logs for React Native version > 0.70', () => {
+    ignoreRequireCycleLogs({ major: 0, minor: 71 });
+    expect(LogBox.ignoreLogs).not.toHaveBeenCalled();
+  });
+
+  it('should not ignore logs when no version is passed', () => {
+    ignoreRequireCycleLogs();
+    expect(LogBox.ignoreLogs).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This PR skips ignoring require cycle logs for RN > 0.70

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes https://github.com/getsentry/sentry-react-native/issues/3484

## :green_heart: How did you test it?
Manual, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
