### PR TITLE
feat: Send Sentry react-native SDK version in the session replay event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Features
+
+- Send Sentry react-native SDK version in the session replay event ()
+
 ### Fixes
 
 - Use proper SDK name for Session Replay tags ([#4428](https://github.com/getsentry/sentry-react-native/pull/4428))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Send Sentry react-native SDK version in the session replay event ()
+- Send Sentry react-native SDK version in the session replay event (#4450)
 
 ### Fixes
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
@@ -48,12 +48,13 @@ final class RNSentryReplayOptions: XCTestCase {
     }
 
     func assertAllDefaultReplayOptionsAreNotNil(replayOptions: [String: Any]) {
-        XCTAssertEqual(replayOptions.count, 5)
+        XCTAssertEqual(replayOptions.count, 6)
         XCTAssertNotNil(replayOptions["sessionSampleRate"])
         XCTAssertNotNil(replayOptions["errorSampleRate"])
         XCTAssertNotNil(replayOptions["maskAllImages"])
         XCTAssertNotNil(replayOptions["maskAllText"])
         XCTAssertNotNil(replayOptions["maskedViewClasses"])
+        XCTAssertNotNil(replayOptions["sdkInfo"])
     }
 
     func testSessionSampleRate() {

--- a/packages/core/ios/RNSentryReplay.mm
+++ b/packages/core/ios/RNSentryReplay.mm
@@ -1,10 +1,10 @@
 #import "RNSentryReplay.h"
 #import "RNSentryReplayBreadcrumbConverterHelper.h"
+#import "RNSentryVersion.h"
 #import "React/RCTTextView.h"
 #import "Replay/RNSentryReplayMask.h"
 #import "Replay/RNSentryReplayUnmask.h"
 #import <Sentry/PrivateSentrySDKOnly.h>
-#import "RNSentryVersion.h"
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 
@@ -28,10 +28,8 @@
         @"maskAllImages" : replayOptions[@"maskAllImages"] ?: [NSNull null],
         @"maskAllText" : replayOptions[@"maskAllText"] ?: [NSNull null],
         @"maskedViewClasses" : [RNSentryReplay getReplayRNRedactClasses:replayOptions],
-        @"sdkInfo": @{
-            @"name": REACT_NATIVE_SDK_NAME,
-            @"version": REACT_NATIVE_SDK_PACKAGE_VERSION
-        }
+        @"sdkInfo" :
+            @ { @"name" : REACT_NATIVE_SDK_NAME, @"version" : REACT_NATIVE_SDK_PACKAGE_VERSION }
     }
                forKey:@"sessionReplay"];
 }

--- a/packages/core/ios/RNSentryReplay.mm
+++ b/packages/core/ios/RNSentryReplay.mm
@@ -4,6 +4,7 @@
 #import "Replay/RNSentryReplayMask.h"
 #import "Replay/RNSentryReplayUnmask.h"
 #import <Sentry/PrivateSentrySDKOnly.h>
+#import "RNSentryVersion.h"
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 
@@ -27,6 +28,10 @@
         @"maskAllImages" : replayOptions[@"maskAllImages"] ?: [NSNull null],
         @"maskAllText" : replayOptions[@"maskAllText"] ?: [NSNull null],
         @"maskedViewClasses" : [RNSentryReplay getReplayRNRedactClasses:replayOptions],
+        @"sdkInfo": @{
+            @"name": REACT_NATIVE_SDK_NAME,
+            @"version": REACT_NATIVE_SDK_PACKAGE_VERSION
+        }
     }
                forKey:@"sessionReplay"];
 }

--- a/packages/core/ios/RNSentryVersion.h
+++ b/packages/core/ios/RNSentryVersion.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
 extern NSString *const NATIVE_SDK_NAME;
+extern NSString *const REACT_NATIVE_SDK_NAME;
 extern NSString *const REACT_NATIVE_SDK_PACKAGE_NAME;
 extern NSString *const REACT_NATIVE_SDK_PACKAGE_VERSION;

--- a/packages/core/ios/RNSentryVersion.m
+++ b/packages/core/ios/RNSentryVersion.m
@@ -1,5 +1,6 @@
 #import "RNSentryVersion.h"
 
 NSString *const NATIVE_SDK_NAME = @"sentry.cocoa.react-native";
+NSString *const REACT_NATIVE_SDK_NAME = @"sentry.javascript.react-native";
 NSString *const REACT_NATIVE_SDK_PACKAGE_NAME = @"npm:@sentry/react-native";
 NSString *const REACT_NATIVE_SDK_PACKAGE_VERSION = @"6.4.0";


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Sending the version and sdk name in the session replay event to show up at Tags tab.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
