### PR TITLE
test(e2e): Add delay on iOS before fetching replays

### DIFF
--- a/dev-packages/e2e-tests/maestro/utils/assertEventIdVisible.yml
+++ b/dev-packages/e2e-tests/maestro/utils/assertEventIdVisible.yml
@@ -10,6 +10,13 @@ jsEngine: graaljs
     id: "eventId"
 - assertTrue: ${maestro.copiedText}
 
+# Add a delay for iOS platform to ensure replays are available before the api call
+- evalScript: |
+    if (maestro.platform === "iOS") {
+      maestro.sleep(10000);
+    }
+    true;
+
 - runScript:
     file: sentryApi.js
     env:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

**Based on: https://github.com/getsentry/sentry-react-native/pull/4839**

## :scroll: Description
<!--- Describe your changes in detail -->
Add a delay for iOS platform to ensure replays are available before the api call

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/getsentry/sentry-react-native/pull/4839#pullrequestreview-2853513925

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog