### PR TITLE
fix(metro): Avoid importing tslib in Sentry Metro Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Sentry Module Collection Script Fails with Spaces in Node Path on iOS ([#4559](https://github.com/getsentry/sentry-react-native/pull/4559))
 - Various crashes and issues of Session Replay on Android. See the Android SDK version bump for more details. ([#4529](https://github.com/getsentry/sentry-react-native/pull/4529))
 - `Sentry.setUser(null)` doesn't crash on iOS with RN 0.77.1 ([#4567](https://github.com/getsentry/sentry-react-native/pull/4567))
+- Avoid importing `tslib` in Sentry Metro Plugin ([#4573](https://github.com/getsentry/sentry-react-native/pull/4573))
 
 ### Dependencies
 

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -27,6 +27,7 @@
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
     "strictBindCallApply": true,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "importHelpers": false
   }
 }

--- a/packages/core/tsconfig.build.tools.json
+++ b/packages/core/tsconfig.build.tools.json
@@ -14,6 +14,7 @@
     "target": "es6",
     "module": "CommonJS",
     "skipLibCheck": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "importHelpers": false
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix


## :scroll: Description
<!--- Describe your changes in detail -->
- fixes: https://github.com/getsentry/sentry-react-native/issues/4562

The Sentry RN Package doesn't depend on `tslib` so it should not import it in its dist files. 

The only file where `tslib` was imported was `metroconfig.js`.

`tslib` was removed in Sentry JS already in v7 -> https://github.com/getsentry/sentry-javascript/pull/9299

## :green_heart: How did you test it?
checked that tslib is not part of the output in dist. 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
