### PR TITLE
fix(ci): Skip metrics when secrets are not available

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
   metrics:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check]
-    if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && env.SENTRY_AUTH_TOKEN != null }}
     env:
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
We should avoid running tests like metrics which depends on Secretes to be executed on forks and by users/bots which are missing the required secrets.



## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests will show as skipped instead of failing. Better experience for community contributors and also for us reviewing the PRs.

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

#skip-changelog 