### PR TITLE
fix(gradle): DISABLE_NATIVE_UPLOAD should not affect JS source maps upload

### DIFF
--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -3,9 +3,16 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
+project.ext.shouldSentryAutoUploadNative = { -> 
+  return System.getenv('SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD') != 'true'
+}
+
+project.ext.shouldSentryAutoUploadGeneral = { ->
+  return System.getenv('SENTRY_DISABLE_AUTO_UPLOAD') != 'true'
+}
+
 project.ext.shouldSentryAutoUpload = { ->
-  return System.getenv('SENTRY_DISABLE_AUTO_UPLOAD') != 'true' &&
-         System.getenv('SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD') != 'true'
+  return shouldSentryAutoUploadGeneral() && shouldSentryAutoUploadNative()
 }
 
 def config = project.hasProperty("sentryCli") ? project.sentryCli : [];
@@ -99,7 +106,7 @@ gradle.projectsEvaluated {
 
           /** Upload source map file to the sentry server via CLI call. */
           def cliTask = tasks.create(nameCliTask) {
-              onlyIf { shouldSentryAutoUpload() }
+              onlyIf { shouldSentryAutoUploadGeneral() }
               description = "upload debug symbols to sentry"
               group = 'sentry.io'
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The new disable native upload flag was not released yet.

This fixes case when the native upload is disabled but still JS source maps should be uploaded.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

#skip-changelog 