### PR TITLE
fix(appRegistry): Handles missing global object and web environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Improve Warm App Start reporting on Android ([#4641](https://github.com/getsentry/sentry-react-native/pull/4641))
+- Improve Warm App Start reporting on Android ([#4641](https://github.com/getsentry/sentry-react-native/pull/4641), [#4695](https://github.com/getsentry/sentry-react-native/pull/4695))
 - Add `createTimeToInitialDisplay({useFocusEffect})` and `createTimeToFullDisplay({useFocusEffect})` to allow record full display on screen focus ([#4665](https://github.com/getsentry/sentry-react-native/pull/4665))
 - Add support for measuring Time to Initial Display for already seen routes ([#4661](https://github.com/getsentry/sentry-react-native/pull/4661))
   - Introduce `enableTimeToInitialDisplayForPreloadedRoutes` option to the React Navigation integration.

--- a/packages/core/src/js/integrations/appRegistry.ts
+++ b/packages/core/src/js/integrations/appRegistry.ts
@@ -1,9 +1,9 @@
 import type { Client, Integration } from '@sentry/core';
 import { getClient, logger } from '@sentry/core';
 
+import { isWeb } from '../utils/environment';
 import { fillTyped } from '../utils/fill';
 import { ReactNativeLibraries } from '../utils/rnlibraries';
-import { isWeb } from '../utils/environment';
 
 export const INTEGRATION_NAME = 'AppRegistry';
 

--- a/packages/core/src/js/integrations/appRegistry.ts
+++ b/packages/core/src/js/integrations/appRegistry.ts
@@ -3,6 +3,7 @@ import { getClient, logger } from '@sentry/core';
 
 import { fillTyped } from '../utils/fill';
 import { ReactNativeLibraries } from '../utils/rnlibraries';
+import { isWeb } from '../utils/environment';
 
 export const INTEGRATION_NAME = 'AppRegistry';
 
@@ -14,6 +15,10 @@ export const appRegistryIntegration = (): Integration & {
   return {
     name: INTEGRATION_NAME,
     setupOnce: () => {
+      if (isWeb()) {
+        return;
+      }
+
       patchAppRegistryRunApplication(callbacks);
     },
     onRunApplication: (callback: () => void) => {
@@ -28,6 +33,9 @@ export const appRegistryIntegration = (): Integration & {
 
 export const patchAppRegistryRunApplication = (callbacks: (() => void)[]): void => {
   const { AppRegistry } = ReactNativeLibraries;
+  if (!AppRegistry) {
+    return;
+  }
 
   fillTyped(AppRegistry, 'runApplication', originalRunApplication => {
     return (...args) => {

--- a/packages/core/src/js/utils/rnlibraries.ts
+++ b/packages/core/src/js/utils/rnlibraries.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-
 import { AppRegistry, Platform, TurboModuleRegistry } from 'react-native';
 
 import type * as ReactNative from '../vendor/react-native';
 import type { ReactNativeLibrariesInterface } from './rnlibrariesinterface';
 
-export const ReactNativeLibraries: Required<ReactNativeLibrariesInterface> = {
+const InternalReactNativeLibrariesInterface: Required<ReactNativeLibrariesInterface> = {
   Devtools: {
     parseErrorStack: (errorStack: string): Array<ReactNative.StackFrame> => {
       const parseErrorStack = require('react-native/Libraries/Core/Devtools/parseErrorStack');
@@ -42,3 +41,5 @@ export const ReactNativeLibraries: Required<ReactNativeLibrariesInterface> = {
     },
   },
 };
+
+export const ReactNativeLibraries: ReactNativeLibrariesInterface = InternalReactNativeLibrariesInterface;

--- a/packages/core/test/integrations/appRegistry.test.ts
+++ b/packages/core/test/integrations/appRegistry.test.ts
@@ -1,7 +1,7 @@
 import { getOriginalFunction } from '@sentry/core';
 
-import * as Environment from '../../src/js/utils/environment';
 import { appRegistryIntegration } from '../../src/js/integrations/appRegistry';
+import * as Environment from '../../src/js/utils/environment';
 import { ReactNativeLibraries } from '../../src/js/utils/rnlibraries';
 
 const originalAppRegistry = ReactNativeLibraries.AppRegistry;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The appRegistry was not yet released.

The integration should handle web env gracefully.

## :green_heart: How did you test it?
sample expo app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
