### PR TITLE
chore(android): Bump Sentry Android SDK to v7.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 
 ## Unreleased
 
-- Bump Android SDK from v7.22.0 to v7.22.1([#4643](https://github.com/getsentry/sentry-react-native/pull/4643))
+### Fixes
+
+- Fixes missing Cold Start measurements by bumping the Android SDK version to v7.22.1 ([#4643](https://github.com/getsentry/sentry-react-native/pull/4643))
+
+### Dependencies
+
+- Bump Android SDK from v7.22.0 to v7.22.1 ([#4643](https://github.com/getsentry/sentry-react-native/pull/4643))
   - [changelog](https://github.com/getsentry/sentry-java/blob/7.x.x/CHANGELOG.md#7221)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.22.0...7.22.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+- Bump Android SDK from v7.22.0 to v7.22.1([#4643](https://github.com/getsentry/sentry-react-native/pull/4643))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/7.x.x/CHANGELOG.md#7221)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.22.0...7.22.1)
+
 ## 6.9.0
 
 ### Features
@@ -16,7 +22,7 @@
 
   ```js
   import Sentry from "@sentry/react-native";
-  
+
   Sentry.showFeedbackWidget();
 
   Sentry.wrap(RootComponent);

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -54,5 +54,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:7.22.0'
+    api 'io.sentry:sentry-android:7.22.1'
 }


### PR DESCRIPTION
Updates the Android SDK dependency to the latest patch version, which includes potential bug fixes and improvements for measuring cold and warm starts.
