### PR TITLE
chore(ci): Skip build when auth token is not available

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -151,8 +151,8 @@ jobs:
   react-native-build:
     name: Build RN ${{ matrix.rn-version }} ${{ matrix.rn-architecture }} ${{ matrix.engine }} ${{ matrix.platform }} ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }}
     runs-on: ${{ matrix.runs-on }}
-    needs: [diff_check]
-    if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
+    needs: [diff_check, auth_token_check]
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') }}
     env:
       RN_VERSION: ${{ matrix.rn-version }}
       RN_ENGINE: ${{ matrix.engine }}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Skips the `react-native-build` CI job when the `auth_token_check` fails [similar to the metrics check](https://github.com/getsentry/sentry-react-native/blob/623b5b8599adf2f64a075a56dffa6f5e3c1ee8be/.github/workflows/e2e.yml#L31).

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failed `dependabot` PRs due to missing `SENTRY_AUTH_TOKEN` causing `sentry reported an error: Invalid token header. No credentials provided. (http status: 401)`:
- [bump Github/codeql-action from 3.28.12 to 3.28.13](https://github.com/getsentry/sentry-react-native/pull/4709)
- [bump reactivecircus/android-emulator-runner from 2.33.0 to 2.34.0](https://github.com/getsentry/sentry-react-native/pull/4710)
- [bump actions/create-github-app-token from 1.11.7 to 1.12.0](https://github.com/getsentry/sentry-react-native/pull/4711)
- [bump axios from 1.6.3 to 1.8.4](https://github.com/getsentry/sentry-react-native/pull/4708)

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog