### PR TITLE
fix(ci): Fixes p-retry version to 6.2.0

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -258,7 +258,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: ${{ matrix.rn-version == '0.65.3' }}
         with:
-          node-version: 16
+          node-version: 18
 
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'ios' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -258,7 +258,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: ${{ matrix.rn-version == '0.65.3' }}
         with:
-          node-version: 18
+          node-version: 16
 
       - uses: ruby/setup-ruby@v1
         if: ${{ matrix.platform == 'ios' }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -227,6 +227,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -227,8 +227,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: yarn.lock
 
       - uses: actions/setup-java@v4
         with:

--- a/dev-packages/e2e-tests/package.json
+++ b/dev-packages/e2e-tests/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "minimist": "1.2.8",
-    "p-retry": "^6.2.0",
+    "p-retry": "6.2.0",
     "semver": "7.6.3",
     "xcode": "3.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19974,7 +19974,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-retry@npm:^6.2.0":
+"p-retry@npm:6.2.0":
   version: 6.2.0
   resolution: "p-retry@npm:6.2.0"
   dependencies:
@@ -22762,7 +22762,7 @@ __metadata:
     babel-jest: ^29.7.0
     jest: ^29.7.0
     minimist: 1.2.8
-    p-retry: ^6.2.0
+    p-retry: 6.2.0
     react: 18.3.1
     react-native: 0.75.4
     react-native-launch-arguments: ^4.0.2


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes p-retry version to `6.2.0` since [the latest release](https://github.com/sindresorhus/p-retry/releases) including https://github.com/sindresorhus/p-retry/pull/82 triggered the issue.

```
error node_modules/p-retry/index.js: Unexpected token: operator (?) in file node_modules/p-retry/index.js at 51:37.
 Error: Unexpected token: operator (?) in file node_modules/p-retry/index.js at 51:37
    at minifyCode (/home/runner/work/sentry-react-native/sentry-react-native/dev-packages/e2e-tests/react-native-versions/0.65.3/RnDiffApp/node_modules/metro-transform-worker/src/index.js:99:13)
    at transformJS (/home/runner/work/sentry-react-native/sentry-react-native/dev-packages/e2e-tests/react-native-versions/0.65.3/RnDiffApp/node_modules/metro-transform-worker/src/index.js:317:28)
    at transformJSWithBabel (/home/runner/work/sentry-react-native/sentry-react-native/dev-packages/e2e-tests/react-native-versions/0.65.3/RnDiffApp/node_modules/metro-transform-worker/src/index.js:408:16)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.transform (/home/runner/work/sentry-react-native/sentry-react-native/dev-packages/e2e-tests/react-native-versions/0.65.3/RnDiffApp/node_modules/metro-transform-worker/src/index.js:569:12)
```

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The following failed CI checks:
- [Build RN 0.65.3 legacy hermes android production no](https://github.com/getsentry/sentry-react-native/actions/runs/11853677283/job/33037789469?pr=4278#logs)
- [Build RN 0.65.3 legacy jsc android production no](https://github.com/getsentry/sentry-react-native/actions/runs/11853677283/job/33037789764?pr=4278#logs)
- [Build RN 0.65.3 legacy jsc ios production no](https://github.com/getsentry/sentry-react-native/actions/runs/11853677283/job/33037790543?pr=4278#logs)

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog