### PR TITLE
fix(cocoapods): Add missing `React-RCTFabric` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Add Replay Custom Masking for iOS, Android and Web ([#4224](https://github.com/getsentry/sentry-react-native/pull/4224), [#4265](https://github.com/getsentry/sentry-react-native/pull/4265), [#4272](https://github.com/getsentry/sentry-react-native/pull/4272))
+- Add Replay Custom Masking for iOS, Android and Web ([#4224](https://github.com/getsentry/sentry-react-native/pull/4224), [#4265](https://github.com/getsentry/sentry-react-native/pull/4265), [#4272](https://github.com/getsentry/sentry-react-native/pull/4272), [#4314](https://github.com/getsentry/sentry-react-native/pull/4314))
 
   ```jsx
   import * as Sentry from '@sentry/react-native';

--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
           "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
       }
 
+      s.dependency "React-RCTFabric" # Required for Fabric Components (like RCTViewComponentView)
       s.dependency "React-Codegen"
       s.dependency "RCT-Folly"
       s.dependency "RCTRequired"


### PR DESCRIPTION
This PR fixes failing builds on iOS new architecture on RN version 0.70 and older.

Before RN 0.71, there was no helper to setup the cocoapods dependencies (no install_modules_dependencies).

And so libraries needed to specifi the list of deps manually.

RNSentry was missing `React-RCTFabric` as no Fabric components were used in the SDK.

This changed in https://github.com/getsentry/sentry-react-native/pull/4224 and was not released.
