### PR TITLE
internal(samples): Add reload JS bundle for Expo sample

### DIFF
--- a/samples/expo/app/(tabs)/index.tsx
+++ b/samples/expo/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import { Button, StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
 import * as Sentry from '@sentry/react-native';
+import { reloadAppAsync } from 'expo';
 
 import { Text, View } from '@/components/Themed';
 import { setScopeProperties } from '@/utils/setScopeProperties';
@@ -82,6 +83,7 @@ export default function TabOneScreen() {
           console.log('Sentry.close() completed.');
         }}
       />
+      <Button title="Reload" onPress={() => reloadAppAsync()} />
     </View>
   );
 }


### PR DESCRIPTION
#skip-changelog 

This PR adds Reload JS Bundle button to the Expo sample app.

This helps with debugging issues related with bundle reload and session replay.

https://github.com/getsentry/sentry-react-native/issues/4234