### PR TITLE
fix(ttd): Equalize TTID and TTFD duration when TTFD manual API is called and resolved before auto TTID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Handle non-string category in getCurrentScreen on iOS ([#4629](https://github.com/getsentry/sentry-react-native/pull/4629))
 - Use route name instead of route key for current route tracking ([#4650](https://github.com/getsentry/sentry-react-native/pull/4650))
   - Using key caused user interaction transaction names to contain route hash in the name.
-- Equalize TTID and TTFD duration when TTFD manual API is called and resolved before auto TTID ([#4665](https://github.com/getsentry/sentry-react-native/pull/4665))
+- Equalize TTID and TTFD duration when TTFD manual API is called and resolved before auto TTID ([#4680](https://github.com/getsentry/sentry-react-native/pull/4680))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Handle non-string category in getCurrentScreen on iOS ([#4629](https://github.com/getsentry/sentry-react-native/pull/4629))
 - Use route name instead of route key for current route tracking ([#4650](https://github.com/getsentry/sentry-react-native/pull/4650))
   - Using key caused user interaction transaction names to contain route hash in the name.
+- Equalize TTID and TTFD duration when TTFD manual API is called and resolved before auto TTID ([#4662](https://github.com/getsentry/sentry-react-native/pull/4662))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
 - Exposed `getDataFromUri` as a public API to retrieve data from a URI ([#4638](https://github.com/getsentry/sentry-react-native/pull/4638))
 - Improve Warm App Start reporting on Android ([#4641](https://github.com/getsentry/sentry-react-native/pull/4641))
-- Add support for measuring Time to Initial Display for already seen routes ([#4665](https://github.com/getsentry/sentry-react-native/pull/4665))
+- Add support for measuring Time to Initial Display for already seen routes ([#4661](https://github.com/getsentry/sentry-react-native/pull/4661))
   - Introduce `enableTimeToInitialDisplayForPreloadedRoutes` option to the React Navigation integration.
 
   ```js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 - Add thread information to spans ([#4579](https://github.com/getsentry/sentry-react-native/pull/4579))
 - Exposed `getDataFromUri` as a public API to retrieve data from a URI ([#4638](https://github.com/getsentry/sentry-react-native/pull/4638))
 - Improve Warm App Start reporting on Android ([#4641](https://github.com/getsentry/sentry-react-native/pull/4641))
+- Add support for measuring Time to Initial Display for already seen routes ([#4661](https://github.com/getsentry/sentry-react-native/pull/4661))
+  - Introduce `enableTimeToInitialDisplayForPreloadedRoutes` option to the React Navigation integration.
+
+  ```js
+  Sentry.reactNavigationIntegration({
+    enableTimeToInitialDisplayForPreloadedRoutes: true,
+  });
+  ```
 
 ### Fixes
 

--- a/packages/core/src/js/tracing/reactnavigation.ts
+++ b/packages/core/src/js/tracing/reactnavigation.ts
@@ -32,8 +32,7 @@ import {
   getDefaultIdleNavigationSpanOptions,
   startIdleNavigationSpan as startGenericIdleNavigationSpan,
 } from './span';
-import { manualInitialDisplaySpans, startTimeToInitialDisplaySpan } from './timetodisplay';
-import { setSpanDurationAsMeasurementOnSpan } from './utils';
+import { manualInitialDisplaySpans, startTimeToInitialDisplaySpan, updateInitialDisplaySpan } from './timetodisplay';
 export const INTEGRATION_NAME = 'ReactNavigation';
 
 const NAVIGATION_HISTORY_MAX_SIZE = 200;
@@ -297,9 +296,10 @@ export const reactNavigationIntegration = ({
           return;
         }
 
-        latestTtidSpan.setStatus({ code: SPAN_STATUS_OK });
-        latestTtidSpan.end(newFrameTimestampInSeconds);
-        setSpanDurationAsMeasurementOnSpan('time_to_initial_display', latestTtidSpan, navigationSpanWithTtid);
+        updateInitialDisplaySpan(newFrameTimestampInSeconds, {
+          activeSpan: navigationSpanWithTtid,
+          span: latestTtidSpan,
+        });
       });
     }
 

--- a/packages/core/test/tracing/reactnavigation.ttid.test.tsx
+++ b/packages/core/test/tracing/reactnavigation.ttid.test.tsx
@@ -351,6 +351,28 @@ describe('React Navigation - TTID', () => {
       expect(getSpanDurationMs(transaction, 'ui.load.initial_display')).toEqual(transaction.measurements?.time_to_initial_display?.value);
     });
 
+    test('ttfd span duration and measurement should equal ttid from ttfd is called earlier than ttid', () => {
+      jest.runOnlyPendingTimers(); // Flush app start transaction
+
+      mockedNavigation.navigateToNewScreen();
+      TestRenderer.render(<TimeToFullDisplay record />);
+      emitNativeFullDisplayEvent();
+      mockedEventEmitter.emitNewFrameEvent();
+
+      jest.runOnlyPendingTimers(); // Flush navigation transaction
+
+      const transaction = getLastTransaction(transportSendMock);
+      const ttfdSpanDuration = getSpanDurationMs(transaction, 'ui.load.full_display');
+      const ttidSpanDuration = getSpanDurationMs(transaction, 'ui.load.initial_display');
+      expect(ttfdSpanDuration).toBeDefined();
+      expect(ttidSpanDuration).toBeDefined();
+      expect(ttfdSpanDuration).toEqual(ttidSpanDuration);
+
+      expect(transaction.measurements?.time_to_full_display?.value).toBeDefined();
+      expect(transaction.measurements?.time_to_initial_display?.value).toBeDefined();
+      expect(transaction.measurements?.time_to_full_display?.value).toEqual(transaction.measurements?.time_to_initial_display?.value);
+    });
+
     test('ttfd span duration and measurement should equal for application start up', () => {
       mockedNavigation.finishAppStartNavigation();
       mockedEventEmitter.emitNewFrameEvent();

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -53,6 +53,7 @@ const reactNavigationIntegration = Sentry.reactNavigationIntegration({
   routeChangeTimeoutMs: 500, // How long it will wait for the route change to complete. Default is 1000ms
   enableTimeToInitialDisplay: isMobileOs,
   ignoreEmptyBackNavigationTransactions: true,
+  enableTimeToInitialDisplayForPreloadedRoutes: true,
 });
 
 Sentry.init({


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes an issue where the TTFD would be reported before the automatic TTID is finished. This can happen during navigation animation, as the automatic TTID waits for the navigation animation to finish, but TTFD is reported when data are available and rendered.           

The expected behavior is that TTFD reported before TTID will be adjusted to the TTID end.

## :green_heart: How did you test it?
sample app and added integration test

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
