### PR TITLE
fix: globally install corepack

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -41,7 +41,7 @@ jobs:
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -59,7 +59,7 @@ jobs:
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -82,7 +82,7 @@ jobs:
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -125,7 +125,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -155,7 +155,7 @@ jobs:
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -189,7 +189,7 @@ jobs:
         dev: [true, false]
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -37,7 +37,7 @@ jobs:
                 --targetPlatform ios
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
       - run: sudo xcode-select -s /Applications/Xcode_14.2.app/Contents/Developer
         if: ${{ matrix.platform == 'ios' }}
 
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -227,7 +227,7 @@ jobs:
       - run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
         if: ${{ matrix.platform == 'ios' }}
 
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -353,9 +353,7 @@ jobs:
           path: dev-packages/e2e-tests
 
       - name: Enable Corepack
-        run: |
-          npm install -g corepack@0.29.4
-          corepack enable
+        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -25,9 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Enable Corepack
-        run: |
-          npm install -g corepack@0.29.4
-          corepack enable
+        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -47,9 +47,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Enable Corepack
-        run: |
-          npm install -g corepack@0.29.4
-          corepack enable
+        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -61,9 +61,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Enable Corepack
-        run: |
-          npm install -g corepack@0.29.4
-          corepack enable
+        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -263,9 +261,7 @@ jobs:
         run: unzip ${{ env.ANDROID_APP_ARCHIVE_PATH }}
 
       - name: Enable Corepack
-        run: |
-          npm install -g corepack@0.29.4
-          corepack enable
+        run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -26,7 +26,7 @@ jobs:
           ruby-version: '3.3.0' # based on what is used in the sample
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 1 # cache the installed gems
-      - run: corepack enable
+      - run: npm i -g corepack
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This repository contains mono repository structure with multiple React Native an
 
 # Requirements
 
-- nodejs 18 (with corepack enabled)
+- nodejs 18 (with corepack globally installed)
 - yarn version specified in `package.json` (at the moment version 3.6)
 
 ## Building

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -14,7 +14,7 @@
     "export:web": "expo export --dump-sourcemap --clear --platform web",
     "prebuild": "expo prebuild --clean --no-install",
     "set-version": "npx react-native-version --skip-tag --never-amend",
-    "eas-build-pre-install": "corepack enable && yarn install --no-immutable --inline-builds && yarn workspace @sentry/react-native build"
+    "eas-build-pre-install": "npm i -g corepack && yarn install --no-immutable --inline-builds && yarn workspace @sentry/react-native build"
   },
   "dependencies": {
     "@sentry/react-native": "6.11.0-beta.0",

--- a/scripts/update-package-json.sh
+++ b/scripts/update-package-json.sh
@@ -1,6 +1,6 @@
 # expects `$repo`, `$tagPrefix` and `$packages` (array) variables to be defined, see e.g. update-javascript.sh
 
-corepack enable # This repository uses Yarn v3 which requires corepack to be enabled
+npm i -g corepack # This repository uses Yarn v3 which requires corepack to be installed
 
 monorepoRoot="$(dirname "$0")/.."
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Updates the corepack command to globally installing corepack.

## :bulb: Motivation and Context

Corepack is not going to be distributed with Node.js v25+
TSC vote https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616


## :green_heart: How did you test it?

CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
