### PR TITLE
ci(e2e): Use exact Xcode version (16.2) for e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -172,11 +172,11 @@ jobs:
           - platform: ios
             rn-version: '0.77.1'
             xcode-version: '16.2'
-            runs-on: macos-14
+            runs-on: macos-15
           - platform: ios
             rn-version: '0.65.3'
             xcode-version: '14.2'
-            runs-on: macos-13
+            runs-on: macos-15
           - platform: android
             runs-on: ubuntu-latest
         exclude:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,9 +171,11 @@ jobs:
         include:
           - platform: ios
             rn-version: '0.77.1'
+            xcode-version: '16.2'
             runs-on: macos-14
           - platform: ios
             rn-version: '0.65.3'
+            xcode-version: '14.2'
             runs-on: macos-13
           - platform: android
             runs-on: ubuntu-latest
@@ -221,8 +223,8 @@ jobs:
           echo "SENTRY_RELEASE=$SENTRY_RELEASE"
           echo "SENTRY_DIST=$SENTRY_DIST"
 
-      - run: sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
-        if: ${{ matrix.platform == 'ios' && matrix.rn-version == '0.65.3' }}
+      - run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+        if: ${{ matrix.platform == 'ios' }}
 
       - run: corepack enable
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -176,7 +176,7 @@ jobs:
           - platform: ios
             rn-version: '0.65.3'
             xcode-version: '14.2'
-            runs-on: macos-15
+            runs-on: macos-13
           - platform: android
             runs-on: ubuntu-latest
         exclude:


### PR DESCRIPTION
Ensures that the clean app e2e tests run with exact xcode versions.

Old RN with Xcode 14.2
Latest RN with Xcode 16.2

- verifies https://github.com/getsentry/sentry-react-native/issues/4622

#skip-changelog 