### PR TITLE
fix(ci): Skip maestro test if SENTRY_AUTH_TOKEN is unavailable or empty

### DIFF
--- a/dev-packages/e2e-tests/cli.mjs
+++ b/dev-packages/e2e-tests/cli.mjs
@@ -231,8 +231,8 @@ if (actions.includes('test')) {
     execFileSync('adb', ['install', '-r', '-d', testApp]);
   }
 
-  if (sentryAuthToken === undefined) {
-    console.log('Skipping maestro test due to unavailable SENTRY_AUTH_TOKEN');
+  if (!sentryAuthToken) {
+    console.log('Skipping maestro test due to unavailable or empty SENTRY_AUTH_TOKEN');
   } else {
     execSync(
       `maestro test maestro \


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Skip maestro test if SENTRY_AUTH_TOKEN is unavailable or empty

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is an additional fix after https://github.com/getsentry/sentry-react-native/pull/4269 since the CI issue was not solved https://github.com/getsentry/sentry-react-native/pull/4284#issuecomment-2483181486

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog