### PR TITLE
Fix crashed last run not returning a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- crashedLastRun now returns the correct value ([#4829](https://github.com/getsentry/sentry-react-native/pull/4829))
 - Expo Updates Context is passed to native after native init to be available for crashes ([#4808](https://github.com/getsentry/sentry-react-native/pull/4808))
 - Expo Updates Context values should all be lowercase ([#4809](https://github.com/getsentry/sentry-react-native/pull/4809))
 

--- a/packages/core/src/js/wrapper.ts
+++ b/packages/core/src/js/wrapper.ts
@@ -695,7 +695,7 @@ export const NATIVE: SentryNativeWrapper = {
       return null;
     }
 
-    const result = RNSentry.crashedLastRun();
+    const result = await RNSentry.crashedLastRun();
     return typeof result === 'boolean' ? result : null;
   },
 

--- a/packages/core/test/wrapper.test.ts
+++ b/packages/core/test/wrapper.test.ts
@@ -14,6 +14,7 @@ jest.mock('react-native', () => {
     addBreadcrumb: jest.fn(),
     captureEnvelope: jest.fn(),
     clearBreadcrumbs: jest.fn(),
+    crashedLastRun: jest.fn(),
     crash: jest.fn(),
     fetchNativeDeviceContexts: jest.fn(() =>
       Promise.resolve({
@@ -783,5 +784,29 @@ describe('Tests Native Wrapper', () => {
       expect(RNSentry.setContext).toHaveBeenCalledWith('key', { self: '[Circular ~]' });
       expect(RNSentry.setContext).toHaveBeenCalledOnce();
     });
+  });
+
+  describe('crashedLastRun', () => {
+    test('return true when promise resolves true ', async () => {
+      (RNSentry.crashedLastRun as jest.Mock).mockResolvedValue(true);
+
+      const result = await NATIVE.crashedLastRun();
+      expect(result).toBeTrue();
+    });
+
+    test('return true when promise resolves false ', async () => {
+      (RNSentry.crashedLastRun as jest.Mock).mockResolvedValue(false);
+
+      const result = await NATIVE.crashedLastRun();
+      expect(result).toBeFalse();
+    });
+
+    test('return null when promise does not resolve ', async () => {
+      (RNSentry.crashedLastRun as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await NATIVE.crashedLastRun();
+      expect(result).toBeNull();
+    });
+
   });
 });

--- a/packages/core/test/wrapper.test.ts
+++ b/packages/core/test/wrapper.test.ts
@@ -807,6 +807,5 @@ describe('Tests Native Wrapper', () => {
       const result = await NATIVE.crashedLastRun();
       expect(result).toBeNull();
     });
-
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

CrashedLastRun had a typo so it was always returning null, this PR fixes this issue.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

typeof Promise<boolean> is object so it never gets valid, but if you await you get the value (boolean) or undefined, matching the original result.
Fixes https://github.com/getsentry/sentry-react-native/issues/4630

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
