### PR TITLE
Adds utility class for converting `JsonObject` to `WritableMap`

### DIFF
--- a/packages/core/RNSentryAndroidTester/app/src/androidTest/java/io/sentry/react/RNSentryJsonConverterTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/androidTest/java/io/sentry/react/RNSentryJsonConverterTest.kt
@@ -1,4 +1,4 @@
-package io.sentry.rnsentryandroidtester
+package io.sentry.react
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.facebook.react.bridge.WritableArray

--- a/packages/core/RNSentryAndroidTester/app/src/androidTest/java/io/sentry/rnsentryandroidtester/RNSentryJsonConverterTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/androidTest/java/io/sentry/rnsentryandroidtester/RNSentryJsonConverterTest.kt
@@ -1,0 +1,103 @@
+package io.sentry.rnsentryandroidtester
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import io.sentry.react.RNSentryJsonConverter.convertToWritable
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RNSentryJsonConverterTest {
+    @Test
+    fun testConvertToWritableWithSimpleJsonObject() {
+        val jsonObject =
+            JSONObject().apply {
+                put("floatKey", 12.3f)
+                put("doubleKey", 12.3)
+                put("intKey", 123)
+                put("stringKey", "test")
+                put("nullKey", JSONObject.NULL)
+            }
+
+        val result: WritableMap? = convertToWritable(jsonObject)
+
+        assertNotNull(result)
+        assertEquals(12.3, result!!.getDouble("floatKey"), 0.0001)
+        assertEquals(12.3, result.getDouble("doubleKey"), 0.0)
+        assertEquals(123, result.getInt("intKey"))
+        assertEquals("test", result.getString("stringKey"))
+        assertNull(result.getString("nullKey"))
+    }
+
+    @Test
+    fun testConvertToWritableWithNestedJsonObject() {
+        val jsonObject =
+            JSONObject().apply {
+                put(
+                    "nested",
+                    JSONObject().apply {
+                        put("key", "value")
+                    },
+                )
+            }
+
+        val result: WritableMap? = convertToWritable(jsonObject)
+
+        assertNotNull(result)
+        val nestedMap = result!!.getMap("nested")
+        assertNotNull(nestedMap)
+        assertEquals("value", nestedMap!!.getString("key"))
+    }
+
+    @Test
+    fun testConvertToWritableWithJsonArray() {
+        val jsonArray =
+            JSONArray().apply {
+                put(1)
+                put(2.5)
+                put("string")
+                put(JSONObject.NULL)
+            }
+
+        val result: WritableArray = convertToWritable(jsonArray)
+
+        assertEquals(1, result.getInt(0))
+        assertEquals(2.5, result.getDouble(1), 0.0)
+        assertEquals("string", result.getString(2))
+        assertNull(result.getString(3))
+    }
+
+    @Test
+    fun testConvertToWritableWithNestedJsonArray() {
+        val jsonObject =
+            JSONObject().apply {
+                put(
+                    "array",
+                    JSONArray().apply {
+                        put(
+                            JSONObject().apply {
+                                put("key1", "value1")
+                            },
+                        )
+                        put(
+                            JSONObject().apply {
+                                put("key2", "value2")
+                            },
+                        )
+                    },
+                )
+            }
+
+        val result: WritableMap? = convertToWritable(jsonObject)
+
+        val array = result?.getArray("array")
+        assertEquals("value1", array?.getMap(0)?.getString("key1"))
+        assertEquals("value2", array?.getMap(1)?.getString("key2"))
+    }
+}

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryJsonConverter.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryJsonConverter.java
@@ -1,0 +1,76 @@
+package io.sentry.react;
+
+import com.facebook.react.bridge.JavaOnlyArray;
+import com.facebook.react.bridge.JavaOnlyMap;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import io.sentry.android.core.AndroidLogger;
+import java.util.Iterator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public final class RNSentryJsonConverter {
+  public static final String NAME = "RNSentry.RNSentryJsonConverter";
+
+  private static final ILogger logger = new AndroidLogger(NAME);
+
+  private RNSentryJsonConverter() {
+    throw new AssertionError("Utility class should not be instantiated");
+  }
+
+  @Nullable
+  public static WritableMap convertToWritable(@NotNull JSONObject jsonObject) {
+    try {
+      WritableMap writableMap = new JavaOnlyMap();
+      Iterator<String> iterator = jsonObject.keys();
+      while (iterator.hasNext()) {
+        String key = iterator.next();
+        Object value = jsonObject.get(key);
+        if (value instanceof Float || value instanceof Double) {
+          writableMap.putDouble(key, jsonObject.getDouble(key));
+        } else if (value instanceof Number) {
+          writableMap.putInt(key, jsonObject.getInt(key));
+        } else if (value instanceof String) {
+          writableMap.putString(key, jsonObject.getString(key));
+        } else if (value instanceof JSONObject) {
+          writableMap.putMap(key, convertToWritable(jsonObject.getJSONObject(key)));
+        } else if (value instanceof JSONArray) {
+          writableMap.putArray(key, convertToWritable(jsonObject.getJSONArray(key)));
+        } else if (value == JSONObject.NULL) {
+          writableMap.putNull(key);
+        }
+      }
+      return writableMap;
+    } catch (JSONException e) {
+      logger.log(SentryLevel.ERROR, "Error parsing json object:" + e.getMessage());
+      return null;
+    }
+  }
+
+  @NotNull
+  public static WritableArray convertToWritable(@NotNull JSONArray jsonArray) throws JSONException {
+    WritableArray writableArray = new JavaOnlyArray();
+    for (int i = 0; i < jsonArray.length(); i++) {
+      Object value = jsonArray.get(i);
+      if (value instanceof Float || value instanceof Double) {
+        writableArray.pushDouble(jsonArray.getDouble(i));
+      } else if (value instanceof Number) {
+        writableArray.pushInt(jsonArray.getInt(i));
+      } else if (value instanceof String) {
+        writableArray.pushString(jsonArray.getString(i));
+      } else if (value instanceof JSONObject) {
+        writableArray.pushMap(convertToWritable(jsonArray.getJSONObject(i)));
+      } else if (value instanceof JSONArray) {
+        writableArray.pushArray(convertToWritable(jsonArray.getJSONArray(i)));
+      } else if (value == JSONObject.NULL) {
+        writableArray.pushNull();
+      }
+    }
+    return writableArray;
+  }
+}

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryJsonConverter.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryJsonConverter.java
@@ -14,7 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public final class RNSentryJsonConverter {
+final class RNSentryJsonConverter {
   public static final String NAME = "RNSentry.RNSentryJsonConverter";
 
   private static final ILogger logger = new AndroidLogger(NAME);
@@ -24,7 +24,7 @@ public final class RNSentryJsonConverter {
   }
 
   @Nullable
-  public static WritableMap convertToWritable(@NotNull JSONObject jsonObject) {
+  static WritableMap convertToWritable(@NotNull JSONObject jsonObject) {
     try {
       WritableMap writableMap = new JavaOnlyMap();
       Iterator<String> iterator = jsonObject.keys();
@@ -53,7 +53,7 @@ public final class RNSentryJsonConverter {
   }
 
   @NotNull
-  public static WritableArray convertToWritable(@NotNull JSONArray jsonArray) throws JSONException {
+  static WritableArray convertToWritable(@NotNull JSONArray jsonArray) throws JSONException {
     WritableArray writableArray = new JavaOnlyArray();
     for (int i = 0; i < jsonArray.length(); i++) {
       Object value = jsonArray.get(i);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Implements a utility class `RNSentryJsonConverter` converting a `JsonObject` to a `WritableMap`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of https://github.com/getsentry/sentry-react-native/issues/3608

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog