### PR TITLE
chore(samples): Update Expo Sample export scripts

### DIFF
--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -25,7 +25,7 @@ const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: !isExpoGo(), // This is not supported in Expo Go.
 });
 
-process.env.EXPO_SKIP_DURING_EXPORT !== 'true' && Sentry.init({
+Sentry.init({
   // Replace the example DSN below with your own DSN:
   dsn: SENTRY_INTERNAL_DSN,
   debug: true,

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -10,7 +10,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "ts:check": "tsc",
-    "export": "EXPO_SKIP_DURING_EXPORT='true' expo export --dump-sourcemap --clear",
+    "export": "expo export --dump-sourcemap --clear --platform all",
+    "export:web": "expo export --dump-sourcemap --clear --platform web",
     "prebuild": "expo prebuild --clean --no-install",
     "set-version": "npx react-native-version --skip-tag --never-amend"
   },


### PR DESCRIPTION
This PR adds `export:web` as to deplay it's common to only export web without the mobile js bundles.

This PR also removes the `EXPO_SKIP_DURING_EXPORT` since since 5.21.0 release (https://github.com/getsentry/sentry-react-native/pull/3730) `___SENTRY_METRO_DEV_SERVER___` is used internally to disable Sentry during the static paths render.