### PR TITLE
test: Fix flaky App Start Tests

### DIFF
--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -63,6 +63,24 @@ jest.mock('@sentry/utils', () => {
   };
 });
 
+// Overrides expect.closeTo to increase tolerance from 0.005 (2 decimal digits) to 0.025
+expect.extend({
+  closeTo(received, expected, tolerance = 0.025) {
+    const pass = Math.abs(expected - received) < tolerance;
+    if (pass) {
+      return {
+        message: () => `expected ${received} not to be close to ${expected} within ${tolerance}`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () => `expected ${received} to be close to ${expected} within ${tolerance}`,
+        pass: false,
+      };
+    }
+  },
+});
+
 describe('App Start Integration', () => {
   beforeEach(() => {
     mockReactNativeBundleExecutionStartTimestamp();

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -65,24 +65,6 @@ jest.mock('@sentry/utils', () => {
   };
 });
 
-// Overrides expect.closeTo to increase tolerance from 0.005 (2 decimal digits) to 0.025
-expect.extend({
-  closeTo(received, expected, tolerance = 0.025) {
-    const pass = Math.abs(expected - received) < tolerance;
-    if (pass) {
-      return {
-        message: () => `expected ${received} not to be close to ${expected} within ${tolerance}`,
-        pass: true,
-      };
-    } else {
-      return {
-        message: () => `expected ${received} to be close to ${expected} within ${tolerance}`,
-        pass: false,
-      };
-    }
-  },
-});
-
 describe('App Start Integration', () => {
   beforeEach(() => {
     mockReactNativeBundleExecutionStartTimestamp();

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -1062,7 +1062,6 @@ function mockReactNativeBundleExecutionStartTimestamp() {
 
   const currentTimeMilliseconds = Date.now();
   dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => currentTimeMilliseconds);
-  Date.now = jest.fn(() => currentTimeMilliseconds);
 }
 
 /**

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -33,6 +33,8 @@ import { NATIVE } from '../../../src/js/wrapper';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
 import { mockFunction } from '../../testutils';
 
+let dateNowSpy: jest.SpyInstance;
+
 jest.mock('../../../src/js/wrapper', () => {
   return {
     NATIVE: {
@@ -1075,6 +1077,10 @@ function mockTooOldAppStart() {
 function mockReactNativeBundleExecutionStartTimestamp() {
   RN_GLOBAL_OBJ.nativePerformanceNow = () => 100; // monotonic clock like `performance.now()`
   RN_GLOBAL_OBJ.__BUNDLE_START_TIME__ = 50; // 50ms after time origin
+
+  const currentTimeMilliseconds = Date.now();
+  dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => currentTimeMilliseconds);
+  Date.now = jest.fn(() => currentTimeMilliseconds);
 }
 
 /**
@@ -1083,6 +1089,10 @@ function mockReactNativeBundleExecutionStartTimestamp() {
 function clearReactNativeBundleExecutionStartTimestamp() {
   delete RN_GLOBAL_OBJ.nativePerformanceNow;
   delete RN_GLOBAL_OBJ.__BUNDLE_START_TIME__;
+
+  if (dateNowSpy) {
+    dateNowSpy.mockRestore();
+  }
 }
 
 function set__DEV__(value: boolean) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
[Mocks `Date.now()` call so that no delay is introduced](https://github.com/getsentry/sentry-react-native/blob/7fd512afedf0e54a9572c2c31545ca61e5a59aed/packages/core/src/js/tracing/utils.ts#L108) during testing.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-react-native/issues/4197

Checking ten different runs that resulted in failure, the cause was the timestamp comparison tolerance. By default the test requires [2 decimal digits precision (`Math.abs(expected - received) < 0.005`)](https://github.com/jestjs/jest/blob/main/docs/ExpectAPI.md#expectclosetonumber-numdigits) but that fails frequently on CI on the following tests:
* Standalone App Start › adds ui kit init start mark as a child of the main app start span
* Standalone App Start › adds bundle execution before react root via private api (used by Sentry.wrap())
* Standalone App Start › Adds bundle execution span

|Test|Expected|Actual|Diff|
|---|---|---|---|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11441700199/job/31830365871)|1729519015.909|1729519015.926|0.017|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11856651594/job/33043360369)|1731675423.905|1731675423.927|0.022|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11950158984/job/33311093816)|1732180783.445|1732180783.467|0.022|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11835394808/job/32978091259)|1731580375.892|1731580375.93|**0.038**|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11820732439/job/32933747699)|1731512750.846|1731512750.854|0.008|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11396351682/job/31710037355)|1729218591.256|1729218591.263|0.007|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11550288665/job/32144969765)|1730104950.111|1730104950.122|0.011|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11362064986/job/31603124067)|1729068194.61|1729068194.618|0.008|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11347458716/job/31558896690)|1729000213.109|1729000213.114|0.005|
|[Run](https://github.com/getsentry/sentry-react-native/actions/runs/11557494716/job/32167681751)|1730130197.896|1730130197.909|0.013|

[To avoid any unexpected introduced delay](https://github.com/getsentry/sentry-react-native/blob/7fd512afedf0e54a9572c2c31545ca61e5a59aed/packages/core/src/js/tracing/utils.ts#L108) the `Date.now()` is mocked.

## :green_heart: How did you test it?
CI (multiple executions of the failed check), Locally by increasing the expected timestamp comparison accuracy to verify that no delay is introduced.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
