### PR TITLE
fix(expo): Upload script should not log out env file not found errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Fixes
 
 - Return `lastEventId` export from `@sentry/core` ([#4315](https://github.com/getsentry/sentry-react-native/pull/4315))
+- Don't log file not found errors when loading envs in `sentry-expo-upload-sourcemaps` ([#4332](https://github.com/getsentry/sentry-react-native/pull/4332))
+
 ### Dependencies
 
 - Bump CLI from v2.38.2 to v2.39.1 ([#4305](https://github.com/getsentry/sentry-react-native/pull/4305), [#4316](https://github.com/getsentry/sentry-react-native/pull/4316))

--- a/packages/core/scripts/expo-upload-sourcemaps.js
+++ b/packages/core/scripts/expo-upload-sourcemaps.js
@@ -111,8 +111,12 @@ function loadDotenv(dotenvPath) {
 
     Object.assign(process.env, dotenvResult);
   } catch (error) {
-    console.warn('⚠️ Failed to load environment variables using dotenv.');
-    console.warn(error);
+    if (error.code === 'ENOENT') {
+      // noop if file does not exist
+    } else {
+      console.warn('⚠️ Failed to load environment variables using dotenv.');
+      console.warn(error);
+    }
   }
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement


## :scroll: Description
<!--- Describe your changes in detail -->
This PR exludes the file not dound error logs from the `sentry-expo-sourcemaps-upload` script output.

The script before is not failing, but the output is cluttered with irrelevant error stack. 

## :green_heart: How did you test it?
run the upload script without `.env.sentry-build-plugin`

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
