### PR TITLE
feat(appStart): Add frame data in app start span

### DIFF
--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -20,8 +20,9 @@ import {
   UI_LOAD,
 } from '../../../src/js/tracing';
 import {
+  _captureAppStart,
   _clearRootComponentCreationTimestampMs,
-  _setAppStartEndTimestampMs,
+  _setAppStartEndData,
   _setRootComponentCreationTimestampMs,
   appStartIntegration,
   setRootComponentCreationTimestampMs,
@@ -788,6 +789,169 @@ describe('App Start Integration', () => {
   });
 });
 
+describe('Frame Data Integration', () => {
+  it('attaches frame data to standalone cold app start span', async () => {
+    const mockEndFrames = {
+      totalFrames: 150,
+      slowFrames: 5,
+      frozenFrames: 2,
+    };
+
+    mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
+
+    mockAppStart({ cold: true });
+
+    const actualEvent = await captureStandAloneAppStart();
+
+    const appStartSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+
+    expect(appStartSpan).toBeDefined();
+    expect(appStartSpan!.data).toEqual(
+      expect.objectContaining({
+        'frames.total': 150,
+        'frames.slow': 5,
+        'frames.frozen': 2,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_COLD_OP,
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+      }),
+    );
+  });
+
+  it('attaches frame data to standalone warm app start span', async () => {
+    const mockEndFrames = {
+      totalFrames: 200,
+      slowFrames: 8,
+      frozenFrames: 1,
+    };
+
+    mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
+
+    mockAppStart({ cold: false });
+
+    const actualEvent = await captureStandAloneAppStart();
+
+    const appStartSpan = actualEvent!.spans!.find(({ description }) => description === 'Warm App Start');
+
+    expect(appStartSpan).toBeDefined();
+    expect(appStartSpan!.data).toEqual(
+      expect.objectContaining({
+        'frames.total': 200,
+        'frames.slow': 8,
+        'frames.frozen': 1,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_WARM_OP,
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+      }),
+    );
+  });
+
+  it('attaches frame data to attached cold app start span', async () => {
+    const mockEndFrames = {
+      totalFrames: 120,
+      slowFrames: 3,
+      frozenFrames: 0,
+    };
+
+    mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
+
+    mockAppStart({ cold: true });
+
+    await _captureAppStart({ isManual: false });
+
+    const actualEvent = await processEvent(getMinimalTransactionEvent());
+
+    const appStartSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+
+    expect(appStartSpan).toBeDefined();
+    expect(appStartSpan!.data).toEqual(
+      expect.objectContaining({
+        'frames.total': 120,
+        'frames.slow': 3,
+        'frames.frozen': 0,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_COLD_OP,
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+      }),
+    );
+  });
+
+  it('attaches frame data to attached warm app start span', async () => {
+    const mockEndFrames = {
+      totalFrames: 180,
+      slowFrames: 12,
+      frozenFrames: 3,
+    };
+
+    mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
+
+    mockAppStart({ cold: false });
+
+    await _captureAppStart({ isManual: false });
+
+    const actualEvent = await processEvent(getMinimalTransactionEvent());
+
+    const appStartSpan = actualEvent!.spans!.find(({ description }) => description === 'Warm App Start');
+
+    expect(appStartSpan).toBeDefined();
+    expect(appStartSpan!.data).toEqual(
+      expect.objectContaining({
+        'frames.total': 180,
+        'frames.slow': 12,
+        'frames.frozen': 3,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_WARM_OP,
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+      }),
+    );
+  });
+
+  it('does not attach frame data when native frames are not available', async () => {
+    mockFunction(NATIVE.fetchNativeFrames).mockRejectedValue(new Error('Native frames not available'));
+
+    mockAppStart({ cold: true });
+
+    const actualEvent = await captureStandAloneAppStart();
+
+    const appStartSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+
+    expect(appStartSpan).toBeDefined();
+    expect(appStartSpan!.data).toEqual(
+      expect.objectContaining({
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_COLD_OP,
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+      }),
+    );
+
+    expect(appStartSpan!.data).not.toHaveProperty('frames.total');
+    expect(appStartSpan!.data).not.toHaveProperty('frames.slow');
+    expect(appStartSpan!.data).not.toHaveProperty('frames.frozen');
+  });
+
+  it('does not attach frame data when NATIVE is not enabled', async () => {
+    const originalEnableNative = NATIVE.enableNative;
+    (NATIVE as any).enableNative = false;
+
+    try {
+      mockAppStart({ cold: true });
+
+      const actualEvent = await captureStandAloneAppStart();
+
+      const appStartSpan = actualEvent!.spans!.find(({ description }) => description === 'Cold App Start');
+
+      expect(appStartSpan).toBeDefined();
+      expect(appStartSpan!.data).toEqual(
+        expect.objectContaining({
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: APP_START_COLD_OP,
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SPAN_ORIGIN_AUTO_APP_START,
+        }),
+      );
+
+      expect(appStartSpan!.data).not.toHaveProperty('frames.total');
+      expect(appStartSpan!.data).not.toHaveProperty('frames.slow');
+      expect(appStartSpan!.data).not.toHaveProperty('frames.frozen');
+    } finally {
+      (NATIVE as any).enableNative = originalEnableNative;
+    }
+  });
+});
+
 function setupIntegration() {
   const client = new TestClient(getDefaultTestClientOptions());
   const integration = appStartIntegration();
@@ -1095,7 +1259,10 @@ function mockAppStart({
       : [],
   };
 
-  _setAppStartEndTimestampMs(appStartEndTimestampMs || timeOriginMilliseconds);
+  _setAppStartEndData({
+    timestampMs: appStartEndTimestampMs || timeOriginMilliseconds,
+    endFrames: null,
+  });
   mockFunction(getTimeOriginMilliseconds).mockReturnValue(timeOriginMilliseconds);
   mockFunction(NATIVE.fetchNativeAppStart).mockResolvedValue(mockAppStartResponse);
 
@@ -1112,7 +1279,10 @@ function mockTooLongAppStart() {
     spans: [],
   };
 
-  _setAppStartEndTimestampMs(timeOriginMilliseconds);
+  _setAppStartEndData({
+    timestampMs: timeOriginMilliseconds,
+    endFrames: null,
+  });
   mockFunction(getTimeOriginMilliseconds).mockReturnValue(timeOriginMilliseconds);
   mockFunction(NATIVE.fetchNativeAppStart).mockResolvedValue(mockAppStartResponse);
 
@@ -1134,7 +1304,10 @@ function mockTooOldAppStart() {
 
   // App start finish timestamp
   // App start length is 5 seconds
-  _setAppStartEndTimestampMs(appStartEndTimestampMilliseconds);
+  _setAppStartEndData({
+    timestampMs: appStartEndTimestampMilliseconds,
+    endFrames: null,
+  });
   mockFunction(getTimeOriginMilliseconds).mockReturnValue(timeOriginMilliseconds - 64000);
   mockFunction(NATIVE.fetchNativeAppStart).mockResolvedValue(mockAppStartResponse);
   // Transaction start timestamp

--- a/packages/core/test/tracing/reactnavigation.ttid.test.tsx
+++ b/packages/core/test/tracing/reactnavigation.ttid.test.tsx
@@ -14,7 +14,7 @@ jest.mock('../../src/js/tracing/timetodisplaynative', () => mockedtimetodisplayn
 import * as Sentry from '../../src/js';
 import { startSpanManual } from '../../src/js';
 import { TimeToFullDisplay, TimeToInitialDisplay } from '../../src/js/tracing';
-import { _setAppStartEndTimestampMs } from '../../src/js/tracing/integrations/appStart';
+import { _setAppStartEndData } from '../../src/js/tracing/integrations/appStart';
 import { SPAN_ORIGIN_AUTO_NAVIGATION_REACT_NAVIGATION, SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY, SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY } from '../../src/js/tracing/origin';
 import { SPAN_THREAD_NAME, SPAN_THREAD_NAME_JAVASCRIPT } from '../../src/js/tracing/span';
 import { isHermesEnabled, notWeb } from '../../src/js/utils/environment';
@@ -47,7 +47,10 @@ describe('React Navigation - TTID', () => {
         type: 'cold',
         spans: [],
       });
-      _setAppStartEndTimestampMs(mockedAppStartTimeSeconds * 1000);
+      _setAppStartEndData({
+        timestampMs: mockedAppStartTimeSeconds * 1000,
+        endFrames: null
+      });
 
       const sut = createTestedInstrumentation({ enableTimeToInitialDisplay: true });
       transportSendMock = initSentry(sut).transportSendMock;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Add frame data in app start span

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partially https://github.com/getsentry/sentry-react-native/issues/4723

## :green_heart: How did you test it?
CI, Manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
