### PR TITLE
feat(ttid): Add support for measuring Time to Initial Display for already seen routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 - Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
 - Exposed `getDataFromUri` as a public API to retrieve data from a URI ([#4638](https://github.com/getsentry/sentry-react-native/pull/4638))
 - Improve Warm App Start reporting on Android ([#4641](https://github.com/getsentry/sentry-react-native/pull/4641))
+- Add support for measuring Time to Initial Display for already seen routes ([#4661](https://github.com/getsentry/sentry-react-native/pull/4661))
+  - Introduce `enableTimeToInitialDisplayForPreloadedRoutes` option to the React Navigation integration.
+
+  ```js
+  Sentry.reactNavigationIntegration({
+    enableTimeToInitialDisplayForPreloadedRoutes: true,
+  });
+  ```
 
 ### Fixes
 

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -53,6 +53,7 @@ const reactNavigationIntegration = Sentry.reactNavigationIntegration({
   routeChangeTimeoutMs: 500, // How long it will wait for the route change to complete. Default is 1000ms
   enableTimeToInitialDisplay: isMobileOs,
   ignoreEmptyBackNavigationTransactions: true,
+  enableTimeToInitialDisplayForPreloadedRoutes: true,
 });
 
 Sentry.init({


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Enhancement


## :scroll: Description
<!--- Describe your changes in detail -->

- Introduced `enableTimeToInitialDisplayForPreloadedRoutes` option to the React Navigation integration.
- Updated logic to measure Time to Initial Display for routes that have already been seen.
- Added tests to verify functionality for preloaded routes in the tracing module.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Depending on an application, this can improve the number of transactions with TTID measurements. 

Originally we excluded already seen routes with the idea that the seen route is already loaded.

But routes that have been seen, can on the next visit refresh their context and this PR enables users to measure the time this next visit takes to load.

## :green_heart: How did you test it?
integration test, manually in sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes