### PR TITLE
chore(deps): v7: update Android SDK to v8.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@
 - Bump Cocoa SDK from v8.50.2 to v8.51.1 ([#4843](https://github.com/getsentry/sentry-react-native/pull/4843))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8511)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.50.0...8.51.1)
-- Bump Android SDK from v8.11.1 to v8.12.0 ([#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8120)
-  - [diff](https://github.com/getsentry/sentry-java/compare/8.11.1...8.12.0)
+- Bump Android SDK from v8.11.1 to v8.13.1 ([#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8131)
+  - [diff](https://github.com/getsentry/sentry-java/compare/8.11.1...8.13.1)
 
 ## 7.0.0-alpha.0
 

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -54,5 +54,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:8.12.0'
+    api 'io.sentry:sentry-android:8.13.1'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Bumps scripts/update-android.sh from 8.12.0 to 8.13.1.

Auto-generated by a [dependency updater](https://github.com/getsentry/github-workflows/blob/main/.github/workflows/updater.yml).
## Changelog
### 8.13.1

#### Fixes

- Fix SDK init crash if initialized from background thread while an activiy is resumed ([#4449](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4449))

#### Dependencies

- Bump Gradle from v8.14 to v8.14.1 ([#4437](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4437))
  - [changelog](https://github-redirect.dependabot.com/gradle/gradle/blob/master/CHANGELOG.md#v8141)
  - [diff](https://github-redirect.dependabot.com/gradle/gradle/compare/v8.14...v8.14.1)

### 8.13.0

#### Features

- Add debug mode for Session Replay masking ([#4357](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4357))
    - Use `Sentry.replay().enableDebugMaskingOverlay()` to overlay the screen with the Session Replay masks.
    - The masks will be invalidated at most once per `frameRate` (default 1 fps).
- Extend Logs API to allow passing in `attributes` ([#4402](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4402))
  - `Sentry.logger.log` now takes a `SentryLogParameters`
  - Use `SentryLogParameters.create(SentryAttributes.of(...))` to pass attributes
    - Attribute values may be of type `string`, `boolean`, `integer` or `double`.
    - Other types will be converted to `string`. Currently we simply call `toString()` but we might offer more in the future.
    - You may manually flatten complex types into multiple separate attributes of simple types.
      - e.g. intead of `SentryAttribute.named("point", Point(10, 20))` you may store it as `SentryAttribute.integerAttribute("point.x", point.x)` and `SentryAttribute.integerAttribute("point.y", point.y)`
    - `SentryAttribute.named()` will automatically infer the type or fall back to `string`.
    - `SentryAttribute.booleanAttribute()` takes a `Boolean` value
    - `SentryAttribute.integerAttribute()` takes a `Integer` value
    - `SentryAttribute.doubleAttribute()` takes a `Double` value
    - `SentryAttribute.stringAttribute()` takes a `String` value
  - We opted for handling parameters via `SentryLogParameters` to avoid creating tons of overloads that are ambiguous.

#### Fixes

- Isolation scope is now forked in `OtelSentrySpanProcessor` instead of `OtelSentryPropagator` ([#4434](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4434))
  - Since propagator may never be invoked we moved the location where isolation scope is forked.
  - Not invoking `OtelSentryPropagator.extract` or having a `sentry-trace` header that failed to parse would cause isolation scope not to be forked.
  - This in turn caused data to bleed between scopes, e.g. from one request into another

#### Dependencies

- Bump Spring Boot to `3.5.0` ([#4111](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4111))

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?

Manual with RN and Expo sample apps, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog
