### PR TITLE
chore: Initialize `RNSentryTimeToDisplay` during native module `init` on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Rename `navigation.processing` span to more expressive `Navigation dispatch to screen A mounted/navigation cancelled` ([#4423](https://github.com/getsentry/sentry-react-native/pull/4423))
 - Add RN SDK package to `sdk.packages` for Cocoa ([#4381](https://github.com/getsentry/sentry-react-native/pull/4381))
 
+### Internal
+
+- Initialize `RNSentryTimeToDisplay` during native module `init` on iOS ([#4443](https://github.com/getsentry/sentry-react-native/pull/4443))
+
 ### Dependencies
 
 - Bump CLI from v2.39.1 to v2.40.0 ([#4412](https://github.com/getsentry/sentry-react-native/pull/4412))

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -78,6 +78,14 @@ static bool hasFetchedAppStart;
     return YES;
 }
 
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _timeToDisplay = [[RNSentryTimeToDisplay alloc] init];
+    }
+    return self;
+}
+
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(initNativeSdk
@@ -151,8 +159,6 @@ RCT_EXPORT_METHOD(initNativeSdk
     [mutableOptions removeObjectForKey:@"tracesSampleRate"];
     [mutableOptions removeObjectForKey:@"tracesSampler"];
     [mutableOptions removeObjectForKey:@"enableTracing"];
-
-    _timeToDisplay = [[RNSentryTimeToDisplay alloc] init];
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
     [RNSentryReplay updateOptions:mutableOptions];


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-react-native/issues/3608

This PR moved the `RNSentryTimeToDisplay` init to the module init, so the time to display functionality is not dependent on the auto init from JS.