### PR TITLE
ci(testflight): Upgrade to macos-15 and Xcode 16.2

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -14,12 +14,12 @@ jobs:
 
   upload_to_testflight:
     name: Build and Upload React Native Sample to Testflight
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
+      - run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
       - uses: ruby/setup-ruby@v1
         with:
           working-directory: samples/react-native


### PR DESCRIPTION
#skip-changelog 

Fixes

ITMS-90725: SDK version issue - This app was built with the iOS 17.4 SDK. Starting April 24, 2025, all iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution.