### PR TITLE
fix(debug-symbolicator): Use new default exports of RN 0.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Disable native driver for Feedback Widget `backgroundColor` animation in unsupported React Native versions ([#4794](https://github.com/getsentry/sentry-react-native/pull/4794))
+- Fix Debug Symbolicator for local development builds (use RN 0.79 default exports) ([#4801](https://github.com/getsentry/sentry-react-native/pull/4801))
 
 ## 6.13.0
 

--- a/packages/core/src/js/utils/rnlibraries.ts
+++ b/packages/core/src/js/utils/rnlibraries.ts
@@ -12,6 +12,7 @@ const InternalReactNativeLibrariesInterface: Required<ReactNativeLibrariesInterf
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (parseErrorStack.default && typeof parseErrorStack.default === 'function') {
         // Starting with react-native 0.79, the parseErrorStack is a default export
+        // https://github.com/facebook/react-native/commit/e5818d92a867dbfa5f60d176b847b1f2131cb6da
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         return parseErrorStack.default(errorStack);
       }
@@ -28,6 +29,7 @@ const InternalReactNativeLibrariesInterface: Required<ReactNativeLibrariesInterf
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (symbolicateStackTrace.default && typeof symbolicateStackTrace.default === 'function') {
         // Starting with react-native 0.79, the symbolicateStackTrace is a default export
+        // https://github.com/facebook/react-native/commit/e5818d92a867dbfa5f60d176b847b1f2131cb6da
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         return symbolicateStackTrace.default(stack, extraData);
       }
@@ -41,6 +43,7 @@ const InternalReactNativeLibrariesInterface: Required<ReactNativeLibrariesInterf
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (getDevServer.default && typeof getDevServer.default === 'function') {
         // Starting with react-native 0.79, the getDevServer is a default export
+        // https://github.com/facebook/react-native/commit/e5818d92a867dbfa5f60d176b847b1f2131cb6da
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         return getDevServer.default();
       }

--- a/packages/core/src/js/utils/rnlibraries.ts
+++ b/packages/core/src/js/utils/rnlibraries.ts
@@ -8,6 +8,15 @@ const InternalReactNativeLibrariesInterface: Required<ReactNativeLibrariesInterf
   Devtools: {
     parseErrorStack: (errorStack: string): Array<ReactNative.StackFrame> => {
       const parseErrorStack = require('react-native/Libraries/Core/Devtools/parseErrorStack');
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (parseErrorStack.default && typeof parseErrorStack.default === 'function') {
+        // Starting with react-native 0.79, the parseErrorStack is a default export
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        return parseErrorStack.default(errorStack);
+      }
+
+      // react-native 0.78 and below
       return parseErrorStack(errorStack);
     },
     symbolicateStackTrace: (
@@ -15,10 +24,28 @@ const InternalReactNativeLibrariesInterface: Required<ReactNativeLibrariesInterf
       extraData?: Record<string, unknown>,
     ): Promise<ReactNative.SymbolicatedStackTrace> => {
       const symbolicateStackTrace = require('react-native/Libraries/Core/Devtools/symbolicateStackTrace');
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (symbolicateStackTrace.default && typeof symbolicateStackTrace.default === 'function') {
+        // Starting with react-native 0.79, the symbolicateStackTrace is a default export
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        return symbolicateStackTrace.default(stack, extraData);
+      }
+
+      // react-native 0.78 and below
       return symbolicateStackTrace(stack, extraData);
     },
     getDevServer: (): ReactNative.DevServerInfo => {
       const getDevServer = require('react-native/Libraries/Core/Devtools/getDevServer');
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (getDevServer.default && typeof getDevServer.default === 'function') {
+        // Starting with react-native 0.79, the getDevServer is a default export
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        return getDevServer.default();
+      }
+
+      // react-native 0.78 and below
       return getDevServer();
     },
   },


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix

## :scroll: Description
<!--- Describe your changes in detail -->
This PR fixes change in export of RN Devlibs. The functions are now exported as default.

Changed in https://github.com/facebook/react-native/commit/e5818d92a867dbfa5f60d176b847b1f2131cb6da

Fixes: https://github.com/getsentry/sentry-react-native/issues/4798

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Without the change the local symbolication doesn't work, the app doesn't crash, warning about missing functions is logged out.

## :green_heart: How did you test it?
sample expo app

Related PR upgrade to SDK 53: (link tba)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
