### PR TITLE
fix(android): Init with ApplicationContext if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Export `extraErrorDataIntegration` from `@sentry/core` ([#4762](https://github.com/getsentry/sentry-react-native/pull/4762))
 - Remove `@sentry-internal/replay` when `includeWebReplay: false` ([#4774](https://github.com/getsentry/sentry-react-native/pull/4774))
+- Initialize Sentry Android with ApplicationContext if available ([#4779](https://github.com/getsentry/sentry-react-native/pull/4779))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Fallback to Current Activity Holder when React Context Activity is not present ([#4779](https://github.com/getsentry/sentry-react-native/pull/4779))
 
+### Fixes
+
+- Initialize Sentry Android with ApplicationContext if available ([#4780](https://github.com/getsentry/sentry-react-native/pull/4780))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v8.49.1 to v8.49.2 ([#4792](https://github.com/getsentry/sentry-react-native/pull/4792))
@@ -29,7 +33,6 @@
 
 - Export `extraErrorDataIntegration` from `@sentry/core` ([#4762](https://github.com/getsentry/sentry-react-native/pull/4762))
 - Remove `@sentry-internal/replay` when `includeWebReplay: false` ([#4774](https://github.com/getsentry/sentry-react-native/pull/4774))
-- Initialize Sentry Android with ApplicationContext if available ([#4779](https://github.com/getsentry/sentry-react-native/pull/4779))
 
 ### Dependencies
 

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryModuleInitWithApplicationTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryModuleInitWithApplicationTest.kt
@@ -1,13 +1,9 @@
 package io.sentry.react
 
 import android.app.Application
-import android.content.Context
-import com.facebook.react.bridge.ReactApplicationContext
 import org.junit.Assert.assertSame
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryModuleInitWithApplicationTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryModuleInitWithApplicationTest.kt
@@ -1,0 +1,33 @@
+package io.sentry.react
+
+import android.app.Application
+import android.content.Context
+import com.facebook.react.bridge.ReactApplicationContext
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RNSentryModuleInitWithApplicationTest {
+    @Test
+    fun `when application context is null fallback to react context`() {
+        val mockedReactContext = Utils.makeReactContextMock()
+        whenever(mockedReactContext.applicationContext).thenReturn(null)
+
+        assertSame(RNSentryModuleImpl(mockedReactContext).applicationContext, mockedReactContext)
+    }
+
+    @Test
+    fun `use application context if available`() {
+        val mockedApplicationContext = mock(Application::class.java)
+        val mockedReactContext = Utils.makeReactContextMock()
+        whenever(mockedReactContext.applicationContext).thenReturn(mockedApplicationContext)
+
+        assertSame(RNSentryModuleImpl(mockedReactContext).applicationContext, mockedApplicationContext)
+    }
+}

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/Utils.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/Utils.kt
@@ -3,7 +3,6 @@ package io.sentry.react
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReactContext
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.mock

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/Utils.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/Utils.kt
@@ -3,6 +3,7 @@ package io.sentry.react
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContext
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.mock
@@ -10,7 +11,7 @@ import org.mockito.kotlin.whenever
 
 class Utils {
     companion object {
-        fun createRNSentryModuleWithMockedContext(): RNSentryModuleImpl {
+        fun makeReactContextMock(): ReactApplicationContext {
             val packageManager = mock(PackageManager::class.java)
             val packageInfo = mock(PackageInfo::class.java)
 
@@ -18,9 +19,13 @@ class Utils {
             whenever(reactContext.packageManager).thenReturn(packageManager)
             whenever(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo)
 
+            return reactContext
+        }
+
+        fun createRNSentryModuleWithMockedContext(): RNSentryModuleImpl {
             RNSentryModuleImpl.lastStartTimestampMs = -1
 
-            return RNSentryModuleImpl(reactContext)
+            return RNSentryModuleImpl(makeReactContextMock())
         }
     }
 }

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -90,6 +90,7 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 
 public class RNSentryModuleImpl {
 
@@ -177,10 +178,20 @@ public class RNSentryModuleImpl {
 
   public void initNativeSdk(final ReadableMap rnOptions, Promise promise) {
     SentryAndroid.init(
-        this.getReactApplicationContext(),
+        getApplicationContext(),
         options -> getSentryAndroidOptions(options, rnOptions, logger));
 
     promise.resolve(true);
+  }
+
+  @TestOnly
+  protected Context getApplicationContext() {
+    final Context context = this.getReactApplicationContext().getApplicationContext();
+    if (context == null) {
+      logger.log(SentryLevel.ERROR, "ApplicationContext is null, using ReactApplicationContext fallback.");
+      return this.getReactApplicationContext();
+    }
+    return context;
   }
 
   protected void getSentryAndroidOptions(

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -178,8 +178,7 @@ public class RNSentryModuleImpl {
 
   public void initNativeSdk(final ReadableMap rnOptions, Promise promise) {
     SentryAndroid.init(
-        getApplicationContext(),
-        options -> getSentryAndroidOptions(options, rnOptions, logger));
+        getApplicationContext(), options -> getSentryAndroidOptions(options, rnOptions, logger));
 
     promise.resolve(true);
   }
@@ -188,7 +187,8 @@ public class RNSentryModuleImpl {
   protected Context getApplicationContext() {
     final Context context = this.getReactApplicationContext().getApplicationContext();
     if (context == null) {
-      logger.log(SentryLevel.ERROR, "ApplicationContext is null, using ReactApplicationContext fallback.");
+      logger.log(
+          SentryLevel.ERROR, "ApplicationContext is null, using ReactApplicationContext fallback.");
       return this.getReactApplicationContext();
     }
     return context;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
This PR passes `applicationContext` to the `sentry-android` initialization function.

This PR is need for improving the current activity tracking from https://github.com/getsentry/sentry-java/pull/4337.

Passing applicationContext will cause the `CurrentActivityIntegration` to be added, which ensures that if activity changes, the global holder hast the correct reference.

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
