### PR TITLE
fix(sample): Disable global promise patch

### DIFF
--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -35,6 +35,7 @@ import { logWithoutTracing } from './utils';
 import { ErrorEvent } from '@sentry/types';
 import HeavyNavigationScreen from './Screens/HeavyNavigationScreen';
 import WebviewScreen from './Screens/WebviewScreen';
+import { isTurboModuleEnabled } from '@sentry/react-native/dist/js/utils/environment';
 
 LogBox.ignoreAllLogs();
 const isMobileOs = Platform.OS === 'android' || Platform.OS === 'ios';
@@ -90,6 +91,13 @@ Sentry.init({
       }),
       Sentry.appStartIntegration({
         standalone: false,
+      }),
+      Sentry.reactNativeErrorHandlersIntegration({
+        patchGlobalPromise: Platform.OS === 'ios' && isTurboModuleEnabled()
+          // The global patch doesn't work on iOS with the New Architecture in this Sample app
+          // In
+          ? false
+          : true,
       }),
     );
     return integrations.filter(i => i.name !== 'Dedupe');


### PR DESCRIPTION
#skip-changelog 

This is a temporary fix to unblock the SDK development using the sample app.

Based on our E2E tests which use minimal RN application this is specific to our sample app setup.

We have not seen any reports of this from our users, but it's possible that application using similar setup might experience the same issue.