### PR TITLE
fix(sample): 'codegen didn't run for RN*' warning caused by incorrect…

### DIFF
--- a/samples/react-native-macos/metro.config.js
+++ b/samples/react-native-macos/metro.config.js
@@ -25,7 +25,7 @@ const config = {
   // Note how we change this from `monorepoRoot` to `projectRoot`. This is part of the optimization!
   watchFolders: [projectRoot, ...Object.values(monorepoPackages)],
   resolver: {
-    resolverMainFields: ['main', 'react-native'],
+    resolverMainFields: ['react-native', 'main'],
     resolveRequest: (context, moduleName, platform) => {
       if (moduleName.includes('promise/')) {
         return context.resolveRequest(

--- a/samples/react-native/metro.config.js
+++ b/samples/react-native/metro.config.js
@@ -25,7 +25,7 @@ const config = {
   // Note how we change this from `monorepoRoot` to `projectRoot`. This is part of the optimization!
   watchFolders: [projectRoot, ...Object.values(monorepoPackages)],
   resolver: {
-    resolverMainFields: ['main', 'react-native'],
+    resolverMainFields: ['react-native', 'main'],
     resolveRequest: (context, moduleName, platform) => {
       if (moduleName.includes('promise/')) {
         return context.resolveRequest(


### PR DESCRIPTION
#skip-changelog 

Fixes sample app warning when using the new architecture.

Originally changed when switching monorepo structure.
- https://github.com/getsentry/sentry-react-native/pull/4057

The `react-native` must be first for the codegen to load in the ts files and generate correct React JS components based on it when new architecture is enabled.