### PR TITLE
fix(tracing): Use route name instead of route key for current route tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Considers the `SENTRY_DISABLE_AUTO_UPLOAD` and `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD` environment variables in the configuration of the Sentry Android Gradle Plugin for Expo plugin ([#4583](https://github.com/getsentry/sentry-react-native/pull/4583))
 - Attach App Start spans to the first created not the first processed root span ([#4618](https://github.com/getsentry/sentry-react-native/pull/4618))
+- Use route name instead of route key for current route tracking ([#4631](https://github.com/getsentry/sentry-react-native/pull/4631))
+  - Using key caused user interaction transaction names to contain route hash in the name.
 
 ### Dependencies
 

--- a/packages/core/src/js/tracing/reactnavigation.ts
+++ b/packages/core/src/js/tracing/reactnavigation.ts
@@ -309,7 +309,7 @@ export const reactNavigationIntegration = ({
       },
     });
 
-    tracing?.setCurrentRoute(route.key);
+    tracing?.setCurrentRoute(route.name);
 
     pushRecentRouteKey(route.key);
     latestRoute = route;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
Current route must be a name, not a key, as keys contain navigation specific hashes and thus generated transaction names would always be unique.


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes
