### PR TITLE
feat(samples): Add Spaceflight News screen with article fetching

### DIFF
--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -29,6 +29,8 @@
     "@react-navigation/stack": "^7.1.1",
     "@sentry/core": "8.54.0",
     "@sentry/react-native": "6.9.1",
+    "@shopify/flash-list": "^1.7.3",
+    "axios": "^1.8.3",
     "delay": "^6.0.0",
     "react": "18.3.1",
     "react-native": "0.77.1",

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -37,6 +37,7 @@ import HeavyNavigationScreen from './Screens/HeavyNavigationScreen';
 import WebviewScreen from './Screens/WebviewScreen';
 import { isTurboModuleEnabled } from '@sentry/react-native/dist/js/utils/environment';
 import * as ImagePicker from 'react-native-image-picker';
+import SpaceflightNewsScreen from './Screens/SpaceflightNewsScreen';
 
 /* false by default to avoid issues in e2e tests waiting for the animation end */
 const RUNNING_INDICATOR = false;
@@ -81,6 +82,7 @@ Sentry.init({
       Sentry.reactNativeTracingIntegration({
         // The time to wait in ms until the transaction will be finished, For testing, default is 1000 ms
         idleTimeoutMs: 5_000,
+        traceFetch: false, // Creates duplicate span for axios requests
       }),
       Sentry.httpClientIntegration({
         // These options are effective only in JS.
@@ -207,6 +209,10 @@ const PerformanceTabNavigator = Sentry.withProfiler(
               name="PerformanceScreen"
               component={PerformanceScreen}
               options={{ title: 'Performance' }}
+            />
+            <Stack.Screen
+              name="SpaceflightNewsScreen"
+              component={SpaceflightNewsScreen}
             />
             <Stack.Screen name="Tracker" component={TrackerScreen} />
             <Stack.Screen

--- a/samples/react-native/src/Screens/PerformanceScreen.tsx
+++ b/samples/react-native/src/Screens/PerformanceScreen.tsx
@@ -41,6 +41,12 @@ const PerformanceScreen = (props: Props) => {
       <StatusBar barStyle="dark-content" />
       <ScrollView style={styles.mainView}>
         <Button
+          title="Open Spaceflight News"
+          onPress={() => {
+            props.navigation.navigate('SpaceflightNewsScreen');
+          }}
+        />
+        <Button
           title="Auto Tracing Example"
           onPress={() => {
             props.navigation.navigate('Tracker');

--- a/samples/react-native/src/Screens/SpaceflightNewsScreen.tsx
+++ b/samples/react-native/src/Screens/SpaceflightNewsScreen.tsx
@@ -1,0 +1,161 @@
+/* eslint-disable react/no-unstable-nested-components */
+import React, { useState, useCallback } from 'react';
+import { View, ActivityIndicator, StyleSheet, RefreshControl, Text, Pressable } from 'react-native';
+import { FlashList } from '@shopify/flash-list';
+import axios from 'axios';
+import { ArticleCard } from '../components/ArticleCard';
+import type { Article } from '../types/api';
+import { useFocusEffect } from '@react-navigation/native';
+
+const ITEMS_PER_PAGE = 2; // Small limit to create more spans
+const AUTO_LOAD_LIMIT = 1; // One auto load at the end of the list then shows button
+const API_URL = 'https://api.spaceflightnewsapi.net/v4/articles';
+
+export default function NewsScreen() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [autoLoadCount, setAutoLoadCount] = useState(0);
+
+  const fetchArticles = async (pageNumber: number, refresh = false) => {
+    try {
+      const response = await axios.get(API_URL, {
+        params: {
+          limit: ITEMS_PER_PAGE,
+          offset: (pageNumber - 1) * ITEMS_PER_PAGE,
+        },
+      });
+
+      const newArticles = response.data.results;
+      setHasMore(response.data.next !== null);
+
+      if (refresh) {
+        setArticles(newArticles);
+        setAutoLoadCount(0);
+      } else {
+        setArticles((prev) => [...prev, ...newArticles]);
+      }
+    } catch (error) {
+      console.error('Error fetching articles:', error);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchArticles(1, true);
+    }, [])
+  );
+
+  const handleLoadMore = () => {
+    if (!loading && hasMore) {
+      setPage((prev) => prev + 1);
+      fetchArticles(page + 1);
+      setAutoLoadCount((prev) => prev + 1);
+    }
+  };
+
+  const handleManualLoadMore = () => {
+    handleLoadMore();
+  };
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    setPage(1);
+    fetchArticles(1, true);
+  };
+
+  const handleEndReached = () => {
+    if (autoLoadCount < AUTO_LOAD_LIMIT) {
+      handleLoadMore();
+    }
+  };
+
+  const LoadMoreButton = () => {
+    if (!hasMore) {return null;}
+    if (loading) {
+      return (
+        <View style={styles.loadMoreContainer}>
+          <ActivityIndicator size="small" color="#007AFF" />
+        </View>
+      );
+    }
+    return (
+      <Pressable
+        style={({ pressed }) => [
+          styles.loadMoreButton,
+          pressed && styles.loadMoreButtonPressed,
+        ]}
+        onPress={handleManualLoadMore}>
+        <Text style={styles.loadMoreText}>Load More Articles</Text>
+      </Pressable>
+    );
+  };
+
+  if (loading && !refreshing) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" color="#007AFF" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlashList
+        data={articles}
+        renderItem={({ item }) => <ArticleCard article={item} />}
+        estimatedItemSize={350}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.5}
+        ListFooterComponent={autoLoadCount >= AUTO_LOAD_LIMIT ? LoadMoreButton : null}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadMoreContainer: {
+    paddingVertical: 20,
+    alignItems: 'center',
+  },
+  loadMoreButton: {
+    backgroundColor: '#007AFF',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    marginVertical: 20,
+    marginHorizontal: 16,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  loadMoreButtonPressed: {
+    opacity: 0.8,
+    transform: [{ scale: 0.98 }],
+  },
+  loadMoreText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/samples/react-native/src/components/ArticleCard.tsx
+++ b/samples/react-native/src/components/ArticleCard.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet, Pressable } from 'react-native';
+import type { Article } from '../types/api';
+import * as Sentry from '@sentry/react-native';
+interface ArticleCardProps {
+  article: Article;
+}
+
+export function ArticleCard({ article }: ArticleCardProps) {
+  return (
+    <View>
+      <Sentry.TimeToFullDisplay record={true} />
+      <Sentry.Profiler name="ArticleCard">
+        <Pressable style={styles.card}>
+          <Image source={{ uri: article.image_url }} style={styles.image} />
+          <View style={styles.content}>
+            <Text style={styles.source}>{article.news_site}</Text>
+            <Text style={styles.title} numberOfLines={2}>
+              {article.title}
+            </Text>
+            <Text style={styles.summary} numberOfLines={3}>
+              {article.summary}
+            </Text>
+            <Text style={styles.date}>
+              {new Date(article.published_at).toLocaleDateString()}
+            </Text>
+          </View>
+        </Pressable>
+      </Sentry.Profiler>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    marginHorizontal: 16,
+    marginVertical: 8,
+    overflow: 'hidden',
+    elevation: 3,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  image: {
+    width: '100%',
+    height: 200,
+    resizeMode: 'cover',
+  },
+  content: {
+    padding: 16,
+  },
+  source: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 4,
+    fontWeight: '600',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: '#1a1a1a',
+  },
+  summary: {
+    fontSize: 16,
+    color: '#444',
+    lineHeight: 22,
+    marginBottom: 12,
+  },
+  date: {
+    fontSize: 14,
+    color: '#666',
+  },
+});

--- a/samples/react-native/src/types/api.ts
+++ b/samples/react-native/src/types/api.ts
@@ -1,0 +1,18 @@
+export interface Article {
+  id: number;
+  title: string;
+  url: string;
+  image_url: string;
+  news_site: string;
+  summary: string;
+  published_at: string;
+  updated_at: string;
+  featured: boolean;
+}
+
+export interface ArticlesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Article[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8230,6 +8230,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shopify/flash-list@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@shopify/flash-list@npm:1.7.3"
+  dependencies:
+    recyclerlistview: 4.2.1
+    tslib: 2.8.1
+  peerDependencies:
+    "@babel/runtime": "*"
+    react: "*"
+    react-native: "*"
+  checksum: cbf3289779141777eab4ec6f1a59b90c6f2f91fb4a880dad09ace5e37559a1448ddbf7a282c8787bb7b4f1b45d3f612f8a940760accfd88313494d47a1d63cce
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -10839,6 +10853,17 @@ __metadata:
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
   checksum: 2859fe01437cf133eee35571abc1d4b5224bb13e530e66cb3581ca226e170541dd5eef9f46abb41592cee0a2f54930c9e4978354e0cf1064748fc20d9a05e9d5
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.8.3":
+  version: 1.8.3
+  resolution: "axios@npm:1.8.3"
+  dependencies:
+    follow-redirects: ^1.15.6
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 85fc8ad7d968e43ea9da5513310637d29654b181411012ee14cc0a4b3662782e6c81ac25eea40b5684f86ed2d8a01fa6fc20b9b48c4da14ef4eaee848fea43bc
   languageName: node
   linkType: hard
 
@@ -18982,7 +19007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.debounce@npm:^4.0.8":
+"lodash.debounce@npm:4.0.8, lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: a3f527d22c548f43ae31c861ada88b2637eb48ac6aa3eb56e82d44917971b8aa96fbb37aa60efea674dc4ee8c42074f90f7b1f772e9db375435f6c83a19b3bc6
@@ -22477,7 +22502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:15.8.1, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -23711,6 +23736,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"recyclerlistview@npm:4.2.1":
+  version: 4.2.1
+  resolution: "recyclerlistview@npm:4.2.1"
+  dependencies:
+    lodash.debounce: 4.0.8
+    prop-types: 15.8.1
+    ts-object-utils: 0.0.5
+  peerDependencies:
+    react: ">= 15.2.1"
+    react-native: ">= 0.30.0"
+  checksum: 48e84937f803ac2acb510b2bc36b3ef1ea9c5383540a832f80c87d7e7f933b26c59e4ffc2d7de529be55e14a8d551c4f6660a450ad220142f351e6bf6e630450
+  languageName: node
+  linkType: hard
+
 "redent@npm:^3.0.0":
   version: 3.0.0
   resolution: "redent@npm:3.0.0"
@@ -24665,6 +24704,7 @@ __metadata:
     "@sentry/babel-plugin-component-annotate": 3.2.2
     "@sentry/core": 8.54.0
     "@sentry/react-native": 6.9.1
+    "@shopify/flash-list": ^1.7.3
     "@types/jest": ^29.5.14
     "@types/node": ^22.13.1
     "@types/react": ^18.2.65
@@ -24672,6 +24712,7 @@ __metadata:
     "@types/react-test-renderer": ^18.0.0
     "@typescript-eslint/eslint-plugin": ^7.18.0
     "@typescript-eslint/parser": ^7.18.0
+    axios: ^1.8.3
     babel-jest: ^29.6.3
     babel-plugin-module-resolver: ^5.0.0
     delay: ^6.0.0
@@ -26364,6 +26405,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-object-utils@npm:0.0.5":
+  version: 0.0.5
+  resolution: "ts-object-utils@npm:0.0.5"
+  checksum: 83c48fbdaba392fb2c01cea53b267ed5538d2bb44fc6c3eecc10bcfabc1780bfa6ec8569b52bbf0140d9b521d9049d5f15884e12286918244d463d854dbc73cb
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.10.1, tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -26384,6 +26432,13 @@ __metadata:
     minimist: "npm:^1.2.6"
     strip-bom: "npm:^3.0.0"
   checksum: 28c5f7bbbcabc9dabd4117e8fdc61483f6872a1c6b02a4b1c4d68c5b79d06896c3cc9547610c4c3ba64658531caa2de13ead1ea1bf321c7b53e969c4752b98c7
+  languageName: node
+  linkType: hard
+
+"tslib@npm:2.8.1":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

![Screenshot 2025-03-13 at 16 20 57](https://github.com/user-attachments/assets/54bd033f-6f0c-4b1d-970c-3052d7634283)
![Screenshot 2025-03-13 at 16 20 44](https://github.com/user-attachments/assets/1c8ca4cc-b411-45f0-9bcc-0d91d6e6020a)

- Introduced a new screen for displaying spaceflight news articles using the Spaceflight News API.
- Integrated `@shopify/flash-list` for efficient rendering of articles.
- Added `ArticleCard` component for individual article display.
- Included navigation to the new screen from the Performance screen.
- Updated dependencies in package.json for `@shopify/flash-list` and `axios`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- This will help us test and debug TTID/TTFD and Flash List related issues...

## :green_heart: How did you test it?
running the sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

#skip-changelog 