### PR TITLE
fix(expo-context): Rename expo_updates to ota_updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Add Expo Updates Event Context ([#4767](https://github.com/getsentry/sentry-react-native/pull/4767))
+- Add Expo Updates Event Context ([#4767](https://github.com/getsentry/sentry-react-native/pull/4767), [#4786](https://github.com/getsentry/sentry-react-native/pull/4786))
   - Automatically collects `updateId`, `channel`, Emergency Launch Reason and other Expo Updates constants
 
 ### Fixes

--- a/packages/core/src/js/integrations/expocontext.ts
+++ b/packages/core/src/js/integrations/expocontext.ts
@@ -6,7 +6,7 @@ import { NATIVE } from '../wrapper';
 
 const INTEGRATION_NAME = 'ExpoContext';
 
-export const EXPO_UPDATES_CONTEXT_KEY = 'expo_updates';
+export const OTA_UPDATES_CONTEXT_KEY = 'ota_updates';
 
 /** Load device context from expo modules. */
 export const expoContextIntegration = (): Integration => {
@@ -25,7 +25,7 @@ export const expoContextIntegration = (): Integration => {
 
     try {
       // Ensures native errors and crashes have the same context as JS errors
-      NATIVE.setContext(EXPO_UPDATES_CONTEXT_KEY, expoUpdates);
+      NATIVE.setContext(OTA_UPDATES_CONTEXT_KEY, expoUpdates);
     } catch (error) {
       logger.error('Error setting Expo updates context:', error);
     }
@@ -43,7 +43,7 @@ export const expoContextIntegration = (): Integration => {
 
   function addExpoUpdatesContext(event: Event): void {
     event.contexts = event.contexts || {};
-    event.contexts[EXPO_UPDATES_CONTEXT_KEY] = {
+    event.contexts[OTA_UPDATES_CONTEXT_KEY] = {
       ...getExpoUpdatesContextCached(),
     };
   }

--- a/packages/core/test/integrations/expocontext.test.ts
+++ b/packages/core/test/integrations/expocontext.test.ts
@@ -1,6 +1,6 @@
 import type { Client, Event } from '@sentry/core';
 
-import { EXPO_UPDATES_CONTEXT_KEY, expoContextIntegration } from '../../src/js/integrations/expocontext';
+import { OTA_UPDATES_CONTEXT_KEY, expoContextIntegration } from '../../src/js/integrations/expocontext';
 import * as environment from '../../src/js/utils/environment';
 import type { ExpoUpdates } from '../../src/js/utils/expoglobalobject';
 import { getExpoDevice } from '../../src/js/utils/expomodules';
@@ -21,7 +21,7 @@ describe('Expo Context Integration', () => {
     it('does not add expo updates context', () => {
       const actualEvent = executeIntegrationFor({});
 
-      expect(actualEvent.contexts?.[EXPO_UPDATES_CONTEXT_KEY]).toBeUndefined();
+      expect(actualEvent.contexts?.[OTA_UPDATES_CONTEXT_KEY]).toBeUndefined();
     });
   });
 
@@ -48,7 +48,7 @@ describe('Expo Context Integration', () => {
       const event1 = await integration.processEvent!({}, {}, {} as Client);
       const event2 = await integration.processEvent!({}, {}, {} as Client);
 
-      expect(event1.contexts![EXPO_UPDATES_CONTEXT_KEY]).not.toBe(event2.contexts![EXPO_UPDATES_CONTEXT_KEY]);
+      expect(event1.contexts![OTA_UPDATES_CONTEXT_KEY]).not.toBe(event2.contexts![OTA_UPDATES_CONTEXT_KEY]);
     });
 
     it('adds isEnabled false if ExpoUpdates module is missing', () => {
@@ -56,7 +56,7 @@ describe('Expo Context Integration', () => {
 
       const actualEvent = executeIntegrationFor({});
 
-      expect(actualEvent.contexts?.[EXPO_UPDATES_CONTEXT_KEY]).toStrictEqual({
+      expect(actualEvent.contexts?.[OTA_UPDATES_CONTEXT_KEY]).toStrictEqual({
         is_enabled: false,
       });
     });
@@ -66,7 +66,7 @@ describe('Expo Context Integration', () => {
 
       const actualEvent = executeIntegrationFor({});
 
-      expect(actualEvent.contexts?.[EXPO_UPDATES_CONTEXT_KEY]).toStrictEqual({
+      expect(actualEvent.contexts?.[OTA_UPDATES_CONTEXT_KEY]).toStrictEqual({
         is_enabled: false,
         is_embedded_launch: false,
         is_emergency_launch: false,
@@ -87,7 +87,7 @@ describe('Expo Context Integration', () => {
 
       const actualEvent = executeIntegrationFor({});
 
-      expect(actualEvent.contexts?.[EXPO_UPDATES_CONTEXT_KEY]).toEqual({
+      expect(actualEvent.contexts?.[OTA_UPDATES_CONTEXT_KEY]).toEqual({
         is_enabled: false,
         is_embedded_launch: false,
         is_emergency_launch: false,
@@ -115,7 +115,7 @@ describe('Expo Context Integration', () => {
 
       const actualEvent = executeIntegrationFor({});
 
-      expect(actualEvent.contexts?.[EXPO_UPDATES_CONTEXT_KEY]).toStrictEqual({
+      expect(actualEvent.contexts?.[OTA_UPDATES_CONTEXT_KEY]).toStrictEqual({
         is_enabled: false,
         is_embedded_launch: false,
         is_emergency_launch: false,
@@ -141,7 +141,7 @@ describe('Expo Context Integration', () => {
 
       const actualEvent = executeIntegrationFor({});
 
-      expect(actualEvent.contexts?.[EXPO_UPDATES_CONTEXT_KEY]).toStrictEqual({
+      expect(actualEvent.contexts?.[OTA_UPDATES_CONTEXT_KEY]).toStrictEqual({
         is_enabled: true,
         is_embedded_launch: false,
         is_emergency_launch: false,

--- a/packages/core/test/integrations/expocontext.test.ts
+++ b/packages/core/test/integrations/expocontext.test.ts
@@ -1,6 +1,6 @@
 import type { Client, Event } from '@sentry/core';
 
-import { OTA_UPDATES_CONTEXT_KEY, expoContextIntegration } from '../../src/js/integrations/expocontext';
+import { expoContextIntegration, OTA_UPDATES_CONTEXT_KEY } from '../../src/js/integrations/expocontext';
 import * as environment from '../../src/js/utils/environment';
 import type { ExpoUpdates } from '../../src/js/utils/expoglobalobject';
 import { getExpoDevice } from '../../src/js/utils/expomodules';


### PR DESCRIPTION
In https://github.com/getsentry/relay/pull/4690 we decided to use generic context name, which can be used by other SDKs.

### Part of:
- https://github.com/getsentry/sentry-react-native/pull/4767
- https://github.com/getsentry/relay/pull/4690
- https://github.com/getsentry/sentry/pull/90148
- https://github.com/getsentry/sentry/pull/90162
- https://github.com/getsentry/sentry/pull/90475