### PR TITLE
fix(ci): Installs corepack before enabling in native tests

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -24,7 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: corepack enable
+      - name: Enable Corepack
+        run: |
+          npm install -g corepack@0.29.4
+          corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Installs corepack before enabling in native tests similar to https://github.com/getsentry/sentry-react-native/pull/4273 after the upgrade to macos-15 https://github.com/getsentry/sentry-react-native/pull/4274 where corepack is not available

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failed test on CI ([example](https://github.com/getsentry/sentry-react-native/actions/runs/11835438689/job/32978334201))

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I reviewed submitted code
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
