### PR TITLE
chore(deps): Bump Android SDK to v8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,9 @@
 
 ### Dependencies
 
-- Bump Android SDK from v7.20.1 to v8.2.0 ([#4529](https://github.com/getsentry/sentry-react-native/pull/4529), [#4471](https://github.com/getsentry/sentry-react-native/pull/4471))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/7.x.x/CHANGELOG.md#820)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.2.0)
+- Bump Android SDK from v7.20.1 to v8.3.0 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#830)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.3.0)
 - Bump Cocoa SDK from v8.44.0 to v8.45.0 ([#4537](https://github.com/getsentry/sentry-react-native/pull/4537))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8450)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.44.0...8.45.0)

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -54,5 +54,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:8.2.0'
+    api 'io.sentry:sentry-android:8.3.0'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

Depends on https://github.com/getsentry/sentry-react-native/pull/4490

## :scroll: Description
<!--- Describe your changes in detail -->
Bumps Android SDK 8.2.0 -> 8.3.0

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-java/releases/tag/8.3.0

## :green_heart: How did you test it?
Manual, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog