### PR TITLE
fix(metro): Use env for default Babel transformer path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Remove `.sentry` tmp directory and use environmental variables instead to save default Babel transformer path ([#4298](https://github.com/getsentry/sentry-react-native/pull/4298))
+  - This resolves concurrency issues when running multiple bundle processes
+
 ## 6.3.0-beta.1
 
 ### Features

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -5,7 +5,7 @@ import * as process from 'process';
 import { env } from 'process';
 
 import { enableLogger } from './enableLogger';
-import { cleanDefaultBabelTransformerPath, saveDefaultBabelTransformerPath } from './sentryBabelTransformerUtils';
+import { setSentryDefaultBabelTransformerPathEnv } from './sentryBabelTransformerUtils';
 import { createSentryMetroSerializer, unstable_beforeAssetSerializationPlugin } from './sentryMetroSerializer';
 import type { DefaultConfigOptions } from './vendor/expo/expoconfig';
 export * from './sentryMetroSerializer';
@@ -143,10 +143,7 @@ export function withSentryBabelTransformer(config: MetroConfig): MetroConfig {
   }
 
   if (defaultBabelTransformerPath) {
-    saveDefaultBabelTransformerPath(defaultBabelTransformerPath);
-    process.on('exit', () => {
-      cleanDefaultBabelTransformerPath();
-    });
+    setSentryDefaultBabelTransformerPathEnv(defaultBabelTransformerPath);
   }
 
   return {

--- a/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
+++ b/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
@@ -1,62 +1,34 @@
 import { logger } from '@sentry/utils';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as process from 'process';
 
 import type { BabelTransformer } from './vendor/metro/metroBabelTransformer';
 
+export const SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH = 'SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH';
+
 /**
- * Saves default Babel transformer path to the project root.
+ * Sets default Babel transformer path to the environment variables.
  */
-export function saveDefaultBabelTransformerPath(defaultBabelTransformerPath: string): void {
-  try {
-    fs.mkdirSync(path.join(process.cwd(), '.sentry'), { recursive: true });
-    fs.writeFileSync(getDefaultBabelTransformerPath(), defaultBabelTransformerPath);
-    logger.debug('Saved default Babel transformer path');
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('[Sentry] Failed to save default Babel transformer path:', e);
-  }
+export function setSentryDefaultBabelTransformerPathEnv(defaultBabelTransformerPath: string): void {
+  process.env[SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH] = defaultBabelTransformerPath;
+  logger.debug(`Saved default Babel transformer path ${defaultBabelTransformerPath}`);
 }
 
 /**
- * Reads default Babel transformer path from the project root.
+ * Reads default Babel transformer path from the environment variables.
  */
-export function readDefaultBabelTransformerPath(): string | undefined {
-  try {
-    return fs.readFileSync(getDefaultBabelTransformerPath()).toString();
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('[Sentry] Failed to read default Babel transformer path:', e);
-  }
-  return undefined;
-}
-
-/**
- * Cleans default Babel transformer path from the project root.
- */
-export function cleanDefaultBabelTransformerPath(): void {
-  try {
-    fs.unlinkSync(getDefaultBabelTransformerPath());
-    logger.debug('Cleaned default Babel transformer path');
-  } catch (e) {
-    // We don't want to fail the build if we can't clean the file
-    // eslint-disable-next-line no-console
-    console.error('[Sentry] Failed to clean default Babel transformer path:', e);
-  }
-}
-
-function getDefaultBabelTransformerPath(): string {
-  return path.join(process.cwd(), '.sentry/.defaultBabelTransformerPath');
+export function getSentryDefaultBabelTransformerPathEnv(): string | undefined {
+  return process.env[SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH];
 }
 
 /**
  * Loads default Babel transformer from `@react-native/metro-config` -> `@react-native/metro-babel-transformer`.
  */
 export function loadDefaultBabelTransformer(): BabelTransformer {
-  const defaultBabelTransformerPath = readDefaultBabelTransformerPath();
+  const defaultBabelTransformerPath = getSentryDefaultBabelTransformerPathEnv();
   if (!defaultBabelTransformerPath) {
-    throw new Error('Default Babel Transformer Path not found in `.sentry` directory.');
+    throw new Error(
+      `Default Babel transformer path environment variable ${SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH} is not set.`,
+    );
   }
 
   logger.debug(`Loading default Babel transformer from ${defaultBabelTransformerPath}`);

--- a/packages/core/test/tools/sentryBabelTransformer.test.ts
+++ b/packages/core/test/tools/sentryBabelTransformer.test.ts
@@ -1,14 +1,8 @@
-jest.mock('fs', () => {
-  return {
-    readFileSync: jest.fn(),
-  };
-});
+import * as process from 'process';
 
-import * as fs from 'fs';
+import { SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH } from '../../src/js/tools/sentryBabelTransformerUtils';
 
-// needs to be defined before sentryBabelTransformer is imported
-// the transformer is created on import (side effect)
-(fs.readFileSync as jest.Mock).mockReturnValue(require.resolve('./fixtures/mockBabelTransformer.js'));
+process.env[SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH] = require.resolve('./fixtures/mockBabelTransformer.js');
 
 import * as SentryBabelTransformer from '../../src/js/tools/sentryBabelTransformer';
 import type { BabelTransformerArgs } from '../../src/js/tools/vendor/metro/metroBabelTransformer';


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR remove use of tmp `.sentry` dir. And adds dedicated Sentry default Babel transformer env instead.

The use of ENV ensures that multiple concurent builds are not sharing the same resource (the tmp dir). The env is by default scoped to the current process and its children.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixes: https://github.com/getsentry/sentry-react-native/issues/4121

## :green_heart: How did you test it?
sample app, updated unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
