### PR TITLE
Kw-remove-sythetic-default-imports

### DIFF
--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -25,7 +25,6 @@
     "target": "es6",
     "module": "es6",
     "skipLibCheck": true,
-    "allowSyntheticDefaultImports": true,
     "strictBindCallApply": true,
     "strictNullChecks": false,
     "importHelpers": false

--- a/packages/core/tsconfig.build.tools.json
+++ b/packages/core/tsconfig.build.tools.json
@@ -14,7 +14,6 @@
     "target": "es6",
     "module": "CommonJS",
     "skipLibCheck": true,
-    "allowSyntheticDefaultImports": true,
     "importHelpers": false
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,7 +12,6 @@
     "plugin/**/*.ts"
   ],
   "exclude": ["dist"],
-  "allowSyntheticDefaultImports": true,
   "compilerOptions": {
     "rootDir": ".",
     "jsx": "react",


### PR DESCRIPTION
This flag is not necessary, we are not importing non existing default anywhere in the SDK code.

#skip-changelog