### PR TITLE
misc(samples): Update Gemfile missing x86 ffi

### DIFF
--- a/samples/react-native/Gemfile.lock
+++ b/samples/react-native/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -273,6 +274,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
 
 DEPENDENCIES


### PR DESCRIPTION
#skip-changelog 

Not sure why, but I keep seeing this Gemfile change after `bundle install`