### PR TITLE
ci(test): Fixes metrics (new, android) failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,6 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
-## Unreleased
-
-### Dependencies
-
-- Bump CLI from v2.39.1 to v2.40.0 ([#4412](https://github.com/getsentry/sentry-react-native/pull/4412))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2400)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.39.1...2.40.0)
-
 ## 6.5.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@expo/swiftlint": "^0.57.1",
-    "@sentry/cli": "2.40.0",
+    "@sentry/cli": "2.39.1",
     "clang-format": "^1.8.0",
     "downlevel-dts": "^0.11.0",
     "google-java-format": "^1.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@sentry/babel-plugin-component-annotate": "2.20.1",
     "@sentry/browser": "8.47.0",
-    "@sentry/cli": "2.40.0",
+    "@sentry/cli": "2.39.1",
     "@sentry/core": "8.47.0",
     "@sentry/react": "8.47.0",
     "@sentry/types": "8.47.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7652,66 +7652,66 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/cli-darwin@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli-darwin@npm:2.40.0"
+"@sentry/cli-darwin@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli-darwin@npm:2.39.1"
   conditions: os=darwin
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-arm64@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli-linux-arm64@npm:2.40.0"
+"@sentry/cli-linux-arm64@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli-linux-arm64@npm:2.39.1"
   conditions: (os=linux | os=freebsd) & cpu=arm64
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-arm@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli-linux-arm@npm:2.40.0"
+"@sentry/cli-linux-arm@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli-linux-arm@npm:2.39.1"
   conditions: (os=linux | os=freebsd) & cpu=arm
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-i686@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli-linux-i686@npm:2.40.0"
+"@sentry/cli-linux-i686@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli-linux-i686@npm:2.39.1"
   conditions: (os=linux | os=freebsd) & (cpu=x86 | cpu=ia32)
   languageName: node
   linkType: hard
 
-"@sentry/cli-linux-x64@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli-linux-x64@npm:2.40.0"
+"@sentry/cli-linux-x64@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli-linux-x64@npm:2.39.1"
   conditions: (os=linux | os=freebsd) & cpu=x64
   languageName: node
   linkType: hard
 
-"@sentry/cli-win32-i686@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli-win32-i686@npm:2.40.0"
+"@sentry/cli-win32-i686@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli-win32-i686@npm:2.39.1"
   conditions: os=win32 & (cpu=x86 | cpu=ia32)
   languageName: node
   linkType: hard
 
-"@sentry/cli-win32-x64@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli-win32-x64@npm:2.40.0"
+"@sentry/cli-win32-x64@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli-win32-x64@npm:2.39.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@sentry/cli@npm:2.40.0":
-  version: 2.40.0
-  resolution: "@sentry/cli@npm:2.40.0"
+"@sentry/cli@npm:2.39.1":
+  version: 2.39.1
+  resolution: "@sentry/cli@npm:2.39.1"
   dependencies:
-    "@sentry/cli-darwin": 2.40.0
-    "@sentry/cli-linux-arm": 2.40.0
-    "@sentry/cli-linux-arm64": 2.40.0
-    "@sentry/cli-linux-i686": 2.40.0
-    "@sentry/cli-linux-x64": 2.40.0
-    "@sentry/cli-win32-i686": 2.40.0
-    "@sentry/cli-win32-x64": 2.40.0
+    "@sentry/cli-darwin": 2.39.1
+    "@sentry/cli-linux-arm": 2.39.1
+    "@sentry/cli-linux-arm64": 2.39.1
+    "@sentry/cli-linux-i686": 2.39.1
+    "@sentry/cli-linux-x64": 2.39.1
+    "@sentry/cli-win32-i686": 2.39.1
+    "@sentry/cli-win32-x64": 2.39.1
     https-proxy-agent: ^5.0.0
     node-fetch: ^2.6.7
     progress: ^2.0.3
@@ -7734,7 +7734,7 @@ __metadata:
       optional: true
   bin:
     sentry-cli: bin/sentry-cli
-  checksum: 2b59d2c3e405d62b63d62ec3833dedb6f0a22d68cffe8ad74ee35306f42171fc56c25d9daff87a459d79b17b86d94be34620185cfeb41eb4a4718f7eef4f811e
+  checksum: 9dc0129d618bc01d178609388bf44d731747057a67bb512e6e1f12e6c428096712a44c965d8fc9f55bdb7930f6565a3065c3cb308bf72399ac16d95b3721c1a1
   languageName: node
   linkType: hard
 
@@ -7809,7 +7809,7 @@ __metadata:
     "@sentry-internal/typescript": 8.47.0
     "@sentry/babel-plugin-component-annotate": 2.20.1
     "@sentry/browser": 8.47.0
-    "@sentry/cli": 2.40.0
+    "@sentry/cli": 2.39.1
     "@sentry/core": 8.47.0
     "@sentry/react": 8.47.0
     "@sentry/types": 8.47.0
@@ -24296,7 +24296,7 @@ __metadata:
   resolution: "sentry-react-native@workspace:."
   dependencies:
     "@expo/swiftlint": ^0.57.1
-    "@sentry/cli": 2.40.0
+    "@sentry/cli": 2.39.1
     clang-format: ^1.8.0
     downlevel-dts: ^0.11.0
     google-java-format: ^1.4.0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Revert "chore: update scripts/update-cli.sh to 2.40.0 (#4412)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes [metrics (new, android)](https://github.com/getsentry/sentry-react-native/actions/runs/12628837574/job/35195892800) failure

```
[ 53%] Building CXX object lib/Support/CMakeFiles/hermesSupport.dir/SHA1.cpp.o
In file included from /home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/lib/Support/SHA1.cpp:8:
/home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/include/hermes/Support/SHA1.h:17:25: error: ‘uint8_t’ was not declared in this scope
   17 | using SHA1 = std::array<uint8_t, SHA1_NUM_BYTES>;
      |                         ^~~~~~~
/home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/include/hermes/Support/SHA1.h:13:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
[ 53%] Building CXX object lib/CMakeFiles/hermesOptimizer.dir/Optimizer/Scalar/InstructionEscapeAnalysis.cpp.o
[ 56%] Building CXX object lib/CMakeFiles/hermesOptimizer.dir/Optimizer/Scalar/TDZDedup.cpp.o
   12 | #include <string>
  +++ |+#include <cstdint>
   13 | 
/home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/include/hermes/Support/SHA1.h:17:48: error: template argument 1 is invalid
   17 | using SHA1 = std::array<uint8_t, SHA1_NUM_BYTES>;
      |                                                ^
/home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/include/hermes/Support/SHA1.h:19:32: error: ‘SHA1’ does not name a type
   19 | std::string hashAsString(const SHA1 &hash);
      |                                ^~~~
/home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/lib/Support/SHA1.cpp:14:32: error: ‘SHA1’ does not name a type
   14 | std::string hashAsString(const SHA1 &hash) {
      |                                ^~~~
/home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/lib/Support/SHA1.cpp: In function ‘std::string hermes::hashAsString(const int&)’:
/home/runner/work/sentry-react-native/sentry-react-native/performance-tests/TestAppSentry/node_modules/react-native/sdks/hermes/lib/Support/SHA1.cpp:19:44: error: invalid types ‘const int[unsigned int]’ for array subscript
   19 |     snprintf(buf + (i * 2), 3, "%02x", hash[i]);
      |                                            ^
gmake[3]: *** [lib/Support/CMakeFiles/hermesSupport.dir/build.make:277: lib/Support/CMakeFiles/hermesSupport.dir/SHA1.cpp.o] Error 1
```

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog