### PR TITLE
feat(featureFlags): Re-export Feature Flags integration

### DIFF
--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -14,6 +14,7 @@ export type {
   UserFeedback,
   ErrorEvent,
   TransactionEvent,
+  FeatureFlagsIntegration,
 } from '@sentry/core';
 
 export {
@@ -47,6 +48,7 @@ export {
   addEventProcessor,
   metricsDefault as metrics,
   lastEventId,
+  featureFlagsIntegration,
 } from '@sentry/core';
 
 export {


### PR DESCRIPTION
The `packages/core/src/js/index.ts` file was modified to export `featureFlagsIntegration` and `type FeatureFlagsIntegration` from `@sentry/core`.

*   The `FeatureFlagsIntegration` type was added to the existing type exports block.
*   The `featureFlagsIntegration` function was added to the existing function exports block.

This change enables the `featureFlagsIntegration` and its associated type to be re-exported from `@sentry/core`, making them accessible for use in other Sentry SDKs, such as `@sentry/react-native`. The modification aligns with the established pattern for exporting integrations within the Sentry codebase. A pull request was prepared to integrate these changes.