### PR TITLE
chore(ci): Pin the CI Environment to Ubuntu 22.04 for metrics android

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
             name: iOS
             appPlain: performance-tests/test-app-plain.ipa
           - platform: android
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-22.04
             name: Android
             appPlain: performance-tests/TestAppPlain/android/app/build/outputs/apk/release/app-release.apk
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,6 +43,7 @@ jobs:
             name: iOS
             appPlain: performance-tests/test-app-plain.ipa
           - platform: android
+            # Not using the latest version due to a known issue: https://github.com/getsentry/sentry-react-native/issues/4418
             runs-on: ubuntu-22.04
             name: Android
             appPlain: performance-tests/TestAppPlain/android/app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Pins the CI Environment to Ubuntu 22.04 for metrics Android to avoid the CI failure as described in https://github.com/getsentry/sentry-react-native/issues/4418#issuecomment-2577512319

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix https://github.com/getsentry/sentry-react-native/issues/4418

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
- [Upgrade the performance test apps](https://github.com/getsentry/sentry-react-native/issues/4426) (TestAppPlain/TestAppSentry) on the latest RN version so that they run with latest Ubuntu.

#skip-changelog