### PR TITLE
fix(e2e): Remove auth token from launch params

### DIFF
--- a/dev-packages/e2e-tests/maestro/utils/launchTestAppClear.yml
+++ b/dev-packages/e2e-tests/maestro/utils/launchTestAppClear.yml
@@ -8,7 +8,6 @@ jsEngine: graaljs
 - launchApp:
     clearState: true
     arguments:
-      sentryAuthToken: ${SENTRY_AUTH_TOKEN}
       replaysOnErrorSampleRate: ${replaysOnErrorSampleRate}
 
 - runFlow: assertTestReady.yml

--- a/dev-packages/e2e-tests/src/EndToEndTests.tsx
+++ b/dev-packages/e2e-tests/src/EndToEndTests.tsx
@@ -1,27 +1,8 @@
 import * as Sentry from '@sentry/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
-import { LaunchArguments } from "react-native-launch-arguments";
 
 const E2E_TESTS_READY_TEXT = 'E2E Tests Ready';
-
-const getSentryAuthToken = ():
-  | { token: string }
-  | { error: string } => {
-  const { sentryAuthToken } = LaunchArguments.value<{
-    sentryAuthToken: unknown;
-  }>();
-
-  if (typeof sentryAuthToken !== 'string') {
-    return { error: 'Sentry Auth Token is required' };
-  }
-
-  if (sentryAuthToken.length === 0) {
-    return { error: 'Sentry Auth Token must not be empty' };
-  }
-
-  return { token: sentryAuthToken };
-};
 
 const EndToEndTestsScreen = (): JSX.Element => {
   const [isReady, setIsReady] = React.useState(false);


### PR DESCRIPTION
This PR Remove unused token launch param from RN E2E tests.

#skip-changelog 
