### PR TITLE
misc(readme): Update from logo to header banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-<p align="center">
-  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
-    <picture>
-      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" media="(prefers-color-scheme: dark)" />
-      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
-      <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" alt="Sentry" width="280">
-    </picture>
-  </a>
-</p>
+<div align="center">
+    <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+        <img src="https://sentry-brand.storage.googleapis.com/github-banners/github-sdk-react.jpg" alt="Sentry for React Native">
+    </a>
+</div>
 
 _Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
 


### PR DESCRIPTION
For reference see https://github.com/getsentry/sentry-cocoa/pull/4236

<img width="927" alt="Screenshot 2024-11-04 at 15 33 28" src="https://github.com/user-attachments/assets/8d9471b2-d949-40ce-8683-3a75ca57d68b">

<img width="1067" alt="Screenshot 2024-11-04 at 15 35 01" src="https://github.com/user-attachments/assets/ef87eb0b-f87e-44f4-adf1-890554268458">

#skip-changelog 