### PR TITLE
chore(deps): v7: update Android SDK to v8.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ Sentry.init({
 
 - It is recommended to use Sentry Self Hosted version `25.2.0` or new for React Native V7 or newer
 
+### Dependencies
+
+- Bump Android SDK from v8.13.2 to v8.13.3 ([#4929](https://github.com/getsentry/sentry-react-native/pull/4929))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8133)
+  - [diff](https://github.com/getsentry/sentry-java/compare/8.13.2...8.13.3)
+
 ## 7.0.0-beta.0
 
 ### Upgrading from 6.x to 7.0
@@ -101,9 +107,9 @@ Version 7 of the SDK is compatible with Sentry self-hosted versions 24.4.2 or hi
 - Bump JavaScript SDK from v8.54.0 to v9.22.0 ([#4568](https://github.com/getsentry/sentry-react-native/pull/4568), [#4752](https://github.com/getsentry/sentry-react-native/pull/4752), [#4860](https://github.com/getsentry/sentry-react-native/pull/4860))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/9.22.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/8.54.0...9.22.0)
-- Bump Android SDK from v7.20.1 to v8.13.3 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490), [#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8133)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.13.3)
+- Bump Android SDK from v7.20.1 to v8.13.2 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490), [#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.13.2)
 
 ## 6.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,9 +101,9 @@ Version 7 of the SDK is compatible with Sentry self-hosted versions 24.4.2 or hi
 - Bump JavaScript SDK from v8.54.0 to v9.22.0 ([#4568](https://github.com/getsentry/sentry-react-native/pull/4568), [#4752](https://github.com/getsentry/sentry-react-native/pull/4752), [#4860](https://github.com/getsentry/sentry-react-native/pull/4860))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/9.22.0/CHANGELOG.md)
   - [diff](https://github.com/getsentry/sentry-javascript/compare/8.54.0...9.22.0)
-- Bump Android SDK from v7.20.1 to v8.13.2 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490), [#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.13.2)
+- Bump Android SDK from v7.20.1 to v8.13.3 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490), [#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8133)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.13.3)
 
 ## 6.15.0
 

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -54,5 +54,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:8.13.2'
+    api 'io.sentry:sentry-android:8.13.3'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

## Changelog
### 8.13.3

#### Fixes

- Send UI Profiling app start chunk when it finishes ([#4423](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4423))
- Republish Javadoc [#4457](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4457)
- Finalize `OkHttpEvent` even if no active span in `SentryOkHttpInterceptor` [#4469](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4469)
- Session Replay: Do not capture current replay for cached events from the past ([#4474](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4474))
- Session Replay: Correctly capture Dialogs and non full-sized windows ([#4354](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4354))
- Session Replay: Fix inconsistent `segment_id` ([#4471](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4471))
- Session Replay: Fix crash on devices with the Unisoc/Spreadtrum T606 chipset ([#4477](https://github-redirect.dependabot.com/getsentry/sentry-java/pull/4477))


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-java/releases/tag/8.13.3

## :green_heart: How did you test it?
Manual, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
