### PR TITLE
feat(plugin): Add support for `.env.sentry-build-plugin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ node_modules.bak
 
 # Sentry React Native Monorepo
 /packages/core/README.md
+.env.sentry-build-plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@
   export SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD=true
   ```
 
+- Add support for `.env.sentry-build-plugin` ([#4281](https://github.com/getsentry/sentry-react-native/pull/4281))
+
+  Don't committing the file to your repository. Use it to set your Sentry Auth Token.
+
+  ```
+  SENTRY_AUTH_TOKEN=your_token_here
+  ```
+
 ### Fixes
 
 - Ignore JavascriptException to filter out obfuscated duplicate JS Errors on Android ([#4232](https://github.com/getsentry/sentry-react-native/pull/4232))

--- a/packages/core/scripts/expo-upload-sourcemaps.js
+++ b/packages/core/scripts/expo-upload-sourcemaps.js
@@ -102,6 +102,20 @@ function groupAssets(assetPaths) {
   return groups;
 }
 
+function loadDotenv(dotenvPath) {
+  try {
+    const dotenvFile = fs.readFileSync(dotenvPath, 'utf-8');
+    // NOTE: Do not use the dotenv.config API directly to read the dotenv file! For some ungodly reason, it falls back to reading `${process.cwd()}/.env` which is absolutely not what we want.
+    // dotenv is dependency of @expo/env, so we can just require it here
+    const dotenvResult = require('dotenv').parse(dotenvFile);
+
+    Object.assign(process.env, dotenvResult);
+  } catch (error) {
+    console.warn('⚠️ Failed to load environment variables using dotenv.');
+    console.warn(error);
+  }
+}
+
 process.env.NODE_ENV = process.env.NODE_ENV || 'development'; // Ensures precedence .env.development > .env (the same as @expo/cli)
 const projectRoot = '.'; // Assume script is run from the project root
 try {
@@ -110,6 +124,8 @@ try {
   console.warn('⚠️ Failed to load environment variables using @expo/env.');
   console.warn(error);
 }
+
+loadDotenv(path.join(projectRoot, '.env.sentry-build-plugin'));
 
 let sentryOrg = getEnvVar(SENTRY_ORG);
 let sentryUrl = getEnvVar(SENTRY_URL);

--- a/packages/core/scripts/sentry-xcode-debug-files.sh
+++ b/packages/core/scripts/sentry-xcode-debug-files.sh
@@ -17,7 +17,11 @@ set -e
 
 LOCAL_NODE_BINARY=${NODE_BINARY:-node}
 
+# The project root by default is one level up from the ios directory
+RN_PROJECT_ROOT="${PROJECT_DIR}/.."
+
 [ -z "$SENTRY_PROPERTIES" ] && export SENTRY_PROPERTIES=sentry.properties
+[ -z "$SENTRY_DOTENV_PATH" ] && export SENTRY_DOTENV_PATH="$RN_PROJECT_ROOT/.env.sentry-build-plugin"
 
 [ -z "$SENTRY_CLI_EXECUTABLE" ] && SENTRY_CLI_PACKAGE_PATH=$("$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/cli/package.json'))")
 [ -z "$SENTRY_CLI_EXECUTABLE" ] && SENTRY_CLI_EXECUTABLE="${SENTRY_CLI_PACKAGE_PATH}/bin/sentry-cli"

--- a/packages/core/scripts/sentry-xcode.sh
+++ b/packages/core/scripts/sentry-xcode.sh
@@ -9,7 +9,11 @@ set -x -e
 
 LOCAL_NODE_BINARY=${NODE_BINARY:-node}
 
+# The project root by default is one level up from the ios directory
+RN_PROJECT_ROOT="$PROJECT_DIR"/..
+
 [ -z "$SENTRY_PROPERTIES" ] && export SENTRY_PROPERTIES=sentry.properties
+[ -z "$SENTRY_DOTENV_PATH" ] && export SENTRY_DOTENV_PATH="$RN_PROJECT_ROOT/.env.sentry-build-plugin"
 [ -z "$SOURCEMAP_FILE" ] && export SOURCEMAP_FILE="$DERIVED_FILE_DIR/main.jsbundle.map"
 
 [ -z "$SENTRY_CLI_EXECUTABLE" ] && SENTRY_CLI_PACKAGE_PATH=$("$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/cli/package.json'))")

--- a/packages/core/scripts/sentry-xcode.sh
+++ b/packages/core/scripts/sentry-xcode.sh
@@ -10,7 +10,7 @@ set -x -e
 LOCAL_NODE_BINARY=${NODE_BINARY:-node}
 
 # The project root by default is one level up from the ios directory
-RN_PROJECT_ROOT="$PROJECT_DIR"/..
+RN_PROJECT_ROOT="${PROJECT_DIR}/.."
 
 [ -z "$SENTRY_PROPERTIES" ] && export SENTRY_PROPERTIES=sentry.properties
 [ -z "$SENTRY_DOTENV_PATH" ] && export SENTRY_DOTENV_PATH="$RN_PROJECT_ROOT/.env.sentry-build-plugin"

--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -203,6 +203,9 @@ gradle.projectsEvaluated {
 
                       project.logger.lifecycle("Sentry-CLI arguments: ${args}")
                       def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
+                      if (!System.getenv('SENTRY_DOTENV_PATH')) {
+                          environment('SENTRY_DOTENV_PATH', "$reactRoot/.env.sentry-build-plugin")
+                      }
                       commandLine(*osCompatibility, *args)
                   }
               }

--- a/samples/expo/.env.sentry-build-plugin.example
+++ b/samples/expo/.env.sentry-build-plugin.example
@@ -1,0 +1,1 @@
+SENTRY_AUTH_TOKEN=your_token_here

--- a/samples/react-native/.env.sentry-build-plugin.example
+++ b/samples/react-native/.env.sentry-build-plugin.example
@@ -1,0 +1,1 @@
+SENTRY_AUTH_TOKEN=your_token_here


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] New feature

## :scroll: Description
<!--- Describe your changes in detail -->
This PR adds support for `.env.sentry-build-plugin` located in the root of the React Native project.

This can later be used by Sentry Wizard to add the Sentry Auth Token.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix out of the box source maps upload without having to manually set `SENTRY_AUTH_TOKEN` in the environment. Currently the wizard add `SENTRY_AUTH_TOKEN` to `.env.local` file which out of the box works only for EAS source maps uploads but not for native Android and iOS builds.

## :green_heart: How did you test it?
using both Expo and bare React Native sample apps 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes
