### PR TITLE
Fix: Aligns Android autoupload logic with iOS

### DIFF
--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -4,7 +4,7 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 project.ext.shouldSentryAutoUpload = { ->
-  return System.getenv('SENTRY_DISABLE_AUTO_UPLOAD') != 'true' ||
+  return System.getenv('SENTRY_DISABLE_AUTO_UPLOAD') != 'true' &&
          System.getenv('SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD') != 'true'
 }
 

--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -3,9 +3,16 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+project.ext.shouldSentryAutoUploadNative = { -> 
+  return System.getenv('SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD') != 'true'
+}
+
+project.ext.shouldSentryAutoUploadGeneral = { ->
+  return System.getenv('SENTRY_DISABLE_AUTO_UPLOAD') != 'true'
+}
+
 project.ext.shouldSentryAutoUpload = { ->
-  return System.getenv('SENTRY_DISABLE_AUTO_UPLOAD') != 'true' &&
-         System.getenv('SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD') != 'true'
+  return shouldSentryAutoUploadGeneral() && shouldSentryAutoUploadNative()
 }
 
 def config = project.hasProperty("sentryCli") ? project.sentryCli : [];
@@ -99,7 +106,7 @@ gradle.projectsEvaluated {
 
           /** Upload source map file to the sentry server via CLI call. */
           def cliTask = tasks.create(nameCliTask) {
-              onlyIf { shouldSentryAutoUpload() }
+              onlyIf { shouldSentryAutoUploadGeneral() }
               description = "upload debug symbols to sentry"
               group = 'sentry.io'
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Aligns Android `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD` logic [with the `SENTRY_DISABLE_XCODE_DEBUG_UPLOAD` on iOS](https://github.com/getsentry/sentry-react-native/blob/7bc4d758f2bdfa0bbb51d2a9119418c0f500e893/packages/core/scripts/sentry-xcode-debug-files.sh#L38), so that the upload is performed only when both the new flag is `false` and the `SENTRY_DISABLE_AUTO_UPLOAD` is `false`

| SENTRY_DISABLE_ AUTO_UPLOAD | SENTRY_DISABLE_ NATIVE_DEBUG_UPLOAD XCODE_DEBUG_UPLOAD |Upload iOS |Upload Android (before)| Upload Android (after)
|---|---|---|---|---|
| true | true | false | false	| false |
| true | false | false | true	| false |
| false | true | false | true	| false |
| false | false | true | true	| true |

https://github.com/getsentry/sentry-react-native/pull/4263 fixes case when the native upload is disabled but still JS source maps should be uploaded.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/getsentry/sentry-react-native/pull/4258#issuecomment-2469917567

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog