### PR TITLE
Feat: add spotlight vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Spotlight",
+      "type": "shell",
+      "command": "npx @spotlightjs/spotlight",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "group": {
+        "kind": "none",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
         "panel": "new"
       },
       "group": {
-        "kind": "none",
+        "kind": "build",
         "isDefault": true
       }
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

A shortcut to open spotlight UI from VSCode

![image](https://github.com/user-attachments/assets/c87ce699-409f-46c2-b97a-77cb76ac9751)

From the terminal UI, on the options for opening a new terminal, you can select to run a task

![image](https://github.com/user-attachments/assets/51dd3005-e26f-45b2-a083-670bd372eebc)

Then on top you will see an option to run spotlight, after clicking it, a new terminal will open and spotlight will be ready/listening your events.

![image](https://github.com/user-attachments/assets/fbfc9764-67be-4d46-bc22-f9603ac01ac6)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It makes the process to open spotlight from VS Code easier 

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps


#skip-changelog