### PR TITLE
test(maestro-sample): Await the mocked relay start before starting the test

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -208,7 +208,7 @@ jobs:
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/${{ matrix.platform }}/*.log
 
   test:
-    name: Test ${{ matrix.platform }} ${{ matrix.build-type }}
+    name: Test ${{ matrix.platform }} ${{ matrix.build-type }} REV2
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, build]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}

--- a/samples/react-native/e2e/captureErrorsScreenTransaction.test.ts
+++ b/samples/react-native/e2e/captureErrorsScreenTransaction.test.ts
@@ -10,12 +10,13 @@ import { maestro } from './utils/maestro';
 
 describe('Capture Errors Screen Transaction', () => {
   let sentryServer = createSentryServer();
-  sentryServer.start();
 
   const getErrorsEnvelope = () =>
     sentryServer.getEnvelope(containingTransactionWithName('Errors'));
 
   beforeAll(async () => {
+    await sentryServer.start();
+
     const waitForErrorsTx = sentryServer.waitForEnvelope(
       containingTransactionWithName('Errors'), // The last created and sent transaction
     );

--- a/samples/react-native/e2e/captureSpaceflightNewsScreenTransaction.test.ts
+++ b/samples/react-native/e2e/captureSpaceflightNewsScreenTransaction.test.ts
@@ -12,7 +12,6 @@ import { maestro } from './utils/maestro';
 
 describe('Capture Spaceflight News Screen Transaction', () => {
   let sentryServer = createSentryServer();
-  sentryServer.start();
 
   let newsEnvelopes: Envelope[] = [];
   let allTransactionEnvelopes: Envelope[] = [];
@@ -24,6 +23,8 @@ describe('Capture Spaceflight News Screen Transaction', () => {
     getItemOfTypeFrom<EventItem>(newsEnvelopes[1], 'transaction');
 
   beforeAll(async () => {
+    await sentryServer.start();
+
     const containingNewsScreen = containingTransactionWithName(
       'SpaceflightNewsScreen',
     );

--- a/samples/react-native/e2e/utils/mockedSentryServer.ts
+++ b/samples/react-native/e2e/utils/mockedSentryServer.ts
@@ -16,7 +16,7 @@ export function createSentryServer({ port = 8961 } = {}): {
     predicate: (envelope: Envelope) => boolean,
   ) => Promise<Envelope>;
   close: () => Promise<void>;
-  start: () => void;
+  start: () => Promise<void>;
   getEnvelope: (predicate: (envelope: Envelope) => boolean) => Envelope;
   getAllEnvelopes: (predicate: (envelope: Envelope) => boolean) => Envelope[];
 } {
@@ -64,7 +64,12 @@ export function createSentryServer({ port = 8961 } = {}): {
 
   return {
     start: () => {
-      server.listen(port);
+      return new Promise<void>((resolve, _reject) => {
+        server.listen(port, () => {
+          console.log(`Sentry server listening on port ${port}`);
+          resolve();
+        });
+      });
     },
     waitForEnvelope: async (
       predicate: (envelope: Envelope) => boolean,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement

## :scroll: Description
<!--- Describe your changes in detail -->
This PR should improve stability of the Maestro React Native Sample E2E tests stability.

This test often fails on the macos runners, likely due to them being slower than the ubuntu counterparts.

Current iOS failure rate [is 40%](https://sentry.sentry.io/explore/discover/homepage/?dataset=transactions&field=title&field=workflow&field=failure_rate%28%29&field=failure_count%28%29&field=count%28%29&name=All%20Events&project=5899451&query=branch%3Amain%20repo%3Agetsentry%2Fsentry-react-native&queryDataset=transaction-like&sort=-workflow&statsPeriod=30d&yAxis=count%28%29)

Android only 3%.

With the updated name we can track the rate after this change.

## :green_heart: How did you test it?
ci runs

#skip-changelog 