### PR TITLE
ci: Update v5 CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,6 @@ on:
       - v5
   pull_request:
 
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,8 @@ concurrency:
 
 env:
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  IOS_DEVICE: 'iPhone 16'
+  IOS_RUNTIME: '18.1'
 
 jobs:
   diff_check:
@@ -43,7 +45,7 @@ jobs:
         platform: ["ios", "android"]
         include:
           - platform: ios
-            runs-on: macos-12
+            runs-on: macos-13
             name: iOS
             appPlain: test/perf/test-app-plain.ipa
           - platform: android
@@ -188,13 +190,9 @@ jobs:
           - platform: ios
             rn-version: '0.73.9'
             runs-on: macos-14 # uses m1 https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
-            runtime: 'latest'
-            device: 'iPhone 14'
           - platform: ios
             rn-version: '0.65.3'
-            runs-on: macos-12
-            runtime: 'latest'
-            device: 'iPhone 14'
+            runs-on: macos-13
           - platform: android
             runs-on: ubuntu-latest
         exclude:
@@ -345,14 +343,10 @@ jobs:
         include:
           - platform: ios
             rn-version: '0.73.9'
-            runs-on: macos-14 # uses m1 https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
-            runtime: 'latest'
-            device: 'iPhone 14'
+            runs-on: macos-15
           - platform: ios
             rn-version: '0.65.3'
-            runs-on: macos-latest
-            runtime: 'latest'
-            device: 'iPhone 14'
+            runs-on: macos-15
           - platform: android
             runs-on: ubuntu-latest
         exclude:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -174,8 +174,6 @@ jobs:
       USE_FRAMEWORKS: ${{ matrix.ios-use-frameworks }}
       PRODUCTION: ${{ matrix.build-type == 'production' && '1' || '0' }}
       RCT_NEW_ARCH_ENABLED: ${{ matrix.rn-architecture == 'new' && '1' || '0' }}
-      IOS_RUNTIME: ${{ matrix.runtime }}
-      IOS_DEVICE: ${{ matrix.device }}
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
@@ -363,7 +361,6 @@ jobs:
             rn-architecture: 'new'
     env:
       PLATFORM: ${{ matrix.platform }}
-      DEVICE: ${{ matrix.device }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,7 @@ on:
       - v5
   pull_request:
 
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
   test-ios:
     name: ios
-    runs-on: macos-14 # uses m1 https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
+    runs-on: macos-15
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
@@ -49,7 +49,7 @@ jobs:
         env:
           SCHEME: RNSentryCocoaTester
           CONFIGURATION: Release
-          DESTINATION: 'platform=iOS Simulator,OS=latest,name=iPhone 14'
+          DESTINATION: 'platform=iOS Simulator,OS=latest,name=iPhone 16'
         run: |
           env NSUnbufferedIO=YES \
             xcodebuild -workspace *.xcworkspace \

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -46,11 +46,9 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
-            runs-on: macos-14 # uses m1 https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
-            runtime: 'latest'
-            device: 'iPhone 14'
+            runs-on: macos-15
           - platform: macos
-            runs-on: macos-14
+            runs-on: macos-15
           - platform: android
             runs-on: ubuntu-latest
         exclude:
@@ -143,7 +141,8 @@ jobs:
             -workspace sentryreactnativesample.xcworkspace \
             -configuration "$CONFIG" \
             -scheme sentryreactnativesample \
-            -destination 'platform=iOS Simulator,OS=${{ matrix.runtime }},name=${{ matrix.device }}' \
+            -sdk 'iphonesimulator' \
+            -destination 'generic/platform=iOS Simulator' \
             ONLY_ACTIVE_ARCH=yes \
             -derivedDataPath "$derivedData" \
             build \

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -181,7 +181,8 @@ if (actions.includes('test')) {
     execSync(`set -o pipefail && xcodebuild \
                   -project node_modules/appium-webdriveragent/WebDriverAgent.xcodeproj \
                   -scheme WebDriverAgentRunner \
-                  -destination 'platform=iOS Simulator,OS=${runtime},name=${device}' \
+                  -sdk 'iphonesimulator' \
+                  -destination 'generic/platform=iOS Simulator' \
                   GCC_TREAT_WARNINGS_AS_ERRORS=0 \
                   COMPILER_INDEX_STORE_ENABLE=NO \
                   ONLY_ACTIVE_ARCH=yes \

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -152,7 +152,8 @@ if (actions.includes('build')) {
                     -workspace ${appName}.xcworkspace \
                     -configuration ${buildType} \
                     -scheme ${appName} \
-                    -destination 'platform=iOS Simulator,OS=${runtime},name=${device}' \
+                    -sdk 'iphonesimulator' \
+                    -destination 'generic/platform=iOS Simulator' \
                     ONLY_ACTIVE_ARCH=yes \
                     -derivedDataPath DerivedData \
                     build | tee xcodebuild.log | xcbeautify`,

--- a/src/js/client.ts
+++ b/src/js/client.ts
@@ -26,7 +26,6 @@ import { ignoreRequireCycleLogs } from './utils/ignorerequirecyclelogs';
 import { mergeOutcomes } from './utils/outcome';
 import { NATIVE } from './wrapper';
 
-
 /**
  * The Sentry React Native SDK Client.
  *


### PR DESCRIPTION
This PR backports CI fixes done in past week on the main branch back to v5, so we are able to release patches of v5 with confidence and passing tests. :)
