### PR TITLE
Change `Cold/Warm App Start` span description to `Cold/Warm Start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
   To learn more about the available configuration options visit [the documentation](https://docs.sentry.io/platforms/react-native/manual-setup/expo/expo-sagp/).
 
+### Changes
+
+Change `Cold/Warm App Start` span description to `Cold/Warm Start` ([#4636](https://github.com/getsentry/sentry-react-native/pull/4636))
+
 ### Fixes
 
 - Various crashes and issues of Session Replay on Android. See the Android SDK version bump for more details. ([#4529](https://github.com/getsentry/sentry-react-native/pull/4529))

--- a/packages/core/src/js/tracing/integrations/appStart.ts
+++ b/packages/core/src/js/tracing/integrations/appStart.ts
@@ -295,7 +295,7 @@ export const appStartIntegration = ({
     const op = appStart.type === 'cold' ? APP_START_COLD_OP : APP_START_WARM_OP;
     const appStartSpanJSON: SpanJSON = createSpanJSON({
       op,
-      description: appStart.type === 'cold' ? 'Cold App Start' : 'Warm App Start',
+      description: appStart.type === 'cold' ? 'Cold Start' : 'Warm Start',
       start_timestamp: appStartTimestampSeconds,
       timestamp: appStartEndTimestampSeconds,
       trace_id: event.contexts.trace.trace_id,

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -151,7 +151,7 @@ describe('App Start Integration', () => {
 
       const actualEvent = await captureStandAloneAppStart();
 
-      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold Start');
       const bundleStartSpan = actualEvent!.spans!.find(
         ({ description }) => description === 'JS Bundle Execution Start',
       );
@@ -159,7 +159,7 @@ describe('App Start Integration', () => {
       expect(appStartRootSpan).toEqual(
         expect.objectContaining(<Partial<SpanJSON>>{
           span_id: expect.any(String),
-          description: 'Cold App Start',
+          description: 'Cold Start',
           op: APP_START_COLD_OP,
           data: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_COLD_OP,
@@ -189,7 +189,7 @@ describe('App Start Integration', () => {
 
       const actualEvent = await captureStandAloneAppStart();
 
-      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold Start');
       const bundleStartSpan = actualEvent!.spans!.find(
         ({ description }) => description === 'JS Bundle Execution Before React Root',
       );
@@ -197,7 +197,7 @@ describe('App Start Integration', () => {
       expect(appStartRootSpan).toEqual(
         expect.objectContaining(<Partial<SpanJSON>>{
           span_id: expect.any(String),
-          description: 'Cold App Start',
+          description: 'Cold Start',
           op: APP_START_COLD_OP,
           data: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_COLD_OP,
@@ -228,13 +228,13 @@ describe('App Start Integration', () => {
 
       const actualEvent = await captureStandAloneAppStart();
 
-      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold Start');
       const nativeSpan = actualEvent!.spans!.find(({ description }) => description === 'test native app start span');
 
       expect(appStartRootSpan).toEqual(
         expect.objectContaining(<Partial<SpanJSON>>{
           span_id: expect.any(String),
-          description: 'Cold App Start',
+          description: 'Cold Start',
           op: APP_START_COLD_OP,
           data: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_COLD_OP,
@@ -465,14 +465,14 @@ describe('App Start Integration', () => {
 
       const actualEvent = await processEvent(getMinimalTransactionEvent());
 
-      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold Start');
       const bundleStartSpan = actualEvent!.spans!.find(
         ({ description }) => description === 'JS Bundle Execution Start',
       );
 
       expect(appStartRootSpan).toEqual(
         expect.objectContaining(<Partial<SpanJSON>>{
-          description: 'Cold App Start',
+          description: 'Cold Start',
           span_id: expect.any(String),
           op: APP_START_COLD_OP,
           origin: SPAN_ORIGIN_AUTO_APP_START,
@@ -505,14 +505,14 @@ describe('App Start Integration', () => {
 
       const actualEvent = await processEvent(getMinimalTransactionEvent());
 
-      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold Start');
       const bundleStartSpan = actualEvent!.spans!.find(
         ({ description }) => description === 'JS Bundle Execution Before React Root',
       );
 
       expect(appStartRootSpan).toEqual(
         expect.objectContaining(<Partial<SpanJSON>>{
-          description: 'Cold App Start',
+          description: 'Cold Start',
           span_id: expect.any(String),
           op: APP_START_COLD_OP,
           origin: SPAN_ORIGIN_AUTO_APP_START,
@@ -545,14 +545,14 @@ describe('App Start Integration', () => {
 
       const actualEvent = await processEvent(getMinimalTransactionEvent());
 
-      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold Start');
       const bundleStartSpan = actualEvent!.spans!.find(
         ({ description }) => description === 'JS Bundle Execution Before React Root',
       );
 
       expect(appStartRootSpan).toEqual(
         expect.objectContaining(<Partial<SpanJSON>>{
-          description: 'Cold App Start',
+          description: 'Cold Start',
           span_id: expect.any(String),
           op: APP_START_COLD_OP,
           origin: SPAN_ORIGIN_AUTO_APP_START,
@@ -586,12 +586,12 @@ describe('App Start Integration', () => {
 
       const actualEvent = await processEvent(getMinimalTransactionEvent());
 
-      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+      const appStartRootSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold Start');
       const nativeSpan = actualEvent!.spans!.find(({ description }) => description === 'test native app start span');
 
       expect(appStartRootSpan).toEqual(
         expect.objectContaining(<Partial<SpanJSON>>{
-          description: 'Cold App Start',
+          description: 'Cold Start',
           span_id: expect.any(String),
           op: APP_START_COLD_OP,
           origin: SPAN_ORIGIN_AUTO_APP_START,
@@ -802,7 +802,7 @@ function expectEventWithAttachedColdAppStart({
     spans: expect.arrayContaining<SpanJSON>([
       {
         op: APP_START_COLD_OP,
-        description: 'Cold App Start',
+        description: 'Cold Start',
         start_timestamp: appStartTimeMilliseconds / 1000,
         timestamp: expect.any(Number),
         trace_id: expect.any(String),
@@ -856,7 +856,7 @@ function expectEventWithAttachedWarmAppStart({
     spans: expect.arrayContaining<SpanJSON>([
       {
         op: APP_START_WARM_OP,
-        description: 'Warm App Start',
+        description: 'Warm Start',
         start_timestamp: appStartTimeMilliseconds / 1000,
         timestamp: expect.any(Number),
         trace_id: expect.any(String),
@@ -913,7 +913,7 @@ function expectEventWithStandaloneColdAppStart(
     spans: expect.arrayContaining<SpanJSON>([
       {
         op: APP_START_COLD_OP,
-        description: 'Cold App Start',
+        description: 'Cold Start',
         start_timestamp: appStartTimeMilliseconds / 1000,
         timestamp: expect.any(Number),
         trace_id: expect.any(String),
@@ -962,7 +962,7 @@ function expectEventWithStandaloneWarmAppStart(
     spans: expect.arrayContaining<SpanJSON>([
       {
         op: APP_START_WARM_OP,
-        description: 'Warm App Start',
+        description: 'Warm Start',
         start_timestamp: appStartTimeMilliseconds / 1000,
         timestamp: expect.any(Number),
         trace_id: expect.any(String),

--- a/packages/core/test/tracing/reactnavigation.ttid.test.tsx
+++ b/packages/core/test/tracing/reactnavigation.ttid.test.tsx
@@ -255,7 +255,7 @@ describe('React Navigation - TTID', () => {
           type: 'transaction',
           spans: expect.arrayContaining([
             expect.objectContaining<Partial<SpanJSON>>({
-              description: 'Cold App Start',
+              description: 'Cold Start',
             }),
             expect.objectContaining<Partial<SpanJSON>>({
               data: {
@@ -289,7 +289,7 @@ describe('React Navigation - TTID', () => {
           type: 'transaction',
           spans: expect.arrayContaining([
             expect.objectContaining<Partial<SpanJSON>>({
-              description: 'Cold App Start',
+              description: 'Cold Start',
             }),
             expect.objectContaining<Partial<SpanJSON>>({
               data: {
@@ -319,7 +319,7 @@ describe('React Navigation - TTID', () => {
           type: 'transaction',
           spans: expect.arrayContaining([
             expect.objectContaining<Partial<SpanJSON>>({
-              description: 'Cold App Start',
+              description: 'Cold Start',
             }),
           ]),
           measurements: expect.objectContaining<Required<TransactionEvent>['measurements']>({


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
It's a description, no logic should rely on it, but turned out some does. I open this PR on v7 branch since logic depends on it, I consider this a breaking change.

This PR aligns the naming to match the native SDKs.

https://github.com/getsentry/sentry-cocoa/blob/5c3fa88fefada71a9fd8c567cffd03f875dd94c7/Sources/Sentry/SentryBuildAppStartSpans.m#L40-L51

https://github.com/getsentry/sentry-java/blob/main/sentry-android-core/src/main/java/io/sentry/android/core/ActivityLifecycleIntegration.java#L767-L773

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?
ci

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [ ] No breaking changes
