### PR TITLE
chore: update scripts/update-android.sh to 7.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Bump Cocoa SDK from v8.37.0 to v8.41.0 ([#4309](https://github.com/getsentry/sentry-react-native/pull/4309))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8410)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.37.0...8.41.0)
+- Bump Android SDK from v7.15.0 to v7.18.1 ([#4329](https://github.com/getsentry/sentry-react-native/pull/4329))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7181)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.15.0...7.18.1)
 
 ## 5.35.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Bump Cocoa SDK from v8.37.0 to v8.41.0 ([#4309](https://github.com/getsentry/sentry-react-native/pull/4309))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8410)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.37.0...8.41.0)
-- Bump Android SDK from v7.15.0 to v7.18.1 ([#4329](https://github.com/getsentry/sentry-react-native/pull/4329))
+- Bump Android SDK from v7.15.0 to v7.18.1 ([#4340](https://github.com/getsentry/sentry-react-native/pull/4340))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#7181)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.15.0...7.18.1)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,5 +54,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:7.15.0'
+    api 'io.sentry:sentry-android:7.18.1'
 }


### PR DESCRIPTION
Bump android to 7.18.1 to include the latest SR fixes in v5.

There were no changes in RN SDK specific to android so this PR is purely dep bump.