### PR TITLE
chore(deps): Sample App: Bumps react-native-screens from 3.34.0 to 3.35.0

### DIFF
--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -32,7 +32,7 @@
     "react-native-gesture-handler": "^2.18.1",
     "react-native-reanimated": "3.15.0",
     "react-native-safe-area-context": "4.10.5",
-    "react-native-screens": "3.34.0",
+    "react-native-screens": "3.35.0",
     "react-native-svg": "^15.6.0",
     "react-native-vector-icons": "^10.0.3",
     "react-native-webview": "^13.12.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21328,16 +21328,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:3.34.0":
-  version: 3.34.0
-  resolution: "react-native-screens@npm:3.34.0"
+"react-native-screens@npm:3.35.0":
+  version: 3.35.0
+  resolution: "react-native-screens@npm:3.35.0"
   dependencies:
     react-freeze: ^1.0.0
     warn-once: ^0.1.0
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 28c1f6e556c318ffcbd79d153b9612cc8a0b8d8b70f909d3cde2fd6d0586a7c151a449e57400d8996f4ee6c3b5140c5c4f643a427e974f6dc573b2bcd8eb7356
+  checksum: cb8a0c8d8a41a8a1065cc2253e4272a970366a7d80bc54e889b2f48de7ccccd3e828e2701de39c0453a67956ec0cad140fb506324cce04419b5e2eb495c038c2
   languageName: node
   linkType: hard
 
@@ -22870,7 +22870,7 @@ __metadata:
     react-native-gesture-handler: ^2.18.1
     react-native-reanimated: 3.15.0
     react-native-safe-area-context: 4.10.5
-    react-native-screens: 3.34.0
+    react-native-screens: 3.35.0
     react-native-svg: ^15.6.0
     react-native-vector-icons: ^10.0.3
     react-native-webview: ^13.12.3


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Bumps react-native-screens from 3.34.0 to 3.35.0 in the sample app

Changelog: https://github.com/software-mansion/react-native-screens/releases/tag/3.35.0

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The new release fixes a JNI crash when the Android app is obfuscated https://github.com/software-mansion/react-native-screens/pull/2290 encountered while debugging https://github.com/getsentry/sentry-react-native/pull/4232

## :green_heart: How did you test it?
Manual testing, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog