### PR TITLE
Fix sdk name for replay tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Use proper SDK name for Session Replay tags ([#4428](https://github.com/getsentry/sentry-react-native/pull/4428))
+
 ### Changes
 
 - Rename `navigation.processing` span to more expressive `Navigation dispatch to screen A mounted/navigation cancelled` ([#4423](https://github.com/getsentry/sentry-react-native/pull/4423))

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -340,7 +340,7 @@ public class RNSentryModuleImpl {
   private SentryReplayOptions getReplayOptions(@NotNull ReadableMap rnOptions) {
     final SdkVersion replaySdkVersion =
         new SdkVersion(
-            RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_NAME,
+            RNSentryVersion.REACT_NATIVE_SDK_NAME,
             RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_VERSION);
     @NotNull
     final SentryReplayOptions androidReplayOptions =

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
@@ -5,4 +5,5 @@ class RNSentryVersion {
   static final String REACT_NATIVE_SDK_PACKAGE_VERSION = "6.5.0";
   static final String NATIVE_SDK_NAME = "sentry.native.android.react-native";
   static final String ANDROID_SDK_NAME = "sentry.java.android.react-native";
+  static final String REACT_NATIVE_SDK_NAME = "sentry.javascript.react-native";
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Use proper name for the RN SDK in replay tags

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
