### PR TITLE
fix(ci): update sample app build target to generic ios simulator

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -53,7 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: corepack enable
+      - name: Enable Corepack
+        run: |
+          npm install -g corepack@0.29.4
+          corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -36,11 +36,9 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
-            runs-on: macos-14 # uses m1 https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
-            runtime: 'latest'
-            device: 'iPhone 14'
+            runs-on: macos-15
           - platform: macos
-            runs-on: macos-14
+            runs-on: macos-15
           - platform: android
             runs-on: ubuntu-latest
         exclude:
@@ -132,7 +130,8 @@ jobs:
             -workspace sentryreactnativesample.xcworkspace \
             -configuration "$CONFIG" \
             -scheme sentryreactnativesample \
-            -destination 'platform=iOS Simulator,OS=${{ matrix.runtime }},name=${{ matrix.device }}' \
+            -sdk 'iphonesimulator' \
+            -destination 'generic/platform=iOS Simulator' \
             ONLY_ACTIVE_ARCH=yes \
             -derivedDataPath "$derivedData" \
             build \

--- a/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
+++ b/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -531,7 +531,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = sentryreactnativesample/Info.plist;

--- a/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
+++ b/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
@@ -499,9 +499,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 97JCY7859U;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sentryreactnativesample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Sentry RN";
@@ -517,6 +519,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.reactnative.sample;
 				PRODUCT_NAME = sentryreactnativesample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.sentry.reactnative.sample";
 				RCT_NEW_ARCH_ENABLED = 1;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -531,9 +534,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 97JCY7859U;
 				INFOPLIST_FILE = sentryreactnativesample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Sentry RN";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -548,6 +553,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.reactnative.sample;
 				PRODUCT_NAME = sentryreactnativesample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.sentry.reactnative.sample";
 				RCT_NEW_ARCH_ENABLED = 1;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
+++ b/samples/react-native/ios/sentryreactnativesample.xcodeproj/project.pbxproj
@@ -498,11 +498,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 97JCY7859U;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sentryreactnativesample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Sentry RN";
@@ -518,7 +517,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.reactnative.sample;
 				PRODUCT_NAME = sentryreactnativesample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.sentry.reactnative.sample";
 				RCT_NEW_ARCH_ENABLED = 1;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -532,11 +530,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 97JCY7859U;
 				INFOPLIST_FILE = sentryreactnativesample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Sentry RN";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -551,7 +548,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.reactnative.sample;
 				PRODUCT_NAME = sentryreactnativesample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.sentry.reactnative.sample";
 				RCT_NEW_ARCH_ENABLED = 1;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
#skip-changelog 

Fix failing sample ios build due to missing iPhone 14 simulator.

The build now uses generic iOS sim target. This should be more resilient for the future.