### PR TITLE
fix(e2e): Add longer timeout for test app start

### DIFF
--- a/dev-packages/e2e-tests/maestro/crash.yml
+++ b/dev-packages/e2e-tests/maestro/crash.yml
@@ -5,4 +5,5 @@ jsEngine: graaljs
 - tapOn: "Crash"
 
 - launchApp
-- assertVisible: "E2E Tests Ready"
+
+- runFlow: utils/assertTestReady.yml

--- a/dev-packages/e2e-tests/maestro/utils/assertTestReady.yml
+++ b/dev-packages/e2e-tests/maestro/utils/assertTestReady.yml
@@ -1,0 +1,9 @@
+appId: ${APP_ID}
+jsEngine: graaljs
+---
+- extendedWaitUntil:
+    visible: "E2E Tests Ready"
+    timeout: 300_000 # 5 minutes
+
+# The RN 0.65 takes a long time to start on iOS.
+# Even locally it can take up to 10 seconds.

--- a/dev-packages/e2e-tests/maestro/utils/launchTestAppClear.yml
+++ b/dev-packages/e2e-tests/maestro/utils/launchTestAppClear.yml
@@ -11,6 +11,4 @@ jsEngine: graaljs
       sentryAuthToken: ${SENTRY_AUTH_TOKEN}
       replaysOnErrorSampleRate: ${replaysOnErrorSampleRate}
 
-- extendedWaitUntil:
-    visible: "E2E Tests Ready"
-    timeout: 120_000 # 2 minutes
+- runFlow: assertTestReady.yml


### PR DESCRIPTION
This PR adds longer timeout for test ready text to appear. 

Especially RN 0.65 on iOS frequently timesout on the current 2 mins timeout.

#skip-changelog 