### PR TITLE
fix(sample-e2e): Fix type errors missing sentry/core and afterAll

### DIFF
--- a/samples/react-native/e2e/captureMessage.test.android.ts
+++ b/samples/react-native/e2e/captureMessage.test.android.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, expect } from '@jest/globals';
+import { describe, it, beforeAll, expect, afterAll } from '@jest/globals';
 import { Envelope } from '@sentry/core';
 import { device } from 'detox';
 import {

--- a/samples/react-native/e2e/captureMessage.test.ios.ts
+++ b/samples/react-native/e2e/captureMessage.test.ios.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, expect } from '@jest/globals';
+import { describe, it, beforeAll, expect, afterAll } from '@jest/globals';
 import { Envelope } from '@sentry/core';
 import { device } from 'detox';
 import {

--- a/samples/react-native/e2e/envelopeHeader.test.android.ts
+++ b/samples/react-native/e2e/envelopeHeader.test.android.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, expect } from '@jest/globals';
+import { describe, it, beforeAll, expect, afterAll } from '@jest/globals';
 import { Envelope } from '@sentry/core';
 import { device } from 'detox';
 import {

--- a/samples/react-native/e2e/envelopeHeader.test.ios.ts
+++ b/samples/react-native/e2e/envelopeHeader.test.ios.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, expect } from '@jest/globals';
+import { describe, it, beforeAll, expect, afterAll } from '@jest/globals';
 import { Envelope } from '@sentry/core';
 import { device } from 'detox';
 import {

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -53,6 +53,7 @@
     "@react-native/metro-config": "0.77.0",
     "@react-native/typescript-config": "0.77.0",
     "@sentry/babel-plugin-component-annotate": "^3.1.2",
+    "@sentry/core": "8.54.0",
     "@types/react": "^18.2.65",
     "@types/react-native-vector-icons": "^6.4.18",
     "@types/react-test-renderer": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25067,6 +25067,7 @@ __metadata:
     "@react-navigation/native-stack": ^7.2.0
     "@react-navigation/stack": ^7.1.1
     "@sentry/babel-plugin-component-annotate": ^3.1.2
+    "@sentry/core": 8.54.0
     "@sentry/react-native": 6.7.0
     "@types/react": ^18.2.65
     "@types/react-native-vector-icons": ^6.4.18


### PR DESCRIPTION
Fixes type errors after merge in main to capture-app-start-errors.

https://github.com/getsentry/sentry-react-native/actions/runs/13392121407/job/37404373063?pr=4472

#skip-changelog 