### PR TITLE
chore(ttd): Fallback to activity holder if react context activity is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Export `extraErrorDataIntegration` from `@sentry/core` ([#4762](https://github.com/getsentry/sentry-react-native/pull/4762))
 - Remove `@sentry-internal/replay` when `includeWebReplay: false` ([#4774](https://github.com/getsentry/sentry-react-native/pull/4774))
+- Fallback to Current Activity Holder when React Context Activity is not present ([#4779](https://github.com/getsentry/sentry-react-native/pull/4779))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Changes
+
+- Fallback to Current Activity Holder when React Context Activity is not present ([#4779](https://github.com/getsentry/sentry-react-native/pull/4779))
+
 ## 6.12.0
 
 ### Features
@@ -17,7 +23,6 @@
 
 - Export `extraErrorDataIntegration` from `@sentry/core` ([#4762](https://github.com/getsentry/sentry-react-native/pull/4762))
 - Remove `@sentry-internal/replay` when `includeWebReplay: false` ([#4774](https://github.com/getsentry/sentry-react-native/pull/4774))
-- Fallback to Current Activity Holder when React Context Activity is not present ([#4779](https://github.com/getsentry/sentry-react-native/pull/4779))
 
 ### Dependencies
 

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/utils/RNSentryActivityUtilsTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/utils/RNSentryActivityUtilsTest.kt
@@ -1,0 +1,52 @@
+package io.sentry.react.utils
+
+import android.app.Activity
+import com.facebook.react.bridge.ReactApplicationContext
+import io.sentry.android.core.AndroidLogger
+import io.sentry.android.core.CurrentActivityHolder
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(JUnit4::class)
+class RNSentryActivityUtilsTest {
+    private val mockedLogger = mock(AndroidLogger::class.java)
+
+    @After
+    fun clearActivityHolder() {
+        CurrentActivityHolder.getInstance().clearActivity()
+    }
+
+    @Test
+    fun `returns react context activity`() {
+        val mockedCurrentActivity = mock(Activity::class.java)
+        val mockedReactContext = mock(ReactApplicationContext::class.java)
+        whenever(mockedReactContext.currentActivity).thenReturn(mockedCurrentActivity)
+
+        assertSame(RNSentryActivityUtils.getCurrentActivity(mockedReactContext, mockedLogger), mockedCurrentActivity)
+    }
+
+    @Test
+    fun `returns current activity holder activity`() {
+        val mockedCurrentActivity = mock(Activity::class.java)
+
+        val mockedReactContext = mock(ReactApplicationContext::class.java)
+        whenever(mockedReactContext.currentActivity).thenReturn(null)
+
+        CurrentActivityHolder.getInstance().setActivity(mockedCurrentActivity)
+        assertSame(RNSentryActivityUtils.getCurrentActivity(mockedReactContext, mockedLogger), mockedCurrentActivity)
+    }
+
+    @Test
+    fun `returns null when no activity exists`() {
+        val mockedReactContext = mock(ReactApplicationContext::class.java)
+        whenever(mockedReactContext.currentActivity).thenReturn(null)
+
+        assertNull(RNSentryActivityUtils.getCurrentActivity(mockedReactContext, mockedLogger))
+    }
+}

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryOnDrawReporterManager.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryOnDrawReporterManager.java
@@ -14,6 +14,7 @@ import io.sentry.android.core.AndroidLogger;
 import io.sentry.android.core.BuildInfoProvider;
 import io.sentry.android.core.SentryAndroidDateProvider;
 import io.sentry.android.core.internal.util.FirstDrawDoneListener;
+import io.sentry.react.utils.RNSentryActivityUtils;
 import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -151,11 +152,12 @@ public class RNSentryOnDrawReporterManager
         return;
       }
 
-      @Nullable Activity activity = reactContext.getCurrentActivity();
+      final @Nullable Activity activity =
+          RNSentryActivityUtils.getCurrentActivity(reactContext, logger);
       if (activity == null) {
         logger.log(
             SentryLevel.ERROR,
-            "[TimeToDisplay] Won't emit next frame drawn event, reactContext is null.");
+            "[TimeToDisplay] Won't emit next frame drawn event, activity is null.");
         return;
       }
 

--- a/packages/core/android/src/main/java/io/sentry/react/utils/RNSentryActivityUtils.java
+++ b/packages/core/android/src/main/java/io/sentry/react/utils/RNSentryActivityUtils.java
@@ -1,0 +1,31 @@
+package io.sentry.react.utils;
+
+import android.app.Activity;
+import com.facebook.react.bridge.ReactApplicationContext;
+import io.sentry.ILogger;
+import io.sentry.SentryLevel;
+import io.sentry.android.core.CurrentActivityHolder;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Utility class for React Native Activity related functionality. */
+public final class RNSentryActivityUtils {
+
+  private RNSentryActivityUtils() {
+    // Prevent instantiation
+  }
+
+  public static @Nullable Activity getCurrentActivity(
+      final @NotNull ReactApplicationContext reactContext, final @NotNull ILogger logger) {
+    final Activity activity = reactContext.getCurrentActivity();
+    if (activity != null) {
+      return activity;
+    }
+
+    logger.log(
+        SentryLevel.DEBUG,
+        "[RNSentryActivityUtils] Given ReactApplicationContext has no activity attached, using"
+            + " CurrentActivityHolder as a fallback.");
+    return CurrentActivityHolder.getInstance().getActivity();
+  }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement


## :scroll: Description
<!--- Describe your changes in detail -->
This PR requires https://github.com/getsentry/sentry-java/pull/4337 to be back ported to `sentry-java@v7`.

This PR adds a fallback to the Sentry Global Activity holder in case the react native context is missing current activity.

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
