### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @krystofwoldrich @lucas-zimerman @antonis
+*       @antonis @lucas-zimerman


### PR DESCRIPTION
Removes krystof as codeowner.

#skip-changelog.