### PR TITLE
fix(appStart): Add frame delay data in app start span

### DIFF
--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -491,6 +491,7 @@ public class RNSentryModuleImpl {
         int totalFrames = 0;
         int slowFrames = 0;
         int frozenFrames = 0;
+        int framesDelay = 0; // TODO
 
         final SparseIntArray[] framesRates = frameMetricsAggregator.getMetrics();
 
@@ -518,6 +519,7 @@ public class RNSentryModuleImpl {
         map.putInt("totalFrames", totalFrames);
         map.putInt("slowFrames", slowFrames);
         map.putInt("frozenFrames", frozenFrames);
+        map.putInt("framesDelay", framesDelay);
 
         promise.resolve(map);
       } catch (Throwable ignored) { // NOPMD - We don't want to crash in any case

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -517,6 +517,11 @@ RCT_EXPORT_METHOD(fetchNativeFrames
 
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
     if (PrivateSentrySDKOnly.isFramesTrackingRunning) {
+        // TODO
+        CFTimeInterval framesDelay = [PrivateSentrySDKOnly getFramesDelay:0.0
+                                                       endSystemTimestamp:0.0];
+        NSNumber *delay = [NSNumber numberWithDouble:framesDelay];
+
         SentryScreenFrames *frames = PrivateSentrySDKOnly.currentScreenFrames;
 
         if (frames == nil) {
@@ -532,6 +537,7 @@ RCT_EXPORT_METHOD(fetchNativeFrames
             @"totalFrames" : total,
             @"frozenFrames" : frozen,
             @"slowFrames" : slow,
+            @"framesDelay" : delay,
         });
     } else {
         resolve(nil);

--- a/packages/core/src/js/NativeRNSentry.ts
+++ b/packages/core/src/js/NativeRNSentry.ts
@@ -112,6 +112,7 @@ export type NativeFramesResponse = {
   totalFrames: number;
   slowFrames: number;
   frozenFrames: number;
+  framesDelay: number;
 };
 
 export type NativeReleaseResponse = {

--- a/packages/core/src/js/tracing/integrations/appStart.ts
+++ b/packages/core/src/js/tracing/integrations/appStart.ts
@@ -154,6 +154,7 @@ function attachFrameDataToSpan(span: SpanJSON, frames: NativeFramesResponse): vo
   span.data['frames.total'] = frames.totalFrames;
   span.data['frames.slow'] = frames.slowFrames;
   span.data['frames.frozen'] = frames.frozenFrames;
+  span.data['frames.delay'] = frames.framesDelay;
 
   logger.debug('[AppStart] Attached frame data to span.', {
     spanId: span.span_id,

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -795,6 +795,7 @@ describe('Frame Data Integration', () => {
       totalFrames: 150,
       slowFrames: 5,
       frozenFrames: 2,
+      framesDelay: 0,
     };
 
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
@@ -822,6 +823,7 @@ describe('Frame Data Integration', () => {
       totalFrames: 200,
       slowFrames: 8,
       frozenFrames: 1,
+      framesDelay: 0,
     };
 
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
@@ -849,6 +851,7 @@ describe('Frame Data Integration', () => {
       totalFrames: 120,
       slowFrames: 3,
       frozenFrames: 0,
+      framesDelay: 0,
     };
 
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
@@ -878,6 +881,7 @@ describe('Frame Data Integration', () => {
       totalFrames: 180,
       slowFrames: 12,
       frozenFrames: 3,
+      framesDelay: 0,
     };
 
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);
@@ -907,6 +911,7 @@ describe('Frame Data Integration', () => {
       totalFrames: 0,
       slowFrames: 0,
       frozenFrames: 0,
+      framesDelay: 0,
     };
 
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValue(mockEndFrames);

--- a/packages/core/test/tracing/integrations/nativeframes.test.ts
+++ b/packages/core/test/tracing/integrations/nativeframes.test.ts
@@ -59,11 +59,13 @@ describe('NativeFramesInstrumentation', () => {
       totalFrames: 100,
       slowFrames: 20,
       frozenFrames: 5,
+      framesDelay: 0,
     };
     const finishFrames = {
       totalFrames: 200,
       slowFrames: 40,
       frozenFrames: 10,
+      framesDelay: 0,
     };
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValueOnce(startFrames).mockResolvedValueOnce(finishFrames);
 
@@ -99,11 +101,13 @@ describe('NativeFramesInstrumentation', () => {
       totalFrames: 0,
       slowFrames: 0,
       frozenFrames: 0,
+      framesDelay: 0,
     };
     const finishFrames = {
       totalFrames: 100,
       slowFrames: 20,
       frozenFrames: 5,
+      framesDelay: 0,
     };
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValueOnce(startFrames).mockResolvedValueOnce(finishFrames);
 
@@ -139,11 +143,13 @@ describe('NativeFramesInstrumentation', () => {
       totalFrames: 100,
       slowFrames: 20,
       frozenFrames: 5,
+      framesDelay: 0,
     };
     const finishFrames = {
       totalFrames: 100,
       slowFrames: 20,
       frozenFrames: 5,
+      framesDelay: 0,
     };
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValueOnce(startFrames).mockResolvedValueOnce(finishFrames);
 
@@ -174,6 +180,7 @@ describe('NativeFramesInstrumentation', () => {
       totalFrames: 200,
       slowFrames: 40,
       frozenFrames: 10,
+      framesDelay: 0,
     };
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValueOnce(startFrames).mockResolvedValueOnce(finishFrames);
 
@@ -203,6 +210,7 @@ describe('NativeFramesInstrumentation', () => {
       totalFrames: 100,
       slowFrames: 20,
       frozenFrames: 5,
+      framesDelay: 0,
     };
     const finishFrames: null = null;
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValueOnce(startFrames).mockResolvedValueOnce(finishFrames);
@@ -244,11 +252,13 @@ describe('NativeFramesInstrumentation', () => {
       totalFrames: 100,
       slowFrames: 20,
       frozenFrames: 5,
+      framesDelay: 0,
     };
     const finishFrames = {
       totalFrames: 200,
       slowFrames: 40,
       frozenFrames: 10,
+      framesDelay: 0,
     };
     mockFunction(NATIVE.fetchNativeFrames).mockResolvedValueOnce(startFrames).mockResolvedValueOnce(finishFrames);
 


### PR DESCRIPTION
**Based on: https://github.com/getsentry/sentry-react-native/pull/4865**

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
