### PR TITLE
fix(exports): Return `lastEventId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Add Replay Custom Masking for iOS, Android and Web ([#4224](https://github.com/getsentry/sentry-react-native/pull/4224), [#4265](https://github.com/getsentry/sentry-react-native/pull/4265), [#4272](https://github.com/getsentry/sentry-react-native/pull/4272))
+- Add Replay Custom Masking for iOS, Android and Web ([#4224](https://github.com/getsentry/sentry-react-native/pull/4224), [#4265](https://github.com/getsentry/sentry-react-native/pull/4265), [#4272](https://github.com/getsentry/sentry-react-native/pull/4272), [#4314](https://github.com/getsentry/sentry-react-native/pull/4314))
 
   ```jsx
   import * as Sentry from '@sentry/react-native';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Return `lastEventId` export from `@sentry/core` ([#4315](https://github.com/getsentry/sentry-react-native/pull/4315))
+
 ## 6.4.0-beta.1
 
 ### Features

--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
           "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
       }
 
+      s.dependency "React-RCTFabric" # Required for Fabric Components (like RCTViewComponentView)
       s.dependency "React-Codegen"
       s.dependency "RCT-Folly"
       s.dependency "RCTRequired"

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -41,6 +41,7 @@ export {
   setCurrentClient,
   addEventProcessor,
   metricsDefault as metrics,
+  lastEventId,
 } from '@sentry/core';
 
 export {


### PR DESCRIPTION
Same as JS https://github.com/getsentry/sentry-javascript/issues/11951#issuecomment-2499563835

Fixes https://github.com/getsentry/sentry-react-native/issues/4311

