### PR TITLE
fix(ios): Disable HTTP Client errors in sentry-cocoa to avoid duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Return `lastEventId` export from `@sentry/core` ([#4315](https://github.com/getsentry/sentry-react-native/pull/4315))
 - Don't log file not found errors when loading envs in `sentry-expo-upload-sourcemaps` ([#4332](https://github.com/getsentry/sentry-react-native/pull/4332))
 - Navigation Span should have no parent by default ([#4326](https://github.com/getsentry/sentry-react-native/pull/4326))
+- Disable HTTP Client Errors on iOS ([#4347](https://github.com/getsentry/sentry-react-native/pull/4347))
 
 ### Dependencies
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.mm
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.mm
@@ -38,6 +38,22 @@ XCTAssertEqual(actualOptions.tracesSampler, nil, @"Traces sampler should not be 
 XCTAssertEqual(actualOptions.enableTracing, false, @"EnableTracing should not be passed to native");
 }
 
+- (void)testCaptureFailedRequestsIsDisabled
+{
+    RNSentry *rnSentry = [[RNSentry alloc] init];
+    NSError *error = nil;
+
+    NSDictionary *_Nonnull mockedReactNativeDictionary = @{
+        @"dsn" : @"https://abcd@efgh.ingest.sentry.io/123456",
+    };
+    SentryOptions *actualOptions = [rnSentry createOptionsWithDictionary:mockedReactNativeDictionary
+                                                                   error:&error];
+
+    XCTAssertNotNil(actualOptions, @"Did not create sentry options");
+    XCTAssertNil(error, @"Should not pass no error");
+    XCTAssertFalse(actualOptions.enableCaptureFailedRequests);
+}
+
 - (void)testCreateOptionsWithDictionaryNativeCrashHandlingDefault
 {
     RNSentry *rnSentry = [[RNSentry alloc] init];

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -215,7 +215,7 @@ RCT_EXPORT_METHOD(initNativeSdk
     }
 
     // Failed requests can only be enabled in one SDK to avoid duplicates
-    sentryOptions.enableCaptureFailedRequests = @NO;
+    sentryOptions.enableCaptureFailedRequests = NO;
 
     return sentryOptions;
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
- fixes https://github.com/getsentry/sentry-react-native/issues/4343

## :green_heart: How did you test it?
native tests, sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
