### PR TITLE
test: Adds unit tests for SR mask/unmask managers

### DIFF
--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayMaskManagerTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayMaskManagerTest.kt
@@ -2,6 +2,7 @@ package io.sentry.react.replay
 
 import com.facebook.react.module.annotations.ReactModule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayMaskManagerTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayMaskManagerTest.kt
@@ -1,0 +1,38 @@
+package io.sentry.react.replay
+
+import com.facebook.react.module.annotations.ReactModule
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.MockitoAnnotations
+
+@RunWith(JUnit4::class)
+class RNSentryReplayMaskManagerTest {
+    private val expectedName = RNSentryReplayMaskManagerImpl.REACT_CLASS
+
+    private lateinit var manager: RNSentryReplayMaskManager
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        manager = RNSentryReplayMaskManager()
+    }
+
+    @Test
+    fun `getName returns correct react class name`() {
+        assertEquals(expectedName, manager.getName())
+    }
+
+    @Test
+    fun `module annotation name matches getName result`() {
+        val annotation = manager.javaClass.getAnnotation(ReactModule::class.java)
+        assertNotNull("ReactModule annotation should be present", annotation)
+        assertEquals(
+            "Annotation name should match getName() result",
+            expectedName,
+            annotation?.name,
+        )
+    }
+}

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayUnmaskManagerTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayUnmaskManagerTest.kt
@@ -2,6 +2,7 @@ package io.sentry.react.replay
 
 import com.facebook.react.module.annotations.ReactModule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayUnmaskManagerTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/replay/RNSentryReplayUnmaskManagerTest.kt
@@ -1,0 +1,38 @@
+package io.sentry.react.replay
+
+import com.facebook.react.module.annotations.ReactModule
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.MockitoAnnotations
+
+@RunWith(JUnit4::class)
+class RNSentryReplayUnmaskManagerTest {
+    private val expectedName = RNSentryReplayUnmaskManagerImpl.REACT_CLASS
+
+    private lateinit var manager: RNSentryReplayUnmaskManager
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        manager = RNSentryReplayUnmaskManager()
+    }
+
+    @Test
+    fun `getName returns correct react class name`() {
+        assertEquals(expectedName, manager.getName())
+    }
+
+    @Test
+    fun `module annotation name matches getName result`() {
+        val annotation = manager.javaClass.getAnnotation(ReactModule::class.java)
+        assertNotNull("ReactModule annotation should be present", annotation)
+        assertEquals(
+            "Annotation name should match getName() result",
+            expectedName,
+            annotation?.name,
+        )
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds unit tests for SR mask/unmask managers

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a follow up to https://github.com/getsentry/sentry-react-native/pull/4957 adding minimal unit tests covering the cases were the error appeared

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Add UI tests for masking

#skip-changelog