### PR TITLE
fix(expo-context): Expo Updates context is passed to native after init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Disable native driver for Feedback Widget `backgroundColor` animation in unsupported React Native versions ([#4794](https://github.com/getsentry/sentry-react-native/pull/4794))
 - Fix Debug Symbolicator for local development builds (use RN 0.79 default exports) ([#4801](https://github.com/getsentry/sentry-react-native/pull/4801))
+- Expo Updates Context is passed to native after native init to be available for crashes ([#4808](https://github.com/getsentry/sentry-react-native/pull/4808))
 
 ## 6.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Expo Updates Context is passed to native after native init to be available for crashes ([#4808](https://github.com/getsentry/sentry-react-native/pull/4808))
+
 ### Dependencies
 
 - Bump CLI from v2.43.1 to v2.44.0 ([#4804](https://github.com/getsentry/sentry-react-native/pull/4804))
@@ -23,7 +27,6 @@
 
 - Disable native driver for Feedback Widget `backgroundColor` animation in unsupported React Native versions ([#4794](https://github.com/getsentry/sentry-react-native/pull/4794))
 - Fix Debug Symbolicator for local development builds (use RN 0.79 default exports) ([#4801](https://github.com/getsentry/sentry-react-native/pull/4801))
-- Expo Updates Context is passed to native after native init to be available for crashes ([#4808](https://github.com/getsentry/sentry-react-native/pull/4808))
 
 ## 6.13.0
 

--- a/packages/core/src/js/client.ts
+++ b/packages/core/src/js/client.ts
@@ -141,6 +141,26 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
   }
 
   /**
+   * Register a hook on this client.
+   *
+   * (Generic method signature to allow for custom React Native Client events.)
+   */
+  public on(hook: string, callback: unknown): () => void {
+    // @ts-expect-error on from the base class doesn't support generic types
+    return super.on(hook, callback);
+  }
+
+  /**
+   * Emit a hook that was previously registered via `on()`.
+   *
+   * (Generic method signature to allow for custom React Native Client events.)
+   */
+  public emit(hook: string, ...rest: unknown[]): void {
+    // @ts-expect-error emit from the base class doesn't support generic types
+    super.emit(hook, ...rest);
+  }
+
+  /**
    * Starts native client with dsn and options
    */
   private _initNativeSdk(): void {
@@ -165,6 +185,7 @@ export class ReactNativeClient extends BaseClient<ReactNativeClientOptions> {
       )
       .then((didCallNativeInit: boolean) => {
         this._options.onReady?.({ didCallNativeInit });
+        this.emit('afterInit');
       })
       .then(undefined, error => {
         logger.error('The OnReady callback threw an error: ', error);

--- a/packages/core/src/js/integrations/expocontext.ts
+++ b/packages/core/src/js/integrations/expocontext.ts
@@ -1,5 +1,6 @@
 import { type DeviceContext, type Event, type Integration, type OsContext, logger } from '@sentry/core';
 
+import type { ReactNativeClient } from '../client';
 import { isExpo, isExpoGo } from '../utils/environment';
 import { getExpoDevice, getExpoUpdates } from '../utils/expomodules';
 import { NATIVE } from '../wrapper';
@@ -12,8 +13,14 @@ export const OTA_UPDATES_CONTEXT_KEY = 'ota_updates';
 export const expoContextIntegration = (): Integration => {
   let _expoUpdatesContextCached: ExpoUpdatesContext | undefined;
 
-  function setup(): void {
-    setExpoUpdatesNativeContext();
+  function setup(client: ReactNativeClient): void {
+    client.on('afterInit', () => {
+      if (!client.getOptions().enableNative) {
+        return;
+      }
+
+      setExpoUpdatesNativeContext();
+    });
   }
 
   function setExpoUpdatesNativeContext(): void {

--- a/packages/core/test/clientAfterInit.test.ts
+++ b/packages/core/test/clientAfterInit.test.ts
@@ -1,0 +1,78 @@
+import { ReactNativeClient } from '../src/js';
+import type { ReactNativeClientOptions } from '../src/js/options';
+import { NATIVE } from './mockWrapper';
+
+jest.useFakeTimers({ advanceTimers: true });
+
+jest.mock('../src/js/wrapper', () => jest.requireActual('./mockWrapper'));
+
+describe('ReactNativeClient emits `afterInit` event', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('emits `afterInit` event when native is enabled', async () => {
+    const client = setupReactNativeClient({
+      enableNative: true,
+    });
+
+    const emitSpy = jest.spyOn(client, 'emit');
+    client.init();
+
+    await jest.runOnlyPendingTimersAsync();
+
+    expect(emitSpy).toHaveBeenCalledWith('afterInit');
+  });
+
+  test('emits `afterInit` event when native is disabled', async () => {
+    const client = setupReactNativeClient({
+      enableNative: false,
+    });
+
+    const emitSpy = jest.spyOn(client, 'emit');
+    client.init();
+
+    await jest.runOnlyPendingTimersAsync();
+    expect(emitSpy).toHaveBeenCalledWith('afterInit');
+  });
+
+  test('emits `afterInit` event when native init is rejected', async () => {
+    NATIVE.initNativeSdk = jest.fn().mockRejectedValue(new Error('Test Native Init Rejected'));
+
+    const client = setupReactNativeClient({
+      enableNative: false,
+    });
+
+    const emitSpy = jest.spyOn(client, 'emit');
+    client.init();
+
+    await jest.runOnlyPendingTimersAsync();
+    expect(emitSpy).toHaveBeenCalledWith('afterInit');
+  });
+});
+
+function setupReactNativeClient(options: Partial<ReactNativeClientOptions> = {}): ReactNativeClient {
+  return new ReactNativeClient({
+    ...DEFAULT_OPTIONS,
+    ...options,
+  });
+}
+
+const EXAMPLE_DSN = 'https://6890c2f6677340daa4804f8194804ea2@o19635.ingest.sentry.io/148053';
+
+const DEFAULT_OPTIONS: ReactNativeClientOptions = {
+  dsn: EXAMPLE_DSN,
+  enableNative: true,
+  enableNativeCrashHandling: true,
+  enableNativeNagger: true,
+  autoInitializeNativeSdk: true,
+  enableAutoPerformanceTracing: true,
+  enableWatchdogTerminationTracking: true,
+  patchGlobalPromise: true,
+  integrations: [],
+  transport: () => ({
+    send: jest.fn(),
+    flush: jest.fn(),
+  }),
+  stackParser: jest.fn().mockReturnValue([]),
+};

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -114,5 +114,9 @@ export function setupTestClient(options: Partial<TestClientOptions> = {}): TestC
   const client = new TestClient(finalOptions);
   setCurrentClient(client);
   client.init();
+
+  // @ts-expect-error Only available on ReactNativeClient
+  client.emit('afterInit');
+
   return client;
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This native context would be lost as it was set before the SDK initializes.

## :green_heart: How did you test it?
sample app, unit tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes