### PR TITLE
feat(replay): iOS: Adds `enableExperimentalViewRenderer` and `enableFastViewRendering` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@
 - Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
 - Exposed `getDataFromUri` as a public API to retrieve data from a URI ([#4638](https://github.com/getsentry/sentry-react-native/pull/4638))
 - Improve Warm App Start reporting on Android ([#4641](https://github.com/getsentry/sentry-react-native/pull/4641))
+- Add experimental flags `enableExperimentalViewRenderer` and `enableFastViewRendering` to enable up to 5x times more performance in Session Replay on iOS ([#4660](https://github.com/getsentry/sentry-react-native/pull/4660))
+
+  ```js
+  import * as Sentry from '@sentry/react-native';
+
+  Sentry.init({
+    integrations: [
+      Sentry.mobileReplayIntegration({
+        enableExperimentalViewRenderer: true,
+        enableFastViewRendering: true,
+      }),
+    ],
+  });
+  ```
 
 ### Fixes
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
@@ -48,13 +48,15 @@ final class RNSentryReplayOptions: XCTestCase {
     }
 
     func assertAllDefaultReplayOptionsAreNotNil(replayOptions: [String: Any]) {
-        XCTAssertEqual(replayOptions.count, 6)
+        XCTAssertEqual(replayOptions.count, 8)
         XCTAssertNotNil(replayOptions["sessionSampleRate"])
         XCTAssertNotNil(replayOptions["errorSampleRate"])
         XCTAssertNotNil(replayOptions["maskAllImages"])
         XCTAssertNotNil(replayOptions["maskAllText"])
         XCTAssertNotNil(replayOptions["maskedViewClasses"])
         XCTAssertNotNil(replayOptions["sdkInfo"])
+        XCTAssertNotNil(replayOptions["enableExperimentalViewRenderer"])
+        XCTAssertNotNil(replayOptions["enableFastViewRendering"])
     }
 
     func testSessionSampleRate() {

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
@@ -166,5 +166,87 @@ final class RNSentryReplayOptions: XCTestCase {
         XCTAssertEqual(actualOptions.sessionReplay.maskAllText, false)
         XCTAssertEqual(actualOptions.sessionReplay.maskedViewClasses.count, 0)
     }
+    
+    func testEnableExperimentalViewRendererDefault() {
+        let optionsDict = ([
+            "dsn": "https://abc@def.ingest.sentry.io/1234567",
+            "replaysOnErrorSampleRate": 0.75
+        ] as NSDictionary).mutableCopy() as! NSMutableDictionary
+
+        RNSentryReplay.updateOptions(optionsDict)
+
+        let actualOptions = try! Options(dict: optionsDict as! [String: Any])
+
+        XCTAssertFalse(actualOptions.sessionReplay.enableExperimentalViewRenderer)
+    }
+    
+    func testEnableExperimentalViewRendererTrue() {
+        let optionsDict = ([
+            "dsn": "https://abc@def.ingest.sentry.io/1234567",
+            "replaysOnErrorSampleRate": 0.75,
+            "mobileReplayOptions": [ "enableExperimentalViewRenderer": true ]
+        ] as NSDictionary).mutableCopy() as! NSMutableDictionary
+
+        RNSentryReplay.updateOptions(optionsDict)
+
+        let actualOptions = try! Options(dict: optionsDict as! [String: Any])
+
+        XCTAssertTrue(actualOptions.sessionReplay.enableExperimentalViewRenderer)
+    }
+    
+    func testEnableExperimentalViewRendererFalse() {
+        let optionsDict = ([
+            "dsn": "https://abc@def.ingest.sentry.io/1234567",
+            "replaysOnErrorSampleRate": 0.75,
+            "mobileReplayOptions": [ "enableExperimentalViewRenderer": false ]
+        ] as NSDictionary).mutableCopy() as! NSMutableDictionary
+
+        RNSentryReplay.updateOptions(optionsDict)
+
+        let actualOptions = try! Options(dict: optionsDict as! [String: Any])
+
+        XCTAssertFalse(actualOptions.sessionReplay.enableExperimentalViewRenderer)
+    }
+    
+    func testEnableFastViewRenderingDefault() {
+        let optionsDict = ([
+            "dsn": "https://abc@def.ingest.sentry.io/1234567",
+            "replaysOnErrorSampleRate": 0.75
+        ] as NSDictionary).mutableCopy() as! NSMutableDictionary
+
+        RNSentryReplay.updateOptions(optionsDict)
+
+        let actualOptions = try! Options(dict: optionsDict as! [String: Any])
+
+        XCTAssertFalse(actualOptions.sessionReplay.enableFastViewRendering)
+    }
+    
+    func testEnableFastViewRenderingTrue() {
+        let optionsDict = ([
+            "dsn": "https://abc@def.ingest.sentry.io/1234567",
+            "replaysOnErrorSampleRate": 0.75,
+            "mobileReplayOptions": [ "enableFastViewRendering": true ]
+        ] as NSDictionary).mutableCopy() as! NSMutableDictionary
+
+        RNSentryReplay.updateOptions(optionsDict)
+
+        let actualOptions = try! Options(dict: optionsDict as! [String: Any])
+
+        XCTAssertTrue(actualOptions.sessionReplay.enableFastViewRendering)
+    }
+    
+    func testEnableFastViewRenderingFalse() {
+        let optionsDict = ([
+            "dsn": "https://abc@def.ingest.sentry.io/1234567",
+            "replaysOnErrorSampleRate": 0.75,
+            "mobileReplayOptions": [ "enableFastViewRendering": false ]
+        ] as NSDictionary).mutableCopy() as! NSMutableDictionary
+
+        RNSentryReplay.updateOptions(optionsDict)
+
+        let actualOptions = try! Options(dict: optionsDict as! [String: Any])
+
+        XCTAssertFalse(actualOptions.sessionReplay.enableFastViewRendering)
+    }
 
 }

--- a/packages/core/ios/RNSentryReplay.mm
+++ b/packages/core/ios/RNSentryReplay.mm
@@ -27,6 +27,8 @@
         @"errorSampleRate" : options[@"replaysOnErrorSampleRate"] ?: [NSNull null],
         @"maskAllImages" : replayOptions[@"maskAllImages"] ?: [NSNull null],
         @"maskAllText" : replayOptions[@"maskAllText"] ?: [NSNull null],
+        @"enableExperimentalViewRenderer" : replayOptions[@"enableExperimentalViewRenderer"] ?: [NSNull null],
+        @"enableFastViewRendering" : replayOptions[@"enableFastViewRendering"] ?: [NSNull null],
         @"maskedViewClasses" : [RNSentryReplay getReplayRNRedactClasses:replayOptions],
         @"sdkInfo" :
             @ { @"name" : REACT_NATIVE_SDK_NAME, @"version" : REACT_NATIVE_SDK_PACKAGE_VERSION }

--- a/packages/core/ios/RNSentryReplay.mm
+++ b/packages/core/ios/RNSentryReplay.mm
@@ -27,7 +27,8 @@
         @"errorSampleRate" : options[@"replaysOnErrorSampleRate"] ?: [NSNull null],
         @"maskAllImages" : replayOptions[@"maskAllImages"] ?: [NSNull null],
         @"maskAllText" : replayOptions[@"maskAllText"] ?: [NSNull null],
-        @"enableExperimentalViewRenderer" : replayOptions[@"enableExperimentalViewRenderer"] ?: [NSNull null],
+        @"enableExperimentalViewRenderer" : replayOptions[@"enableExperimentalViewRenderer"]
+            ?: [NSNull null],
         @"enableFastViewRendering" : replayOptions[@"enableFastViewRendering"] ?: [NSNull null],
         @"maskedViewClasses" : [RNSentryReplay getReplayRNRedactClasses:replayOptions],
         @"sdkInfo" :

--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -45,7 +45,7 @@ export interface MobileReplayOptions {
   enableExperimentalViewRenderer?: boolean;
 
   /**
-   * Enables up to 5x faster but incommpelte view rendering used by the Session Replay integration on iOS.
+   * Enables up to 5x faster but incomplete view rendering used by the Session Replay integration on iOS.
    *
    * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing
    * interruptions and visual lag.

--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -31,12 +31,39 @@ export interface MobileReplayOptions {
    * @default true
    */
   maskAllVectors?: boolean;
+
+  /**
+   * Enables the up to 5x faster experimental view renderer used by the Session Replay integration on iOS.
+   *
+   * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing
+   * interruptions and visual lag.
+   *
+   * - Experiment: This is an experimental feature and is therefore disabled by default.
+   *
+   * @default false
+   */
+  enableExperimentalViewRenderer?: boolean;
+
+  /**
+   * Enables up to 5x faster but incommpelte view rendering used by the Session Replay integration on iOS.
+   *
+   * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing
+   * interruptions and visual lag.
+   *
+   * - Note: This flag can only be used together with `enableExperimentalViewRenderer` with up to 20% faster render times.
+   * - Experiment: This is an experimental feature and is therefore disabled by default.
+   *
+   * @default false
+   */
+  enableFastViewRendering?: boolean;
 }
 
 const defaultOptions: Required<MobileReplayOptions> = {
   maskAllText: true,
   maskAllImages: true,
   maskAllVectors: true,
+  enableExperimentalViewRenderer: false,
+  enableFastViewRendering: false,
 };
 
 type MobileReplayIntegration = Integration & {

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -98,6 +98,8 @@ Sentry.init({
         maskAllImages: true,
         maskAllVectors: true,
         maskAllText: true,
+        enableExperimentalViewRenderer: true,
+        enableFastViewRendering: true,
       }),
       Sentry.appStartIntegration({
         standalone: false,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring

Depends on https://github.com/getsentry/sentry-cocoa/pull/4988

## :scroll: Description
<!--- Describe your changes in detail -->
Adds `enableExperimentalViewRenderer` and `enableFastViewRendering` mobile replay options from sentry-cocoa

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-react-native/issues/4658

## :green_heart: How did you test it?

Sample App, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
