### PR TITLE
chore(e2e): Bump E2E tests to RN 0.80.1

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -163,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.65.3', '0.80.0']
+        rn-version: ['0.65.3', '0.80.1']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -171,7 +171,7 @@ jobs:
         engine: ['hermes', 'jsc']
         include:
           - platform: ios
-            rn-version: '0.80.0'
+            rn-version: '0.80.1'
             xcode-version: '16.2'
             runs-on: macos-15
           - platform: ios
@@ -182,7 +182,7 @@ jobs:
             runs-on: ubuntu-latest
         exclude:
           # exclude JSC for new RN versions (keeping the matrix manageable)
-          - rn-version: '0.80.0'
+          - rn-version: '0.80.1'
             engine: 'jsc'
           # exclude all rn versions lower than 0.70.0 for new architecture
           - rn-version: '0.65.3'
@@ -301,7 +301,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.65.3', '0.80.0']
+        rn-version: ['0.65.3', '0.80.1']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -309,7 +309,7 @@ jobs:
         engine: ['hermes', 'jsc']
         include:
           - platform: ios
-            rn-version: '0.80.0'
+            rn-version: '0.80.1'
             runs-on: macos-15
           - platform: ios
             rn-version: '0.65.3'
@@ -323,7 +323,7 @@ jobs:
           # e2e test only the default combinations
           - rn-version: '0.65.3'
             engine: 'hermes'
-          - rn-version: '0.80.0'
+          - rn-version: '0.80.1'
             engine: 'jsc'
 
     steps:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Bumps E2E tests to the latest RN version to verify compatibility

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/getsentry/sentry-react-native/pull/3567

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog