### PR TITLE
chore(expo-sample): Add Expo Dev Client

### DIFF
--- a/samples/expo/app/(tabs)/index.tsx
+++ b/samples/expo/app/(tabs)/index.tsx
@@ -9,6 +9,7 @@ import { setScopeProperties } from '@/utils/setScopeProperties';
 import React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { useUpdates } from 'expo-updates';
+import { isWeb } from '../../utils/isWeb';
 
 const isRunningInExpoGo = Constants.appOwnership === 'expo';
 
@@ -26,6 +27,7 @@ export default function TabOneScreen() {
         onPress={() => {
           DevClient.openMenu();
         }}
+        disabled={isWeb()}
       />
       <Button
         title="Capture message"

--- a/samples/expo/app/(tabs)/index.tsx
+++ b/samples/expo/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import { Button, StyleSheet } from 'react-native';
 import Constants from 'expo-constants';
 import * as Sentry from '@sentry/react-native';
 import { reloadAppAsync } from 'expo';
+import * as DevClient from 'expo-dev-client';
 
 import { Text, View } from '@/components/Themed';
 import { setScopeProperties } from '@/utils/setScopeProperties';
@@ -9,7 +10,7 @@ import React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { useUpdates } from 'expo-updates';
 
-const isRunningInExpoGo = Constants.appOwnership === 'expo'
+const isRunningInExpoGo = Constants.appOwnership === 'expo';
 
 export default function TabOneScreen() {
   const { currentlyRunning } = useUpdates();
@@ -20,6 +21,12 @@ export default function TabOneScreen() {
       <Text>Update ID: {currentlyRunning.updateId}</Text>
       <Text>Channel: {currentlyRunning.channel}</Text>
       <Text>Runtime Version: {currentlyRunning.runtimeVersion}</Text>
+      <Button
+        title="Open DevMenu"
+        onPress={() => {
+          DevClient.openMenu();
+        }}
+      />
       <Button
         title="Capture message"
         onPress={() => {
@@ -35,8 +42,8 @@ export default function TabOneScreen() {
       <Button
         title="Capture exception with cause"
         onPress={() => {
-          const error = new Error('Captured exception')
-          error.cause = new Error('Cause of captured exception')
+          const error = new Error('Captured exception');
+          error.cause = new Error('Cause of captured exception');
           Sentry.captureException(error);
         }}
       />

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -21,6 +21,7 @@
     "@types/react": "~18.3.12",
     "expo": "~52.0.42",
     "expo-constants": "~17.0.8",
+    "expo-dev-client": "~5.0.20",
     "expo-image-picker": "~16.0.5",
     "expo-linking": "~7.0.5",
     "expo-router": "~4.0.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10264,6 +10264,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:8.11.0":
+  version: 8.11.0
+  resolution: "ajv@npm:8.11.0"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 5e0ff226806763be73e93dd7805b634f6f5921e3e90ca04acdf8db81eed9d8d3f0d4c5f1213047f45ebbf8047ffe0c840fa1ef2ec42c3a644899f69aa72b5bef
+  languageName: node
+  linkType: hard
+
 "ajv@npm:8.12.0":
   version: 8.12.0
   resolution: "ajv@npm:8.12.0"
@@ -15018,6 +15030,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-dev-client@npm:~5.0.20":
+  version: 5.0.20
+  resolution: "expo-dev-client@npm:5.0.20"
+  dependencies:
+    expo-dev-launcher: 5.0.35
+    expo-dev-menu: 6.0.25
+    expo-dev-menu-interface: 1.9.3
+    expo-manifests: ~0.15.8
+    expo-updates-interface: ~1.0.0
+  peerDependencies:
+    expo: "*"
+  checksum: bc853c70217c2e9e4903d2f23bc383e1b4f8a9037d95c5af66d8c1c4835edce045e1eda98b1479e72ad88e379899e3af16f625f7f75974650e72a258e60c34c2
+  languageName: node
+  linkType: hard
+
+"expo-dev-launcher@npm:5.0.35":
+  version: 5.0.35
+  resolution: "expo-dev-launcher@npm:5.0.35"
+  dependencies:
+    ajv: 8.11.0
+    expo-dev-menu: 6.0.25
+    expo-manifests: ~0.15.8
+    resolve-from: ^5.0.0
+  peerDependencies:
+    expo: "*"
+  checksum: 621f4a3ca047f5663a7a7dcbd790a19b41d8c01ef629ae075db7fd7af3dc5b829e463defc3bb247fea0d618f0598b7a7e3461d96cf6711b5076749c63ed305e9
+  languageName: node
+  linkType: hard
+
+"expo-dev-menu-interface@npm:1.9.3":
+  version: 1.9.3
+  resolution: "expo-dev-menu-interface@npm:1.9.3"
+  peerDependencies:
+    expo: "*"
+  checksum: e70f62146d80e71ed52c78bdc452e01e4f8ccdda78523aa719ebf042fb41ad8a37d2ad7af11c40d9cd3eca14dc23fb7e63187e52bbd28be29bb9c0c061616309
+  languageName: node
+  linkType: hard
+
+"expo-dev-menu@npm:6.0.25":
+  version: 6.0.25
+  resolution: "expo-dev-menu@npm:6.0.25"
+  dependencies:
+    expo-dev-menu-interface: 1.9.3
+  peerDependencies:
+    expo: "*"
+  checksum: 6ec93000526929f26b55ffb7e78341afd51fbffb881d25bdf2b65cfa41a2b7052bde567f08f5fa9909e2b324c23fb7878d5aca0da2279aeef2229cd676ac12a0
+  languageName: node
+  linkType: hard
+
 "expo-eas-client@npm:~0.13.3":
   version: 0.13.3
   resolution: "expo-eas-client@npm:0.13.3"
@@ -15142,6 +15203,18 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: dfc40ec2249df450faac0627519d0461e7520ddec93aff26bb24ffa0ba59623016ec3fbfd44673f656af9d176fb862502c1b03efbf385664a5a4cdd6ef4cdb11
+  languageName: node
+  linkType: hard
+
+"expo-manifests@npm:~0.15.8":
+  version: 0.15.8
+  resolution: "expo-manifests@npm:0.15.8"
+  dependencies:
+    "@expo/config": ~10.0.11
+    expo-json-utils: ~0.14.0
+  peerDependencies:
+    expo: "*"
+  checksum: 608e3ca95757b6adc2374442691cb918402810c69ed9fca6acd3f64bdfbd7e6be33470e777cb4d8656c322cd2e2a1524066bf8dcf9d11c1a21e5ce11145f31f2
   languageName: node
   linkType: hard
 
@@ -25124,6 +25197,7 @@ __metadata:
     "@types/react": ~18.3.12
     expo: ~52.0.42
     expo-constants: ~17.0.8
+    expo-dev-client: ~5.0.20
     expo-image-picker: ~16.0.5
     expo-linking: ~7.0.5
     expo-router: ~4.0.19


### PR DESCRIPTION
The Dev Client makes it easier to test different EAS Updates as it allows developers to loging to their EAS Account and pick an update in the Dev Menu.

https://docs.expo.dev/versions/latest/sdk/dev-client/

#skip-changelog 