### PR TITLE
test(ts3.8): fix ts3.8 type check failure due to duplicate types

### DIFF
--- a/dev-packages/type-check/run-type-check.sh
+++ b/dev-packages/type-check/run-type-check.sh
@@ -14,6 +14,9 @@ yalc add @sentry/react-native
 
 yarn install
 
+echo "Removing duplicate React types..."
+rm -rf ./node_modules/@types/react-native/node_modules/@types/react
+
 yarn type-check
 
 rm yarn.lock


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes ts3.8 type check failure due to duplicate types bye removing the duplication before running the check

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Typecheck issue https://github.com/getsentry/sentry-react-native/actions/runs/13950985149/job/39050330145

## :green_heart: How did you test it?
Locally, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog