### PR TITLE
Remove date range for LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2025 Sentry
+Copyright (c) 2017 Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
While updating the date ranges for multiple PRs, Michi pointed out that we don't need date ranges for our licenses. I'm sorry about the fuzz.

In our internal [Open Source Legal Policy](https://www.notion.so/sentry/Open-Source-Legal-Policy-ac4885d265cb4d7898a01c060b061e42), we decided that licenses don't require a data range. This also has the advantage of not updating the date range yearly.

#skip-changelog

cc @gavin-zee