### PR TITLE
fix(appStart): Attach App Start spans to the first created not the first processed root span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 - Considers the `SENTRY_DISABLE_AUTO_UPLOAD` and `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD` environment variables in the configuration of the Sentry Android Gradle Plugin for Expo plugin ([#4583](https://github.com/getsentry/sentry-react-native/pull/4583))
+- Attach App Start spans to the first created not the first processed root span ([#4618](https://github.com/getsentry/sentry-react-native/pull/4618))
 
 ### Dependencies
 

--- a/packages/core/test/profiling/integration.test.ts
+++ b/packages/core/test/profiling/integration.test.ts
@@ -262,8 +262,9 @@ describe('profiling integration', () => {
       const transaction1 = Sentry.startSpanManual({ name: 'test-name-1' }, span => span);
       const transaction2 = Sentry.startSpanManual({ name: 'test-name-2' }, span => span);
       transaction1.end();
-      transaction2.end();
+      jest.runOnlyPendingTimers();
 
+      transaction2.end();
       jest.runAllTimers();
 
       expectEnvelopeToContainProfile(

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -34,6 +34,10 @@ import { NATIVE } from '../../../src/js/wrapper';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
 import { mockFunction } from '../../testutils';
 
+type AppStartIntegrationTest = ReturnType<typeof appStartIntegration> & {
+  setFirstStartedActiveRootSpanId: (spanId: string | undefined) => void;
+};
+
 let dateNowSpy: jest.SpyInstance;
 
 jest.mock('../../../src/js/wrapper', () => {
@@ -692,7 +696,10 @@ describe('App Start Integration', () => {
       const integration = appStartIntegration();
       const client = new TestClient(getDefaultTestClientOptions());
 
-      const actualEvent = await integration.processEvent(getMinimalTransactionEvent(), {}, client);
+      const firstEvent = getMinimalTransactionEvent();
+      (integration as AppStartIntegrationTest).setFirstStartedActiveRootSpanId(firstEvent.contexts?.trace?.span_id);
+
+      const actualEvent = await integration.processEvent(firstEvent, {}, client);
       expect(actualEvent).toEqual(
         expectEventWithAttachedColdAppStart({ timeOriginMilliseconds, appStartTimeMilliseconds }),
       );
@@ -725,6 +732,7 @@ describe('App Start Integration', () => {
 
 function processEvent(event: Event): PromiseLike<Event | null> | Event | null {
   const integration = appStartIntegration();
+  (integration as AppStartIntegrationTest).setFirstStartedActiveRootSpanId(event.contexts?.trace?.span_id);
   return integration.processEvent(event, {}, new TestClient(getDefaultTestClientOptions()));
 }
 

--- a/packages/core/test/tracing/reactnavigation.ttid.test.tsx
+++ b/packages/core/test/tracing/reactnavigation.ttid.test.tsx
@@ -367,6 +367,7 @@ describe('React Navigation - TTID', () => {
     });
 
     test('idle transaction should cancel the ttid span if new frame not received', () => {
+      jest.runOnlyPendingTimers(); // Flush app start transaction
       mockedNavigation.navigateToNewScreen();
       jest.runOnlyPendingTimers(); // Flush ttid transaction
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Fixes the app start being attached to the first started not first processed transaction.

The first started transaction doesn't have to end first.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes https://github.com/getsentry/sentry-react-native/issues/4512

## :green_heart: How did you test it?
unit tests + e2e test coming in follow up PR

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
