### PR TITLE
test(ts3.8): fix ts3.8 type check test to not include dom types

### DIFF
--- a/dev-packages/type-check/ts3.8-test/index.ts
+++ b/dev-packages/type-check/ts3.8-test/index.ts
@@ -20,6 +20,7 @@ declare global {
   }
   interface PerformanceEntry {}
 }
+import 'react-native';
 
 // we need to import the SDK to ensure tsc check the types
 import * as _Sentry from '@sentry/react-native';

--- a/dev-packages/type-check/ts3.8-test/index.ts
+++ b/dev-packages/type-check/ts3.8-test/index.ts
@@ -1,2 +1,25 @@
+declare global {
+  interface History {}
+  interface IDBObjectStore {}
+  interface Window {
+    fetch: any;
+  }
+  interface ShadowRoot {}
+  interface BufferSource {}
+  interface PerformanceResourceTiming {
+    decodedBodySize: any;
+    encodedBodySize: any;
+    duration: any;
+    domInteractive: any;
+    domContentLoadedEventEnd: any;
+    domContentLoadedEventStart: any;
+    loadEventStart: any;
+    loadEventEnd: number;
+    domComplete: number;
+    redirectCount: number;
+  }
+  interface PerformanceEntry {}
+}
+
 // we need to import the SDK to ensure tsc check the types
 import * as _Sentry from '@sentry/react-native';

--- a/dev-packages/type-check/ts3.8-test/package.json
+++ b/dev-packages/type-check/ts3.8-test/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/react": "17.0.58",
+    "@types/react": "17.0.83",
     "@types/react-native": "0.65.30",
     "typescript": "3.8.3"
   },

--- a/dev-packages/type-check/ts3.8-test/tsconfig.build.json
+++ b/dev-packages/type-check/ts3.8-test/tsconfig.build.json
@@ -5,7 +5,9 @@
   "compilerOptions": {
     "skipLibCheck": false,
     "noEmit": true,
+    "importHelpers": true,
     "types": [],
+    "lib": ["es2015"],
     "jsx": "react-native",
     "target": "es6",
     "moduleResolution": "node",


### PR DESCRIPTION
#skip-changelog 

This PR changes the type check test project to only include the es2015/es6 types excluding dom, which would cause duplicate declarations when the project would import React or React Native.

- This is needed for https://github.com/getsentry/sentry-react-native/pull/4224
  - Where we want to export React Native HostComponent Type