### PR TITLE
fix(metro): Remove sentry-internal/replay package on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Export `extraErrorDataIntegration` from `@sentry/core` ([#4762](https://github.com/getsentry/sentry-react-native/pull/4762))
+- Remove `@sentry-internal/replay` when `includeWebReplay: false` ([#4774](https://github.com/getsentry/sentry-react-native/pull/4774))
 
 ### Dependencies
 

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -212,7 +212,7 @@ export function withSentryResolver(config: MetroConfig, includeWebReplay: boolea
     if (
       (includeWebReplay === false ||
         (includeWebReplay === undefined && (platform === 'android' || platform === 'ios'))) &&
-      (oldMetroModuleName ?? moduleName).includes('@sentry/replay')
+      !!(oldMetroModuleName ?? moduleName).match(/@sentry(?:-internal)?\/replay/)
     ) {
       return { type: 'empty' } as Resolution;
     }

--- a/packages/core/test/tools/metroconfig.test.ts
+++ b/packages/core/test/tools/metroconfig.test.ts
@@ -169,72 +169,74 @@ describe('metroconfig', () => {
         }));
       });
 
-      test('keep Web Replay when platform is web and includeWebReplay is true', () => {
-        const modifiedConfig = withSentryResolver(config, true);
-        resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'web');
+      describe.each([['@sentry/replay'], ['@sentry-internal/replay']])('with %s', replayPackage => {
+        test('keep Web Replay when platform is web and includeWebReplay is true', () => {
+          const modifiedConfig = withSentryResolver(config, true);
+          resolveRequest(modifiedConfig, contextMock, replayPackage, 'web');
 
-        ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, '@sentry/replay', 'web');
-      });
+          ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, replayPackage, 'web');
+        });
 
-      test('removes Web Replay when platform is web and includeWebReplay is false', () => {
-        const modifiedConfig = withSentryResolver(config, false);
-        const result = resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'web');
+        test('removes Web Replay when platform is web and includeWebReplay is false', () => {
+          const modifiedConfig = withSentryResolver(config, false);
+          const result = resolveRequest(modifiedConfig, contextMock, replayPackage, 'web');
 
-        expect(result).toEqual({ type: 'empty' });
-        expect(originalResolverMock).not.toHaveBeenCalled();
-      });
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolverMock).not.toHaveBeenCalled();
+        });
 
-      test('keep Web Replay when platform is android and includeWebReplay is true', () => {
-        const modifiedConfig = withSentryResolver(config, true);
-        resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'android');
+        test('keep Web Replay when platform is android and includeWebReplay is true', () => {
+          const modifiedConfig = withSentryResolver(config, true);
+          resolveRequest(modifiedConfig, contextMock, replayPackage, 'android');
 
-        ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, '@sentry/replay', 'android');
-      });
+          ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, replayPackage, 'android');
+        });
 
-      test('removes Web Replay when platform is android and includeWebReplay is false', () => {
-        const modifiedConfig = withSentryResolver(config, false);
-        const result = resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'android');
+        test('removes Web Replay when platform is android and includeWebReplay is false', () => {
+          const modifiedConfig = withSentryResolver(config, false);
+          const result = resolveRequest(modifiedConfig, contextMock, replayPackage, 'android');
 
-        expect(result).toEqual({ type: 'empty' });
-        expect(originalResolverMock).not.toHaveBeenCalled();
-      });
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolverMock).not.toHaveBeenCalled();
+        });
 
-      test('removes Web Replay when platform is android and includeWebReplay is undefined', () => {
-        const modifiedConfig = withSentryResolver(config, undefined);
-        const result = resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'android');
+        test('removes Web Replay when platform is android and includeWebReplay is undefined', () => {
+          const modifiedConfig = withSentryResolver(config, undefined);
+          const result = resolveRequest(modifiedConfig, contextMock, replayPackage, 'android');
 
-        expect(result).toEqual({ type: 'empty' });
-        expect(originalResolverMock).not.toHaveBeenCalled();
-      });
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolverMock).not.toHaveBeenCalled();
+        });
 
-      test('keep Web Replay when platform is undefined and includeWebReplay is null', () => {
-        const modifiedConfig = withSentryResolver(config, undefined);
-        resolveRequest(modifiedConfig, contextMock, '@sentry/replay', null);
+        test('keep Web Replay when platform is undefined and includeWebReplay is null', () => {
+          const modifiedConfig = withSentryResolver(config, undefined);
+          resolveRequest(modifiedConfig, contextMock, replayPackage, null);
 
-        ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, '@sentry/replay', null);
-      });
+          ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, replayPackage, null);
+        });
 
-      test('keep Web Replay when platform is ios and includeWebReplay is true', () => {
-        const modifiedConfig = withSentryResolver(config, true);
-        resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'ios');
+        test('keep Web Replay when platform is ios and includeWebReplay is true', () => {
+          const modifiedConfig = withSentryResolver(config, true);
+          resolveRequest(modifiedConfig, contextMock, replayPackage, 'ios');
 
-        ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, '@sentry/replay', 'ios');
-      });
+          ExpectToBeCalledWithMetroParameters(originalResolverMock, contextMock, replayPackage, 'ios');
+        });
 
-      test('removes Web Replay when platform is ios and includeWebReplay is false', () => {
-        const modifiedConfig = withSentryResolver(config, false);
-        const result = resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'ios');
+        test('removes Web Replay when platform is ios and includeWebReplay is false', () => {
+          const modifiedConfig = withSentryResolver(config, false);
+          const result = resolveRequest(modifiedConfig, contextMock, replayPackage, 'ios');
 
-        expect(result).toEqual({ type: 'empty' });
-        expect(originalResolverMock).not.toHaveBeenCalled();
-      });
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolverMock).not.toHaveBeenCalled();
+        });
 
-      test('removes Web Replay when platform is ios and includeWebReplay is undefined', () => {
-        const modifiedConfig = withSentryResolver(config, undefined);
-        const result = resolveRequest(modifiedConfig, contextMock, '@sentry/replay', 'ios');
+        test('removes Web Replay when platform is ios and includeWebReplay is undefined', () => {
+          const modifiedConfig = withSentryResolver(config, undefined);
+          const result = resolveRequest(modifiedConfig, contextMock, replayPackage, 'ios');
 
-        expect(result).toEqual({ type: 'empty' });
-        expect(originalResolverMock).not.toHaveBeenCalled();
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolverMock).not.toHaveBeenCalled();
+        });
       });
 
       test('calls originalResolver when moduleName is not @sentry/replay', () => {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
`@sentry/replay` was replaced by `@sentry-internal/replay` in version 8 of the JS core.

To avoid this in the future we should introduce more strict bundle size checks.

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
