### PR TITLE
fix(core): Export missing SeverityLevel from types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - Fix Replay redacting of RN Classes on iOS ([#4243](https://github.com/getsentry/sentry-react-native/pull/4243))
 - Speed up getBinaryImages for finishing transactions and capturing events ([#4194](https://github.com/getsentry/sentry-react-native/pull/4194))
 - Replay `maskAll*` set to `false` on iOS kept all masked ([#4257](https://github.com/getsentry/sentry-react-native/pull/4257))
-- Add missing `getRootSpan`, `withActiveSpan` and `suppressTracing` exports from `@sentry/core` ([#4254](https://github.com/getsentry/sentry-react-native/pull/4254))
+- Add missing `getRootSpan`, `withActiveSpan` and `suppressTracing` exports from `@sentry/core`, and `SeverityLevel` export from `@sentry/types` ([#4254](https://github.com/getsentry/sentry-react-native/pull/4254), [#4260](https://github.com/getsentry/sentry-react-native/pull/4260))
 
 ### Dependencies
 

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -4,6 +4,7 @@ export type {
   SdkInfo,
   Event,
   Exception,
+  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,


### PR DESCRIPTION
This PR adds the missing export SeverityLevel from @sentry/types.
