### PR TITLE
fix(samples): Only load browser replay when Expo sample is running on web

### DIFF
--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -10,6 +10,7 @@ import * as Sentry from '@sentry/react-native';
 import { ErrorEvent } from '@sentry/core';
 import { isExpoGo } from '../utils/isExpoGo';
 import { LogBox } from 'react-native';
+import { isWeb } from '../utils/isWeb';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -56,8 +57,10 @@ Sentry.init({
       }),
       navigationIntegration,
       Sentry.reactNativeTracingIntegration(),
-      Sentry.browserReplayIntegration(),
     );
+    if (isWeb()) {
+      integrations.push(Sentry.browserReplayIntegration());
+    }
     return integrations.filter(i => i.name !== 'Dedupe');
   },
   enableAutoSessionTracking: true,

--- a/samples/expo/utils/isWeb.ts
+++ b/samples/expo/utils/isWeb.ts
@@ -1,0 +1,5 @@
+import { Platform } from 'react-native';
+
+export function isWeb(): boolean {
+  return Platform.OS === 'web';
+}


### PR DESCRIPTION
Small fix as browser replay causes a crash due to https://github.com/getsentry/sentry-javascript/blob/de2c1ad309b850c1254c69890c96e869e297fa4c/packages/replay-internal/src/replay.ts#L764

#skip-changelog
