### PR TITLE
feat: Adds span thread info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   <FeedbackWidget/>
   ```
 
+- Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
+
 ## 6.8.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Features
 
 - Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
+
+### Fixes
+
 - Considers the `SENTRY_DISABLE_AUTO_UPLOAD` and `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD` environment variables in the configuration of the Sentry Android Gradle Plugin for Expo plugin ([#4583](https://github.com/getsentry/sentry-react-native/pull/4583))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Features
+
+- Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
+
 ## 6.9.0
 
 ### Features
@@ -40,8 +46,6 @@
   ```
 
   To learn more about the available configuration options visit [the documentation](https://docs.sentry.io/platforms/react-native/user-feedback/configuration).
-
-- Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
 
 ## 6.8.0
 

--- a/packages/core/src/js/tracing/reactnativetracing.ts
+++ b/packages/core/src/js/tracing/reactnativetracing.ts
@@ -5,7 +5,7 @@ import { getClient } from '@sentry/core';
 
 import { isWeb } from '../utils/environment';
 import { getDevServer } from './../integrations/debugsymbolicatorutils';
-import { addDefaultOpForSpanFrom, defaultIdleOptions } from './span';
+import { addDefaultOpForSpanFrom, addThreadInfoToSpan, defaultIdleOptions } from './span';
 
 export const INTEGRATION_NAME = 'ReactNativeTracing';
 
@@ -119,6 +119,7 @@ export const reactNativeTracingIntegration = (
 
   const setup = (client: Client): void => {
     addDefaultOpForSpanFrom(client);
+    addThreadInfoToSpan(client);
 
     instrumentOutgoingRequests(client, {
       traceFetch: finalOptions.traceFetch,

--- a/packages/core/src/js/tracing/span.ts
+++ b/packages/core/src/js/tracing/span.ts
@@ -154,3 +154,29 @@ export function addDefaultOpForSpanFrom(client: Client): void {
     }
   });
 }
+
+const SPAN_THREAD_ID = 'thread.id';
+const SPAN_THREAD_ID_MAIN = 1;
+const SPAN_THREAD_ID_JAVASCRIPT = 2;
+const SPAN_THREAD_NAME = 'thread.name';
+const SPAN_THREAD_NAME_MAIN = 'main';
+const SPAN_THREAD_NAME_JAVASCRIPT = 'javascript';
+const UI_THREAD_PREFIX = 'ui.';
+
+/**
+ * Adds thread info to spans.
+ * Ref: https://reactnative.dev/architecture/threading-model
+ */
+export function addThreadInfoToSpan(client: Client): void {
+  client.on('spanStart', (span: Span) => {
+    if (!spanToJSON(span).data?.[SPAN_THREAD_ID]) {
+      if (spanToJSON(span).op?.startsWith(UI_THREAD_PREFIX)) {
+        span.setAttribute(SPAN_THREAD_ID, SPAN_THREAD_ID_MAIN);
+        span.setAttribute(SPAN_THREAD_NAME, SPAN_THREAD_NAME_MAIN);
+      } else {
+        span.setAttribute(SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT);
+        span.setAttribute(SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT);
+      }
+    }
+  });
+}

--- a/packages/core/src/js/tracing/span.ts
+++ b/packages/core/src/js/tracing/span.ts
@@ -155,9 +155,6 @@ export function addDefaultOpForSpanFrom(client: Client): void {
   });
 }
 
-export const SPAN_THREAD_ID = 'thread.id';
-export const SPAN_THREAD_ID_MAIN = 1;
-export const SPAN_THREAD_ID_JAVASCRIPT = 2;
 export const SPAN_THREAD_NAME = 'thread.name';
 export const SPAN_THREAD_NAME_MAIN = 'main';
 export const SPAN_THREAD_NAME_JAVASCRIPT = 'javascript';
@@ -168,8 +165,7 @@ export const SPAN_THREAD_NAME_JAVASCRIPT = 'javascript';
  */
 export function addThreadInfoToSpan(client: Client): void {
   client.on('spanStart', (span: Span) => {
-    if (!spanToJSON(span).data?.[SPAN_THREAD_ID]) {
-      span.setAttribute(SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT);
+    if (!spanToJSON(span).data?.[SPAN_THREAD_NAME]) {
       span.setAttribute(SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT);
     }
   });
@@ -180,7 +176,6 @@ export function addThreadInfoToSpan(client: Client): void {
  */
 export function setMainThreadInfo(spanJSON: SpanJSON): SpanJSON {
   spanJSON.data = spanJSON.data || {};
-  spanJSON.data[SPAN_THREAD_ID] = SPAN_THREAD_ID_MAIN;
   spanJSON.data[SPAN_THREAD_NAME] = SPAN_THREAD_NAME_MAIN;
   return spanJSON;
 }

--- a/packages/core/src/js/tracing/span.ts
+++ b/packages/core/src/js/tracing/span.ts
@@ -155,12 +155,13 @@ export function addDefaultOpForSpanFrom(client: Client): void {
   });
 }
 
-const SPAN_THREAD_ID = 'thread.id';
-const SPAN_THREAD_ID_MAIN = 1;
-const SPAN_THREAD_ID_JAVASCRIPT = 2;
-const SPAN_THREAD_NAME = 'thread.name';
-const SPAN_THREAD_NAME_MAIN = 'main';
-const SPAN_THREAD_NAME_JAVASCRIPT = 'javascript';
+export const SPAN_THREAD_ID = 'thread.id';
+export const SPAN_THREAD_ID_MAIN = 1;
+export const SPAN_THREAD_ID_JAVASCRIPT = 2;
+export const SPAN_THREAD_NAME = 'thread.name';
+export const SPAN_THREAD_NAME_MAIN = 'main';
+export const SPAN_THREAD_NAME_JAVASCRIPT = 'javascript';
+
 const UI_THREAD_PREFIX = 'ui.';
 
 /**

--- a/packages/core/src/js/tracing/span.ts
+++ b/packages/core/src/js/tracing/span.ts
@@ -1,4 +1,4 @@
-import type { Client, Scope, Span, StartSpanOptions } from '@sentry/core';
+import type { Client, Scope, Span, SpanJSON, StartSpanOptions } from '@sentry/core';
 import {
   generatePropagationContext,
   getActiveSpan,
@@ -162,22 +162,25 @@ export const SPAN_THREAD_NAME = 'thread.name';
 export const SPAN_THREAD_NAME_MAIN = 'main';
 export const SPAN_THREAD_NAME_JAVASCRIPT = 'javascript';
 
-const UI_THREAD_PREFIX = 'ui.';
-
 /**
- * Adds thread info to spans.
+ * Adds Javascript thread info to spans.
  * Ref: https://reactnative.dev/architecture/threading-model
  */
 export function addThreadInfoToSpan(client: Client): void {
   client.on('spanStart', (span: Span) => {
     if (!spanToJSON(span).data?.[SPAN_THREAD_ID]) {
-      if (spanToJSON(span).op?.startsWith(UI_THREAD_PREFIX)) {
-        span.setAttribute(SPAN_THREAD_ID, SPAN_THREAD_ID_MAIN);
-        span.setAttribute(SPAN_THREAD_NAME, SPAN_THREAD_NAME_MAIN);
-      } else {
-        span.setAttribute(SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT);
-        span.setAttribute(SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT);
-      }
+      span.setAttribute(SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT);
+      span.setAttribute(SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT);
     }
   });
+}
+
+/**
+ * Sets the Main thread info to the span.
+ */
+export function setMainThreadInfo(spanJSON: SpanJSON): SpanJSON {
+  spanJSON.data = spanJSON.data || {};
+  spanJSON.data[SPAN_THREAD_ID] = SPAN_THREAD_ID_MAIN;
+  spanJSON.data[SPAN_THREAD_NAME] = SPAN_THREAD_NAME_MAIN;
+  return spanJSON;
 }

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -27,6 +27,12 @@ import {
   setRootComponentCreationTimestampMs,
 } from '../../../src/js/tracing/integrations/appStart';
 import { SPAN_ORIGIN_AUTO_APP_START, SPAN_ORIGIN_MANUAL_APP_START } from '../../../src/js/tracing/origin';
+import {
+  SPAN_THREAD_ID,
+  SPAN_THREAD_ID_MAIN,
+  SPAN_THREAD_NAME,
+  SPAN_THREAD_NAME_MAIN,
+} from '../../../src/js/tracing/span';
 import { getTimeOriginMilliseconds } from '../../../src/js/tracing/utils';
 import { RN_GLOBAL_OBJ } from '../../../src/js/utils/worldwide';
 import { NATIVE } from '../../../src/js/wrapper';
@@ -252,6 +258,8 @@ describe('App Start Integration', () => {
           data: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: appStartRootSpan!.op,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+            [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+            [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
           },
         }),
       );
@@ -612,6 +620,8 @@ describe('App Start Integration', () => {
           data: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: appStartRootSpan!.op,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+            [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+            [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
           },
         }),
       );

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -27,12 +27,7 @@ import {
   setRootComponentCreationTimestampMs,
 } from '../../../src/js/tracing/integrations/appStart';
 import { SPAN_ORIGIN_AUTO_APP_START, SPAN_ORIGIN_MANUAL_APP_START } from '../../../src/js/tracing/origin';
-import {
-  SPAN_THREAD_ID,
-  SPAN_THREAD_ID_MAIN,
-  SPAN_THREAD_NAME,
-  SPAN_THREAD_NAME_MAIN,
-} from '../../../src/js/tracing/span';
+import { SPAN_THREAD_NAME, SPAN_THREAD_NAME_MAIN } from '../../../src/js/tracing/span';
 import { getTimeOriginMilliseconds } from '../../../src/js/tracing/utils';
 import { RN_GLOBAL_OBJ } from '../../../src/js/utils/worldwide';
 import { NATIVE } from '../../../src/js/wrapper';
@@ -258,7 +253,6 @@ describe('App Start Integration', () => {
           data: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: appStartRootSpan!.op,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
-            [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
             [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
           },
         }),
@@ -620,7 +614,6 @@ describe('App Start Integration', () => {
           data: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: appStartRootSpan!.op,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
-            [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
             [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
           },
         }),

--- a/packages/core/test/tracing/reactnativenavigation.test.ts
+++ b/packages/core/test/tracing/reactnativenavigation.test.ts
@@ -32,6 +32,12 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '../../src/js/tracing/semanticAttributes';
+import {
+  SPAN_THREAD_ID,
+  SPAN_THREAD_ID_JAVASCRIPT,
+  SPAN_THREAD_NAME,
+  SPAN_THREAD_NAME_JAVASCRIPT,
+} from '../../src/js/tracing/span';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 
 interface MockEventsRegistry extends EventsRegistry {
@@ -87,6 +93,8 @@ describe('React Native Navigation Instrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+              [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
         }),
@@ -131,6 +139,8 @@ describe('React Native Navigation Instrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+              [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
         }),
@@ -206,6 +216,8 @@ describe('React Native Navigation Instrumentation', () => {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
                 [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
                 [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
             }),
           }),
@@ -294,6 +306,8 @@ describe('React Native Navigation Instrumentation', () => {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
                 [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
                 [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
             }),
           }),
@@ -342,6 +356,8 @@ describe('React Native Navigation Instrumentation', () => {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
                 [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
                 [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
             }),
           }),

--- a/packages/core/test/tracing/reactnativenavigation.test.ts
+++ b/packages/core/test/tracing/reactnativenavigation.test.ts
@@ -32,12 +32,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '../../src/js/tracing/semanticAttributes';
-import {
-  SPAN_THREAD_ID,
-  SPAN_THREAD_ID_JAVASCRIPT,
-  SPAN_THREAD_NAME,
-  SPAN_THREAD_NAME_JAVASCRIPT,
-} from '../../src/js/tracing/span';
+import { SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT } from '../../src/js/tracing/span';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 
 interface MockEventsRegistry extends EventsRegistry {
@@ -93,7 +88,6 @@ describe('React Native Navigation Instrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
               [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
@@ -139,7 +133,6 @@ describe('React Native Navigation Instrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
               [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
@@ -216,7 +209,6 @@ describe('React Native Navigation Instrumentation', () => {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
                 [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
                 [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
             }),
@@ -306,7 +298,6 @@ describe('React Native Navigation Instrumentation', () => {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
                 [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
                 [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
             }),
@@ -356,7 +347,6 @@ describe('React Native Navigation Instrumentation', () => {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
                 [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
                 [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
             }),

--- a/packages/core/test/tracing/reactnavigation.test.ts
+++ b/packages/core/test/tracing/reactnavigation.test.ts
@@ -20,13 +20,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '../../src/js/tracing/semanticAttributes';
-import {
-  DEFAULT_NAVIGATION_SPAN_NAME,
-  SPAN_THREAD_ID,
-  SPAN_THREAD_ID_JAVASCRIPT,
-  SPAN_THREAD_NAME,
-  SPAN_THREAD_NAME_JAVASCRIPT,
-} from '../../src/js/tracing/span';
+import { DEFAULT_NAVIGATION_SPAN_NAME, SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT } from '../../src/js/tracing/span';
 import { RN_GLOBAL_OBJ } from '../../src/js/utils/worldwide';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 import { NATIVE } from '../mockWrapper';
@@ -89,7 +83,6 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
               [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
@@ -200,7 +193,6 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
               [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
@@ -239,7 +231,6 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
               [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
@@ -280,7 +271,6 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
-              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
               [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),

--- a/packages/core/test/tracing/reactnavigation.test.ts
+++ b/packages/core/test/tracing/reactnavigation.test.ts
@@ -20,7 +20,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '../../src/js/tracing/semanticAttributes';
-import { DEFAULT_NAVIGATION_SPAN_NAME } from '../../src/js/tracing/span';
+import {
+  DEFAULT_NAVIGATION_SPAN_NAME,
+  SPAN_THREAD_ID,
+  SPAN_THREAD_ID_JAVASCRIPT,
+  SPAN_THREAD_NAME,
+  SPAN_THREAD_NAME_JAVASCRIPT,
+} from '../../src/js/tracing/span';
 import { RN_GLOBAL_OBJ } from '../../src/js/utils/worldwide';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
 import { NATIVE } from '../mockWrapper';
@@ -83,6 +89,8 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+              [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
         }),
@@ -192,6 +200,8 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+              [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
         }),
@@ -229,6 +239,8 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+              [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
         }),
@@ -268,6 +280,8 @@ describe('ReactNavigationInstrumentation', () => {
               [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
               [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
               [SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON]: 'idleTimeout',
+              [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+              [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
             },
           }),
         }),

--- a/packages/core/test/tracing/reactnavigation.ttid.test.tsx
+++ b/packages/core/test/tracing/reactnavigation.ttid.test.tsx
@@ -16,6 +16,7 @@ import { startSpanManual } from '../../src/js';
 import { TimeToFullDisplay, TimeToInitialDisplay } from '../../src/js/tracing';
 import { _setAppStartEndTimestampMs } from '../../src/js/tracing/integrations/appStart';
 import { SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION, SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY, SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY } from '../../src/js/tracing/origin';
+import { SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT, SPAN_THREAD_ID_MAIN, SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT,SPAN_THREAD_NAME_MAIN } from '../../src/js/tracing/span';
 import { isHermesEnabled, notWeb } from '../../src/js/utils/environment';
 import { createSentryFallbackEventEmitter } from '../../src/js/utils/sentryeventemitterfallback';
 import { RN_GLOBAL_OBJ } from '../../src/js/utils/worldwide';
@@ -80,6 +81,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',
@@ -110,6 +113,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',
@@ -146,6 +151,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',
@@ -203,6 +210,8 @@ describe('React Navigation - TTID', () => {
                 'sentry.op': 'navigation.processing',
                 'sentry.origin': SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION,
                 'sentry.source': 'custom',
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Navigation dispatch to screen New Screen mounted',
               op: 'navigation.processing',
@@ -231,6 +240,8 @@ describe('React Navigation - TTID', () => {
                 'sentry.op': 'navigation.processing',
                 'sentry.origin': SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION,
                 'sentry.source': 'custom',
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Navigation dispatch to screen Initial Screen mounted',
               op: 'navigation.processing',
@@ -261,6 +272,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
               },
               description: 'Initial Screen initial display',
               op: 'ui.load.initial_display',
@@ -295,6 +308,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.full_display',
                 'sentry.origin': SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
               },
               description: 'Time To Full Display',
               op: 'ui.load.full_display',
@@ -371,6 +386,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',

--- a/packages/core/test/tracing/reactnavigation.ttid.test.tsx
+++ b/packages/core/test/tracing/reactnavigation.ttid.test.tsx
@@ -16,7 +16,7 @@ import { startSpanManual } from '../../src/js';
 import { TimeToFullDisplay, TimeToInitialDisplay } from '../../src/js/tracing';
 import { _setAppStartEndTimestampMs } from '../../src/js/tracing/integrations/appStart';
 import { SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION, SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY, SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY } from '../../src/js/tracing/origin';
-import { SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT, SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT } from '../../src/js/tracing/span';
+import { SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT } from '../../src/js/tracing/span';
 import { isHermesEnabled, notWeb } from '../../src/js/utils/environment';
 import { createSentryFallbackEventEmitter } from '../../src/js/utils/sentryeventemitterfallback';
 import { RN_GLOBAL_OBJ } from '../../src/js/utils/worldwide';
@@ -81,7 +81,6 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',
@@ -113,7 +112,6 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',
@@ -151,7 +149,6 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',
@@ -210,7 +207,6 @@ describe('React Navigation - TTID', () => {
                 'sentry.op': 'navigation.processing',
                 'sentry.origin': SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION,
                 'sentry.source': 'custom',
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Navigation dispatch to screen New Screen mounted',
@@ -240,7 +236,6 @@ describe('React Navigation - TTID', () => {
                 'sentry.op': 'navigation.processing',
                 'sentry.origin': SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION,
                 'sentry.source': 'custom',
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Navigation dispatch to screen Initial Screen mounted',
@@ -272,7 +267,6 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Initial Screen initial display',
@@ -308,7 +302,6 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.full_display',
                 'sentry.origin': SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Time To Full Display',
@@ -386,7 +379,6 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
                 [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',

--- a/packages/core/test/tracing/reactnavigation.ttid.test.tsx
+++ b/packages/core/test/tracing/reactnavigation.ttid.test.tsx
@@ -16,7 +16,7 @@ import { startSpanManual } from '../../src/js';
 import { TimeToFullDisplay, TimeToInitialDisplay } from '../../src/js/tracing';
 import { _setAppStartEndTimestampMs } from '../../src/js/tracing/integrations/appStart';
 import { SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION, SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY, SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY } from '../../src/js/tracing/origin';
-import { SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT, SPAN_THREAD_ID_MAIN, SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT,SPAN_THREAD_NAME_MAIN } from '../../src/js/tracing/span';
+import { SPAN_THREAD_ID, SPAN_THREAD_ID_JAVASCRIPT, SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT } from '../../src/js/tracing/span';
 import { isHermesEnabled, notWeb } from '../../src/js/utils/environment';
 import { createSentryFallbackEventEmitter } from '../../src/js/utils/sentryeventemitterfallback';
 import { RN_GLOBAL_OBJ } from '../../src/js/utils/worldwide';
@@ -81,8 +81,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
-                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',
@@ -113,8 +113,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
-                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',
@@ -151,8 +151,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
-                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',
@@ -272,8 +272,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
-                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Initial Screen initial display',
               op: 'ui.load.initial_display',
@@ -308,8 +308,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.full_display',
                 'sentry.origin': SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
-                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'Time To Full Display',
               op: 'ui.load.full_display',
@@ -386,8 +386,8 @@ describe('React Navigation - TTID', () => {
               data: {
                 'sentry.op': 'ui.load.initial_display',
                 'sentry.origin': SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY,
-                [SPAN_THREAD_ID]: SPAN_THREAD_ID_MAIN,
-                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_MAIN,
+                [SPAN_THREAD_ID]: SPAN_THREAD_ID_JAVASCRIPT,
+                [SPAN_THREAD_NAME]: SPAN_THREAD_NAME_JAVASCRIPT,
               },
               description: 'New Screen initial display',
               op: 'ui.load.initial_display',


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds span thread info. This would be:
- `name: main` for UI threads
- `name: javascript` for JS threads

Ref: https://reactnative.dev/architecture/threading-model

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-react-native/issues/4461

## :green_heart: How did you test it?
Manual, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
