### PR TITLE
fix(expo-sample): Remove trailing comma from `app.json`

### DIFF
--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -50,7 +50,7 @@
             "autoUploadProguardMapping": true,
             "uploadNativeSymbols": true,
             "includeNativeSources": true,
-            "includeSourceContext": true,
+            "includeSourceContext": true
           }
         }
       ],


### PR DESCRIPTION
The trailing command breaks SDK release because react-native-version doesn't support https://json-5.com/json-vs-json5 (includes trailing commas and comments), but Expo tooling does.

#skip-changelog 