### PR TITLE
test(e2e): Return new architecture

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -326,10 +326,7 @@ jobs:
             engine: 'hermes'
           - rn-version: '0.76.0'
             engine: 'jsc'
-          # E2E timeout due to a race condition https://github.com/facebook/react-native/issues/42123#issuecomment-1881203719
-          - rn-version: '0.76.0'
-            platform: 'ios'
-            rn-architecture: 'new'
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
#skip-changelog 

The tests were disabled due to a bug in RN new arch, which caused the tests to fail is CI.

Since then the bug was fixed so we can reenabled the tests.

- https://github.com/getsentry/sentry-react-native/pull/3513