### PR TITLE
chore(ci): Fixes iOS binary size diff failure

### DIFF
--- a/performance-tests/metrics-ios.yml
+++ b/performance-tests/metrics-ios.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 600 KiB
-  diffMax: 1200 KiB
+  diffMax: 1300 KiB


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Increase iOS binary size diff by 100KB (to 1300 KB) to avoid failing binary size checks.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've noticed that `metrics (new, ios)` check has [started to fail](https://github.com/getsentry/sentry-react-native/actions/runs/14660729848/job/41152206746?pr=4726) consistently (though marginally) due to small changes in the size of the app in the [Feedback Widget Drop 2](https://github.com/getsentry/sentry-react-native/pull/4726) branch. 
```
BinarySizeTest > app size() FAILED
    java.lang.AssertionError: 1237822 should be < 1228800
        at BinarySizeTest.app size(BinarySizeTest.kt:37)
```

Notes:
- We [last pumped the diff by 100kb in January](https://github.com/getsentry/sentry-react-native/pull/4489)
- [The Android diffMax is 2.5MB](https://github.com/getsentry/sentry-react-native/blob/main/performance-tests/metrics-android.yml)

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog