### PR TITLE
fix(sample): Disable asyncRoutes for iOS in Expo configuration

### DIFF
--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -65,6 +65,7 @@
         {
           "asyncRoutes": {
             "web": true,
+            "ios": false,
             "default": "development"
           }
         }


### PR DESCRIPTION
This is not related to the Sentry RN SDK, it happens in app without Sentry as well.

Disabling the feature fixes https://github.com/expo/expo/issues/35224

#skip-changelog 