### PR TITLE
fix(ci): Skip maestro test if SENTRY_AUTH_TOKEN is unavailable

### DIFF
--- a/dev-packages/e2e-tests/cli.mjs
+++ b/dev-packages/e2e-tests/cli.mjs
@@ -231,15 +231,19 @@ if (actions.includes('test')) {
     execFileSync('adb', ['install', '-r', '-d', testApp]);
   }
 
-  execSync(
-    `maestro test maestro \
-      --env=APP_ID="${appId}" \
-      --env=SENTRY_AUTH_TOKEN="${sentryAuthToken}" \
-      --debug-output maestro-logs \
-      --flatten-debug-output`,
-    {
-      stdio: 'inherit',
-      cwd: e2eDir,
-    },
-  );
+  if (sentryAuthToken === undefined) {
+    console.log('Skipping maestro test due to unavailable SENTRY_AUTH_TOKEN');
+  } else {
+    execSync(
+      `maestro test maestro \
+        --env=APP_ID="${appId}" \
+        --env=SENTRY_AUTH_TOKEN="${sentryAuthToken}" \
+        --debug-output maestro-logs \
+        --flatten-debug-output`,
+      {
+        stdio: 'inherit',
+        cwd: e2eDir,
+      },
+    );
+  }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Skip maestro if SENTRY_AUTH_TOKEN is unavailable

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/getsentry/sentry-react-native/pull/4268#issuecomment-2473342812

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog