### PR TITLE
feat: Add RN SDK package to `sdk.packages` on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   ```
 
 - Export `Span` type from `@sentry/types` ([#4345](https://github.com/getsentry/sentry-react-native/pull/4345))
+- Add RN SDK package to `sdk.packages` on Android ([#4380](https://github.com/getsentry/sentry-react-native/pull/4380))
 
 ### Fixes
 

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -93,8 +93,6 @@ public class RNSentryModuleImpl {
 
   public static final String NAME = "RNSentry";
 
-  private static final String NATIVE_SDK_NAME = "sentry.native.android.react-native";
-  private static final String ANDROID_SDK_NAME = "sentry.java.android.react-native";
   private static final ILogger logger = new AndroidLogger(NAME);
   private static final BuildInfoProvider buildInfo = new BuildInfoProvider(logger);
   private static final String modulesPath = "modules.json";
@@ -191,13 +189,14 @@ public class RNSentryModuleImpl {
       @NotNull SentryAndroidOptions options, @NotNull ReadableMap rnOptions, ILogger logger) {
     @Nullable SdkVersion sdkVersion = options.getSdkVersion();
     if (sdkVersion == null) {
-      sdkVersion = new SdkVersion(ANDROID_SDK_NAME, BuildConfig.VERSION_NAME);
+      sdkVersion = new SdkVersion(RNSentryVersion.ANDROID_SDK_NAME, BuildConfig.VERSION_NAME);
     } else {
-      sdkVersion.setName(ANDROID_SDK_NAME);
+      sdkVersion.setName(RNSentryVersion.ANDROID_SDK_NAME);
     }
+    sdkVersion.addPackage(RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_NAME, RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_VERSION);
 
     options.setSentryClientName(sdkVersion.getName() + "/" + sdkVersion.getVersion());
-    options.setNativeSdkName(NATIVE_SDK_NAME);
+    options.setNativeSdkName(RNSentryVersion.NATIVE_SDK_NAME);
     options.setSdkVersion(sdkVersion);
 
     if (rnOptions.hasKey("debug") && rnOptions.getBoolean("debug")) {
@@ -970,10 +969,10 @@ public class RNSentryModuleImpl {
     SdkVersion sdk = event.getSdk();
     if (sdk != null) {
       switch (sdk.getName()) {
-        case NATIVE_SDK_NAME:
+        case RNSentryVersion.NATIVE_SDK_NAME:
           setEventEnvironmentTag(event, "native");
           break;
-        case ANDROID_SDK_NAME:
+        case RNSentryVersion.ANDROID_SDK_NAME:
           setEventEnvironmentTag(event, "java");
           break;
         default:

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
@@ -1,0 +1,8 @@
+package io.sentry.react;
+
+class RNSentryVersion {
+    static final String REACT_NATIVE_SDK_PACKAGE_NAME = "npm:@sentry/react-native";
+    static final String REACT_NATIVE_SDK_PACKAGE_VERSION = "6.4.0";
+    static final String NATIVE_SDK_NAME = "sentry.native.android.react-native";
+    static final String ANDROID_SDK_NAME = "sentry.java.android.react-native";
+}

--- a/scripts/version-bump.js
+++ b/scripts/version-bump.js
@@ -4,7 +4,10 @@ const replace = require('replace-in-file');
 const pjson = require('../packages/core/package.json');
 
 replace({
-  files: ['packages/core/src/js/version.ts'],
+  files: [
+    'packages/core/src/js/version.ts',
+    'packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java',
+  ],
   from: /\d+\.\d+.\d+(?:-\w+(?:\.\w+)?)?/g,
   to: pjson.version,
 })


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This improves session replays metadata, as now the events will contain name and version of the RN sdk in the `event.sdk.packages`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This helps whe debuggin session replay in Sentry product.

## :green_heart: How did you test it?
sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
