### PR TITLE
Ref: Remove sentry/utils from update list

### DIFF
--- a/scripts/update-javascript.sh
+++ b/scripts/update-javascript.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 tagPrefix=''
 repo="https://github.com/getsentry/sentry-javascript.git"
-packages=('@sentry/browser' '@sentry/core' '@sentry/react' '@sentry/types' '@sentry/utils' '@sentry-internal/typescript')
+packages=('@sentry/browser' '@sentry/core' '@sentry/react' '@sentry/types' '@sentry-internal/typescript')
 packages+=('@sentry-internal/eslint-config-sdk' '@sentry-internal/eslint-plugin-sdk')
 
 . $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Removes the package sentry/utils from the update list.

Sentry JavaScript will not update this package on V9 since it was merged on sentry/core https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#deprecations-4

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without this change, the action for updating the Sentry SDKs will fail.

CI error:
https://github.com/getsentry/sentry-react-native/actions/runs/13259874007/job/37030814458

## :green_heart: How did you test it?

CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog.
