### PR TITLE
ci: Skip metrics on release branches

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
   metrics:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, auth_token_check]
-    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/heads/kw/ci') }}
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/heads/kw') }}
     env:
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
   metrics:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, auth_token_check]
-    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/' ) }}
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/heads/kw/ci') }}
     env:
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
   metrics:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, auth_token_check]
-    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/pull/4312') }}
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') }}
     env:
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
   metrics:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, auth_token_check]
-    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' }}
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/' ) }}
     env:
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
   metrics:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, auth_token_check]
-    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/heads/kw') }}
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') && !startsWith(github.ref, 'refs/pull/4312') }}
     env:
       SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:


### PR DESCRIPTION
This PR adds a skip for `Metrics` perf jobs on release branches, these jobs are flaky (negative app start diff) and thus can block releases for "no reason". 

#skip-changelog 


[Example of tests run with test condition](https://github.com/getsentry/sentry-react-native/actions/runs/12028115666/job/33530586109?pr=4312)