### PR TITLE
fix(breadcrumb-ios): Handle non-string category in getCurrentScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Considers the `SENTRY_DISABLE_AUTO_UPLOAD` and `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD` environment variables in the configuration of the Sentry Android Gradle Plugin for Expo plugin ([#4583](https://github.com/getsentry/sentry-react-native/pull/4583))
 - Attach App Start spans to the first created not the first processed root span ([#4618](https://github.com/getsentry/sentry-react-native/pull/4618))
+- Handle non-string category in getCurrentScreen on iOS ([#4629](https://github.com/getsentry/sentry-react-native/pull/4629))
 
 ### Dependencies
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryBreadcrumbTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryBreadcrumbTests.swift
@@ -54,6 +54,12 @@ final class RNSentryBreadcrumbTests: XCTestCase {
         XCTAssertNil(actual)
     }
 
+    func testNullForNonStringCategory() {
+        let map: [String: Any] = ["category": false]
+        let actual = RNSentryBreadcrumb.getCurrentScreen(from: map)
+        XCTAssertNil(actual)
+    }
+
     func testNullForNonNavigationCategory() {
         let map: [String: Any] = ["category": "unknown"]
         let actual = RNSentryBreadcrumb.getCurrentScreen(from: map)

--- a/packages/core/ios/RNSentryBreadcrumb.m
+++ b/packages/core/ios/RNSentryBreadcrumb.m
@@ -39,7 +39,7 @@
 + (NSString *_Nullable)getCurrentScreenFrom:(NSDictionary<NSString *, id> *_Nonnull)dict
 {
     NSString *_Nullable maybeCategory = [dict valueForKey:@"category"];
-    if (![maybeCategory isEqualToString:@"navigation"]) {
+    if ([maybeCategory isKindOfClass:[NSString class]] && ![maybeCategory isEqualToString:@"navigation"]) {
         return nil;
     }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
- fixes https://github.com/getsentry/sentry-react-native/issues/4627#issuecomment-2701139257

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes