### PR TITLE
fix(span): Navigation Span should have no parent by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Add Replay Custom Masking for iOS, Android and Web ([#4224](https://github.com/getsentry/sentry-react-native/pull/4224), [#4265](https://github.com/getsentry/sentry-react-native/pull/4265), [#4272](https://github.com/getsentry/sentry-react-native/pull/4272))
+- Add Replay Custom Masking for iOS, Android and Web ([#4224](https://github.com/getsentry/sentry-react-native/pull/4224), [#4265](https://github.com/getsentry/sentry-react-native/pull/4265), [#4272](https://github.com/getsentry/sentry-react-native/pull/4272), [#4314](https://github.com/getsentry/sentry-react-native/pull/4314))
 
   ```jsx
   import * as Sentry from '@sentry/react-native';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Fixes
 
 - Return `lastEventId` export from `@sentry/core` ([#4315](https://github.com/getsentry/sentry-react-native/pull/4315))
+- Navigation Span should have no parent by default ([#4326](https://github.com/getsentry/sentry-react-native/pull/4326))
+
 ### Dependencies
 
 - Bump CLI from v2.38.2 to v2.39.1 ([#4305](https://github.com/getsentry/sentry-react-native/pull/4305), [#4316](https://github.com/getsentry/sentry-react-native/pull/4316))

--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
           "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
       }
 
+      s.dependency "React-RCTFabric" # Required for Fabric Components (like RCTViewComponentView)
       s.dependency "React-Codegen"
       s.dependency "RCT-Folly"
       s.dependency "RCTRequired"

--- a/packages/core/src/js/tracing/span.ts
+++ b/packages/core/src/js/tracing/span.ts
@@ -57,6 +57,7 @@ export const startIdleNavigationSpan = (
   }
 
   const activeSpan = getActiveSpan();
+  clearActiveSpanFromScope(getCurrentScope());
   if (activeSpan && isRootSpan(activeSpan) && isSentryInteractionSpan(activeSpan)) {
     logger.log(
       `[startIdleNavigationSpan] Canceling ${
@@ -128,9 +129,9 @@ export function isSentryInteractionSpan(span: Span): boolean {
   return [SPAN_ORIGIN_AUTO_INTERACTION, SPAN_ORIGIN_MANUAL_INTERACTION].includes(spanToJSON(span).origin);
 }
 
-const SCOPE_SPAN_FIELD = '_sentrySpan';
+export const SCOPE_SPAN_FIELD = '_sentrySpan';
 
-type ScopeWithMaybeSpan = Scope & {
+export type ScopeWithMaybeSpan = Scope & {
   [SCOPE_SPAN_FIELD]?: Span;
 };
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes a bug introduced in RN SDK V6. Where unfinished navigations spans are set as parents of newly created navigations spans.

This is unexpected as navigations span should be a active root span (aka transaction in the SDK V5).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This issue was reported by the sales team working with clients trying out the new SDK V6.

## :green_heart: How did you test it?
added unit test for the behaviour, tests failed before the fix.

Also tested this with the Sentry RN Demo App.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes