### PR TITLE
fix(app-start): Use ms to calculate app start age threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Avoid silent failure when JS bundle was not created due to Sentry Xcode scripts failure ([#4690](https://github.com/getsentry/sentry-react-native/pull/4690))
 - Prevent crash on iOS during profiling stop when debug images are missing ([#4738](https://github.com/getsentry/sentry-react-native/pull/4738))
+- Attach only App Starts within the 60s threshold (fixed comparison units, use ms) ([#4746](https://github.com/getsentry/sentry-react-native/pull/4746))
 
 ### Dependencies
 

--- a/packages/core/src/js/tracing/integrations/appStart.ts
+++ b/packages/core/src/js/tracing/integrations/appStart.ts
@@ -297,7 +297,7 @@ export const appStartIntegration = ({
     }
 
     const isAppStartWithinBounds =
-      !!event.start_timestamp && appStartTimestampMs >= event.start_timestamp - MAX_APP_START_AGE_MS;
+      !!event.start_timestamp && appStartTimestampMs >= event.start_timestamp * 1_000 - MAX_APP_START_AGE_MS;
     if (!__DEV__ && !isAppStartWithinBounds) {
       logger.warn('[AppStart] App start timestamp is too far in the past to be used for app start span.');
       return;

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -128,11 +128,15 @@ describe('App Start Integration', () => {
 
     it('Does add App Start Span older than threshold in development builds', async () => {
       set__DEV__(true);
-      const [timeOriginMilliseconds, appStartTimeMilliseconds] = mockTooOldAppStart();
+      const [timeOriginMilliseconds, appStartTimeMilliseconds, appStartDurationMilliseconds] = mockTooOldAppStart();
 
       const actualEvent = await captureStandAloneAppStart();
       expect(actualEvent).toEqual(
-        expectEventWithStandaloneWarmAppStart(actualEvent, { timeOriginMilliseconds, appStartTimeMilliseconds }),
+        expectEventWithStandaloneWarmAppStart(actualEvent, {
+          timeOriginMilliseconds,
+          appStartTimeMilliseconds,
+          appStartDurationMilliseconds,
+        }),
       );
     });
 
@@ -433,21 +437,27 @@ describe('App Start Integration', () => {
 
     it('Does not add App Start Span older than threshold', async () => {
       set__DEV__(false);
-      mockTooOldAppStart();
+      const [timeOriginMilliseconds] = mockTooOldAppStart();
 
-      const actualEvent = await processEvent(getMinimalTransactionEvent());
-      expect(actualEvent).toStrictEqual(getMinimalTransactionEvent());
+      const actualEvent = await processEvent(
+        getMinimalTransactionEvent({ startTimestampSeconds: timeOriginMilliseconds }),
+      );
+      expect(actualEvent).toStrictEqual(getMinimalTransactionEvent({ startTimestampSeconds: timeOriginMilliseconds }));
     });
 
     it('Does add App Start Span older than threshold in development builds', async () => {
       set__DEV__(true);
-      const [timeOriginMilliseconds, appStartTimeMilliseconds] = mockTooOldAppStart();
+      const [timeOriginMilliseconds, appStartTimeMilliseconds, appStartDurationMilliseconds] = mockTooOldAppStart();
 
       const actualEvent = await processEvent(
         getMinimalTransactionEvent({ startTimestampSeconds: timeOriginMilliseconds }),
       );
       expect(actualEvent).toEqual(
-        expectEventWithAttachedWarmAppStart({ timeOriginMilliseconds, appStartTimeMilliseconds }),
+        expectEventWithAttachedWarmAppStart({
+          timeOriginMilliseconds,
+          appStartTimeMilliseconds,
+          appStartDurationMilliseconds,
+        }),
       );
     });
 
@@ -901,9 +911,11 @@ function expectEventWithAttachedColdAppStart({
 function expectEventWithAttachedWarmAppStart({
   timeOriginMilliseconds,
   appStartTimeMilliseconds,
+  appStartDurationMilliseconds,
 }: {
   timeOriginMilliseconds: number;
   appStartTimeMilliseconds: number;
+  appStartDurationMilliseconds?: number;
 }) {
   return expect.objectContaining<TransactionEvent>({
     type: 'transaction',
@@ -920,7 +932,7 @@ function expectEventWithAttachedWarmAppStart({
     }),
     measurements: expect.objectContaining({
       [APP_START_WARM_MEASUREMENT]: {
-        value: timeOriginMilliseconds - appStartTimeMilliseconds,
+        value: appStartDurationMilliseconds || timeOriginMilliseconds - appStartTimeMilliseconds,
         unit: 'millisecond',
       },
     }),
@@ -1006,9 +1018,11 @@ function expectEventWithStandaloneWarmAppStart(
   {
     timeOriginMilliseconds,
     appStartTimeMilliseconds,
+    appStartDurationMilliseconds,
   }: {
     timeOriginMilliseconds: number;
     appStartTimeMilliseconds: number;
+    appStartDurationMilliseconds?: number;
   },
 ) {
   return expect.objectContaining<TransactionEvent>({
@@ -1026,7 +1040,7 @@ function expectEventWithStandaloneWarmAppStart(
     }),
     measurements: expect.objectContaining({
       [APP_START_WARM_MEASUREMENT]: {
-        value: timeOriginMilliseconds - appStartTimeMilliseconds,
+        value: appStartDurationMilliseconds || timeOriginMilliseconds - appStartTimeMilliseconds,
         unit: 'millisecond',
       },
     }),
@@ -1107,7 +1121,10 @@ function mockTooLongAppStart() {
 
 function mockTooOldAppStart() {
   const timeOriginMilliseconds = Date.now();
+  // Ensures app start is old (more than 1 minute before transaction start)
   const appStartTimeMilliseconds = timeOriginMilliseconds - 65000;
+  const appStartEndTimestampMilliseconds = appStartTimeMilliseconds + 5000;
+  const appStartDurationMilliseconds = appStartEndTimestampMilliseconds - appStartTimeMilliseconds;
   const mockAppStartResponse: NativeAppStartResponse = {
     type: 'warm',
     app_start_timestamp_ms: appStartTimeMilliseconds,
@@ -1116,13 +1133,14 @@ function mockTooOldAppStart() {
   };
 
   // App start finish timestamp
-  _setAppStartEndTimestampMs(timeOriginMilliseconds);
+  // App start length is 5 seconds
+  _setAppStartEndTimestampMs(appStartEndTimestampMilliseconds);
   mockFunction(getTimeOriginMilliseconds).mockReturnValue(timeOriginMilliseconds - 64000);
   mockFunction(NATIVE.fetchNativeAppStart).mockResolvedValue(mockAppStartResponse);
   // Transaction start timestamp
   mockFunction(timestampInSeconds).mockReturnValue(timeOriginMilliseconds / 1000 + 65);
 
-  return [timeOriginMilliseconds, appStartTimeMilliseconds];
+  return [timeOriginMilliseconds, appStartTimeMilliseconds, appStartDurationMilliseconds];
 }
 
 /**


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
The app start age check, compared seconds (transaction start) with milliseconds (app start).

The test were passing because the test app start was also too long, so it was rejected by the next check in order.

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes