### PR TITLE
fix(cocoa): Update the RN SDK version to current 6.5.0

### DIFF
--- a/packages/core/ios/RNSentryVersion.m
+++ b/packages/core/ios/RNSentryVersion.m
@@ -2,4 +2,4 @@
 
 NSString *const NATIVE_SDK_NAME = @"sentry.cocoa.react-native";
 NSString *const REACT_NATIVE_SDK_PACKAGE_NAME = @"npm:@sentry/react-native";
-NSString *const REACT_NATIVE_SDK_PACKAGE_VERSION = @"6.4.0";
+NSString *const REACT_NATIVE_SDK_PACKAGE_VERSION = @"6.5.0";


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->

The baked in value is automatically updated during version release, but when adding this feature this value was set incorrectly to 6.4.0 instead of 6.5.0.

- Update script: https://github.com/getsentry/sentry-react-native/blob/main/scripts/version-bump.js#L10

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

#skip-changelog 