### PR TITLE
fix: Changed `gradle.projectsEvaluated` to `project.afterEvaluate` in the Sentry Gradle Plugin to ensure tasks are created correctly with `--configure-on-demand`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -159,6 +159,7 @@ jobs:
       USE_FRAMEWORKS: ${{ matrix.ios-use-frameworks }}
       PRODUCTION: ${{ matrix.build-type == 'production' && '1' || '0' }}
       RCT_NEW_ARCH_ENABLED: ${{ matrix.rn-architecture == 'new' && '1' || '0' }}
+      SENTRY_DISABLE_AUTO_UPLOAD: 'false'
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
   });
   ```
 
+### Changes
+
+- Change `gradle.projectsEvaluated` to `project.afterEvaluate` in the Sentry Gradle Plugin to fix tasks not being created when using `--configure-on-demand` ([#4687](https://github.com/getsentry/sentry-react-native/pull/4687))
+
 ### Fixes
 
 - Considers the `SENTRY_DISABLE_AUTO_UPLOAD` and `SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD` environment variables in the configuration of the Sentry Android Gradle Plugin for Expo plugin ([#4583](https://github.com/getsentry/sentry-react-native/pull/4583))

--- a/dev-packages/e2e-tests/patch-scripts/rn.patch.xcode.js
+++ b/dev-packages/e2e-tests/patch-scripts/rn.patch.xcode.js
@@ -32,7 +32,6 @@ if (semver.satisfies(args['rn-version'], `< ${newBundleScriptRNVersion}`, { incl
   logger.info('Applying old bundle script patch');
   bundleScript = `
 export NODE_BINARY=node
-export SENTRY_CLI_EXTRA_ARGS="--force-foreground"
 ../node_modules/@sentry/react-native/scripts/sentry-xcode.sh ../node_modules/react-native/scripts/react-native-xcode.sh
 `;
   bundleScriptRegex = /(packager|scripts)\/react-native-xcode\.sh\b/;
@@ -40,7 +39,6 @@ export SENTRY_CLI_EXTRA_ARGS="--force-foreground"
 } else if (semver.satisfies(args['rn-version'], `>= ${newBundleScriptRNVersion}`, { includePrerelease: true })) {
   logger.info('Applying new bundle script patch');
   bundleScript = `
-export SENTRY_CLI_EXTRA_ARGS="--force-foreground"
 WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
 REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"
 

--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-project.ext.shouldSentryAutoUploadNative = { -> 
+project.ext.shouldSentryAutoUploadNative = { ->
   return System.getenv('SENTRY_DISABLE_NATIVE_DEBUG_UPLOAD') != 'true'
 }
 
@@ -17,7 +17,9 @@ project.ext.shouldSentryAutoUpload = { ->
 
 def config = project.hasProperty("sentryCli") ? project.sentryCli : [];
 
-gradle.projectsEvaluated {
+// gradle.projectsEvaluated doesn't work with --configure-on-demand
+// the task are create too late and not executed
+project.afterEvaluate {
     def releases = extractReleasesInfo()
 
     if (config.flavorAware && config.sentryProperties) {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The Expo CLI uses `--configure-on-demand` flag https://github.com/expo/expo/blob/0b739b22bf7ce312cd0399a7147f2f11da7f75ef/packages/@expo/cli/src/start/platforms/android/gradle.ts#L75

which causes the tasks created in `gradle.projectsEvaluated` to not be executed.

This PR updates the `sentry.gradle` to use `project.afterEvaluate` which executes earlier and this task are correctly registered and executed.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes: https://github.com/getsentry/sentry-react-native/issues/3907

## :green_heart: How did you test it?
sample app,

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
