### PR TITLE
Fix: don't symbolicate console asserts that came from metro.

### DIFF
--- a/packages/core/src/js/integrations/debugsymbolicator.ts
+++ b/packages/core/src/js/integrations/debugsymbolicator.ts
@@ -33,6 +33,14 @@ export const debugSymbolicatorIntegration = (): Integration => {
 };
 
 async function processEvent(event: Event, hint: EventHint): Promise<Event> {
+  // event created by consoleIntegration, symbolicator can trigger those events.
+  // so we drop the event to avoid an infinite loop.
+  if (
+    event.extra?.['arguments'] &&
+    event.message?.startsWith("Assertion failed: 'this' is expected an Event object, but got")
+  ) {
+    return event;
+  }
   if (event.exception?.values && isErrorLike(hint.originalException)) {
     // originalException is ErrorLike object
     const errorGroup = getExceptionGroup(hint.originalException);

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -16,6 +16,7 @@ import Animated, {
 
 // Import the Sentry React Native SDK
 import * as Sentry from '@sentry/react-native';
+import * as SentryCore from '@sentry/core';
 import { FeedbackWidget } from '@sentry/react-native';
 
 import ErrorsScreen from './Screens/ErrorsScreen';
@@ -81,6 +82,7 @@ Sentry.init({
   integrations(integrations) {
     integrations.push(
       reactNavigationIntegration,
+      SentryCore.captureConsoleIntegration(),
       Sentry.reactNativeTracingIntegration({
         // The time to wait in ms until the transaction will be finished, For testing, default is 1000 ms
         idleTimeoutMs: 5_000,

--- a/samples/react-native/src/Screens/ErrorsScreen.tsx
+++ b/samples/react-native/src/Screens/ErrorsScreen.tsx
@@ -239,6 +239,26 @@ const ErrorsScreen = (_props: Props) => {
           />
         ) : null}
         <View style={styles.mainViewBottomWhiteSpace} />
+        <Button
+          title="Log console assert"
+          onPress={() => {
+            // Sample code from https://gitlab.cin.ufpe.br/vrs2/iot-trafficlight-final/-/blob/main/node_modules/event-target-shim/dist/event-target-shim.mjs?ref_type=heads#L40
+            // This code is used by Metro and the assert is triggered when interacting with Debug Symbolicator integration.
+            // When using consoleintegration and filtering assert, it could trigger an infinite loop where debug symbolicator
+            // triggers the console integration, then it creates an event, that again calls debug symbolicator and the loop restart.
+            function pd(event: string) {
+              // const retv = privateData.get(event);
+              const retv = null;
+              console.assert(
+                  retv != null,
+                  "'this' is expected an Event object, but got",
+                  event
+              );
+              return retv;
+          }
+            pd('<object>');
+          }}
+        />
       </ScrollView>
     </>
   );


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Adds a small patch to DebugSymbolicator that ignores events generated by metro.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In short: when interacting with the metro bridge, React Native uses the following code: https://gitlab.cin.ufpe.br/vrs2/iot-trafficlight-final/-/blob/main/node_modules/event-target-shim/dist/event-target-shim.mjs?ref_type=heads#L40
```typescript
/**
 * Get private data.
 * @param {Event} event The event object to get private data.
 * @returns {PrivateData} The private data of the event.
 * @private
 */
function pd(event) {
    const retv = privateData.get(event);
    console.assert(
        retv != null,
        "'this' is expected an Event object, but got",
        event
    );
    return retv
}
```

When adding the Sentry console integration and also filtering by asserts, the above snippet can be called when we are symbolicating in dev builds, creating new events, that would then, be again symbolicated, and so on...
By avoiding the symbolication of events that comes from this specific assert, apps when tested in debug mode should no longer freeze when loading the console integration.

Fixes: https://github.com/getsentry/sentry-react-native/issues/3992

## :green_heart: How did you test it?

Tests, locally, replicated the problematic library code so it is easier to test it on the sample app.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
