### PR TITLE
fix(profiling): Prevent crash on iOS when debug images are missing on profiling end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Avoid silent failure when JS bundle was not created due to Sentry Xcode scripts failure ([#4690](https://github.com/getsentry/sentry-react-native/pull/4690))
+- Prevent crash on iOS during profiling stop when debug images are missing ([#4738](https://github.com/getsentry/sentry-react-native/pull/4738))
 
 ### Dependencies
 

--- a/packages/core/src/js/profiling/integration.ts
+++ b/packages/core/src/js/profiling/integration.ts
@@ -315,9 +315,7 @@ export function addNativeProfileToHermesProfile(
   return {
     ...hermes,
     profile: addNativeThreadCpuProfileToHermes(hermes.profile, native.profile, hermes.transaction.active_thread_id),
-    debug_meta: {
-      images: native.debug_meta.images,
-    },
+    ...(native.debug_meta?.images ? { debug_meta: { images: native.debug_meta.images } } : {}),
     measurements: native.measurements,
   };
 }

--- a/packages/core/src/js/profiling/nativeTypes.ts
+++ b/packages/core/src/js/profiling/nativeTypes.ts
@@ -39,7 +39,7 @@ export interface NativeProfileEvent {
       unit: string;
     }
   >;
-  debug_meta: {
+  debug_meta?: {
     images: {
       type: 'macho';
       debug_id: string;

--- a/packages/core/test/profiling/fixtures.ts
+++ b/packages/core/test/profiling/fixtures.ts
@@ -83,6 +83,15 @@ export function createMockMinimalValidHermesProfileEvent(): HermesProfileEvent {
 /**
  * Create a mock native (iOS/Apple) profile.
  */
+export function createMockMinimalValidAppleProfileWithoutDebugMeta(): NativeProfileEvent {
+  const profile = createMockMinimalValidAppleProfile();
+  delete profile.debug_meta;
+  return profile;
+}
+
+/**
+ * Create a mock native (iOS/Apple) profile.
+ */
 export function createMockMinimalValidAppleProfile(): NativeProfileEvent {
   return {
     debug_meta: {

--- a/packages/core/test/profiling/integration.test.ts
+++ b/packages/core/test/profiling/integration.test.ts
@@ -17,6 +17,7 @@ import { envelopeItemPayload, envelopeItems } from '../testutils';
 import {
   createMockMinimalValidAndroidProfile,
   createMockMinimalValidAppleProfile,
+  createMockMinimalValidAppleProfileWithoutDebugMeta,
   createMockMinimalValidHermesProfile,
 } from './fixtures';
 
@@ -155,6 +156,41 @@ describe('profiling integration', () => {
     });
 
     describe('with native profiling', () => {
+      test('should create a new mixed profile and add it to the transaction envelope with missing debug_meta', () => {
+        mockWrapper.NATIVE.stopProfiling.mockReturnValue({
+          hermesProfile: createMockMinimalValidHermesProfile(),
+          nativeProfile: createMockMinimalValidAppleProfileWithoutDebugMeta(),
+        });
+
+        const transaction = Sentry.startSpan({ name: 'test-name' }, span => span);
+
+        jest.runAllTimers();
+
+        const envelope: Envelope | undefined = mock.transportSendMock.mock.lastCall?.[0];
+        expectEnvelopeToContainProfile(envelope, 'test-name', spanToJSON(transaction).trace_id);
+        // Expect merged profile
+        expect(getProfileFromEnvelope(envelope)).toEqual(
+          expect.objectContaining(<Partial<Profile>>{
+            profile: expect.objectContaining(<Partial<ThreadCpuProfile>>{
+              frames: [
+                {
+                  function: '[root]',
+                  in_app: false,
+                },
+                {
+                  instruction_addr: '0x0000000000000003',
+                  platform: 'cocoa',
+                },
+                {
+                  instruction_addr: '0x0000000000000004',
+                  platform: 'cocoa',
+                },
+              ],
+            }),
+          }),
+        );
+      });
+
       test('should create a new mixed profile and add it to the transaction envelope', () => {
         mockWrapper.NATIVE.stopProfiling.mockReturnValue({
           hermesProfile: createMockMinimalValidHermesProfile(),


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The `debug_images` was typed incorrectly. This native field is optional.

Reading property of the undefined value caused a crash.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes: https://github.com/getsentry/sentry-react-native/issues/4733

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
