### PR TITLE
fix(sample): Add NSPhotoLibraryUsageDescription to Info.plist

### DIFF
--- a/samples/react-native/ios/sentryreactnativesample/Info.plist
+++ b/samples/react-native/ios/sentryreactnativesample/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>The Photo Library Access is required for attaching images/screenshots from the users&apos; library to a user feedback form.</string>
+	<string>The Photo Library Access is required for attaching images/screenshots to a user feedback form.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
#skip-changelog 

Fix missing NSPhotoLibraryUsageDescription for the `react-native-image-picker` dep.

Fixes:


ITMS-90683: Missing purpose string in Info.plist - Your app’s code references one or more APIs that access sensitive user data, or the app has one or more entitlements that permit such access. The Info.plist file for the “[sentryreactnativesample.app](http://sentryreactnativesample.app/)” bundle should contain a NSPhotoLibraryUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. If you’re using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. For details, visit: https://developer.apple.com/documentation/uikit/protecting_the_user_s_privacy/requesting_access_to_protected_resources.