### PR TITLE
misc: Removes deprecated Sentry.metrics API

### DIFF
--- a/samples/expo/app/(tabs)/index.tsx
+++ b/samples/expo/app/(tabs)/index.tsx
@@ -4,31 +4,11 @@ import * as Sentry from '@sentry/react-native';
 
 import { Text, View } from '@/components/Themed';
 import { setScopeProperties } from '@/utils/setScopeProperties';
-import { timestampInSeconds } from '@sentry/utils';
 import React from 'react';
 
 const isRunningInExpoGo = Constants.appOwnership === 'expo'
 
 export default function TabOneScreen() {
-  const [componentMountStartTimestamp] = React.useState<number>(() => {
-    return timestampInSeconds();
-  });
-
-  React.useEffect(() => {
-    if (componentMountStartTimestamp) {
-      // Distributions help you get the most insights from your data by allowing you to obtain aggregations such as p90, min, max, and avg.
-      Sentry.metrics.distribution(
-        'tab_one_mount_time',
-        timestampInSeconds() - componentMountStartTimestamp,
-        {
-          unit: "seconds",
-        },
-      );
-    }
-    // We only want this to run once.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <View style={styles.container}>
       <Sentry.TimeToInitialDisplay record />
@@ -42,7 +22,6 @@ export default function TabOneScreen() {
       <Button
         title="Capture exception"
         onPress={() => {
-          Sentry.metrics.increment('tab_one.capture_exception_button_press', 1);
           Sentry.captureException(new Error('Captured exception'));
         }}
       />

--- a/samples/react-native-macos/src/Screens/ErrorsScreen.tsx
+++ b/samples/react-native-macos/src/Screens/ErrorsScreen.tsx
@@ -15,32 +15,12 @@ import { setScopeProperties } from '../setScopeProperties';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { UserFeedbackModal } from '../components/UserFeedbackModal';
 import { FallbackRender } from '@sentry/react';
-import { timestampInSeconds } from '@sentry/utils';
 
 interface Props {
   navigation: StackNavigationProp<any, 'HomeScreen'>;
 }
 
 const ErrorsScreen = (_props: Props) => {
-  const [componentMountStartTimestamp] = React.useState<number>(() => {
-    return timestampInSeconds();
-  });
-
-  React.useEffect(() => {
-    if (componentMountStartTimestamp) {
-      // Distributions help you get the most insights from your data by allowing you to obtain aggregations such as p90, min, max, and avg.
-      Sentry.metrics.distribution(
-        'home_mount_time',
-        timestampInSeconds() - componentMountStartTimestamp,
-        {
-          unit: 'seconds',
-        },
-      );
-    }
-    // We only want this to run once.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   // Show bad code inside error boundary to trigger it.
   const [showBadCode, setShowBadCode] = React.useState(false);
   const [isFeedbackVisible, setFeedbackVisible] = React.useState(false);

--- a/samples/react-native-macos/src/Screens/TrackerScreen.tsx
+++ b/samples/react-native-macos/src/Screens/TrackerScreen.tsx
@@ -53,9 +53,6 @@ const TrackerScreen = () => {
   };
 
   const onRefreshButtonPress = () => {
-    Sentry.metrics.increment('tracker_screen.refresh_button_press', 1, {
-      tags: { graph: 'none', public_data: true },
-    });
     loadData();
   };
 

--- a/samples/react-native/src/Screens/ErrorsScreen.tsx
+++ b/samples/react-native/src/Screens/ErrorsScreen.tsx
@@ -19,7 +19,6 @@ import { UserFeedbackModal } from '../components/UserFeedbackModal';
 import { FallbackRender } from '@sentry/react';
 import NativeSampleModule from '../../tm/NativeSampleModule';
 import NativePlatformSampleModule from '../../tm/NativePlatformSampleModule';
-import { timestampInSeconds } from '@sentry/utils';
 
 const { AssetsModule, CppModule, CrashModule } = NativeModules;
 
@@ -28,25 +27,6 @@ interface Props {
 }
 
 const ErrorsScreen = (_props: Props) => {
-  const [componentMountStartTimestamp] = React.useState<number>(() => {
-    return timestampInSeconds();
-  });
-
-  React.useEffect(() => {
-    if (componentMountStartTimestamp) {
-      // Distributions help you get the most insights from your data by allowing you to obtain aggregations such as p90, min, max, and avg.
-      Sentry.metrics.distribution(
-        'home_mount_time',
-        timestampInSeconds() - componentMountStartTimestamp,
-        {
-          unit: 'seconds',
-        },
-      );
-    }
-    // We only want this to run once.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   // Show bad code inside error boundary to trigger it.
   const [showBadCode, setShowBadCode] = React.useState(false);
   const [isFeedbackVisible, setFeedbackVisible] = React.useState(false);

--- a/samples/react-native/src/Screens/TrackerScreen.tsx
+++ b/samples/react-native/src/Screens/TrackerScreen.tsx
@@ -53,9 +53,6 @@ const TrackerScreen = () => {
   };
 
   const onRefreshButtonPress = () => {
-    Sentry.metrics.increment('tracker_screen.refresh_button_press', 1, {
-      tags: { graph: 'none', public_data: true },
-    });
     loadData();
   };
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
- [Removes metric from the RN app](https://github.com/getsentry/sentry-react-native/commit/e60030005981557b907dbbabc13218a173223342)
- [Removes metric from the MacOS app](https://github.com/getsentry/sentry-react-native/commit/e21831ec59167e4e6bcc2cf902dffbeea73605d1)
- [Removes metric from the Expo app](https://github.com/getsentry/sentry-react-native/commit/616db8cc82ed105e65e5d0bd0d96412dd8415db3)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-react-native/issues/4242

## :green_heart: How did you test it?
Manual testing

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog