### PR TITLE
chore(ci): Add Sentry Android Gradle Plugin update script in the workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - antonis/sagp-updater # temporary branch to test bump script
 
 jobs:
   android:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - antonis/sagp-updater # temporary branch to test bump script
 
 jobs:
   android:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -86,3 +86,14 @@ jobs:
       changelog-entry: false
     secrets:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
+
+  sentry-android-gradle-plugin:
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
+    with:
+      path: scripts/update-sentry-android-gradle-plugin.sh
+      name: Sentry Android Gradle Plugin
+      pattern: '^v[0-9.]+$' # only match non-preview versions
+      pr-strategy: update
+      changelog-entry: false
+    secrets:
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -93,7 +93,7 @@ jobs:
     with:
       path: scripts/update-sentry-android-gradle-plugin.sh
       name: Sentry Android Gradle Plugin
-      pattern: '^v[0-9.]+$' # only match non-preview versions
+      pattern: '^[0-9.]+$'
       pr-strategy: update
       changelog-entry: false
     secrets:

--- a/packages/core/plugin/src/withSentryAndroidGradlePlugin.ts
+++ b/packages/core/plugin/src/withSentryAndroidGradlePlugin.ts
@@ -13,6 +13,8 @@ export interface SentryAndroidGradlePluginOptions {
   includeSourceContext?: boolean;
 }
 
+export const sentryAndroidGradlePluginVersion = '4.14.1';
+
 /**
  * Adds the Sentry Android Gradle Plugin to the project.
  * https://docs.sentry.io/platforms/react-native/manual-setup/manual-setup/#enable-sentry-agp
@@ -29,8 +31,6 @@ export function withSentryAndroidGradlePlugin(
     includeSourceContext = false,
   }: SentryAndroidGradlePluginOptions = {},
 ): any {
-  const version = '4.14.1';
-
   // Modify android/build.gradle
   const withSentryProjectBuildGradle = (config: any): any => {
     return withProjectBuildGradle(config, (projectBuildGradle: any) => {
@@ -45,7 +45,7 @@ export function withSentryAndroidGradlePlugin(
         return config;
       }
 
-      const dependency = `classpath("io.sentry:sentry-android-gradle-plugin:${version}")`;
+      const dependency = `classpath("io.sentry:sentry-android-gradle-plugin:${sentryAndroidGradlePluginVersion}")`;
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (projectBuildGradle.modResults.contents.includes(dependency)) {

--- a/packages/core/test/expo-plugin/withSentryAndroidGradlePlugin.test.ts
+++ b/packages/core/test/expo-plugin/withSentryAndroidGradlePlugin.test.ts
@@ -2,7 +2,10 @@ import { withAppBuildGradle, withProjectBuildGradle } from '@expo/config-plugins
 
 import { warnOnce } from '../../plugin/src/utils';
 import type { SentryAndroidGradlePluginOptions } from '../../plugin/src/withSentryAndroidGradlePlugin';
-import { withSentryAndroidGradlePlugin } from '../../plugin/src/withSentryAndroidGradlePlugin';
+import {
+  sentryAndroidGradlePluginVersion,
+  withSentryAndroidGradlePlugin,
+} from '../../plugin/src/withSentryAndroidGradlePlugin';
 
 jest.mock('@expo/config-plugins', () => ({
   withProjectBuildGradle: jest.fn(),
@@ -43,7 +46,6 @@ describe('withSentryAndroidGradlePlugin', () => {
   });
 
   it('adds the Sentry plugin to build.gradle when enableAndroidGradlePlugin is enabled', () => {
-    const version = '4.14.1';
     const options: SentryAndroidGradlePluginOptions = { enableAndroidGradlePlugin: true };
 
     (withProjectBuildGradle as jest.Mock).mockImplementation((config, callback) => {
@@ -65,13 +67,12 @@ describe('withSentryAndroidGradlePlugin', () => {
     });
 
     expect(modifiedGradle.modResults.contents).toContain(
-      `classpath("io.sentry:sentry-android-gradle-plugin:${version}")`,
+      `classpath("io.sentry:sentry-android-gradle-plugin:${sentryAndroidGradlePluginVersion}")`,
     );
   });
 
   it('warnOnce if the Sentry plugin is already included in build.gradle', () => {
-    const version = '4.14.1';
-    const includedBuildGradle = `dependencies { classpath("io.sentry:sentry-android-gradle-plugin:${version}")}`;
+    const includedBuildGradle = `dependencies { classpath("io.sentry:sentry-android-gradle-plugin:${sentryAndroidGradlePluginVersion}")}`;
     const options: SentryAndroidGradlePluginOptions = { enableAndroidGradlePlugin: true };
 
     (withProjectBuildGradle as jest.Mock).mockImplementation((config, callback) => {

--- a/scripts/update-sentry-android-gradle-plugin.sh
+++ b/scripts/update-sentry-android-gradle-plugin.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 {get-version|get-repo|set-version <new_version>}"
+  exit 1
+fi
+
+# Files to search and update Sentry Android Gradle Plugin version
+files=(
+  "$(dirname "$0")/../packages/core/plugin/src/withSentryAndroidGradlePlugin.ts"
+  "$(dirname "$0")/../samples/react-native/android/build.gradle"
+)
+
+# Regex patterns to match version declarations
+ts_regex="export const sentryAndroidGradlePluginVersion = ['\"]([0-9]+\.[0-9]+\.[0-9]+)['\"]"
+gradle_regex="classpath\(['\"]io\.sentry:sentry-android-gradle-plugin:([0-9]+\.[0-9]+\.[0-9]+)['\"]"
+
+# Sentry uses a prefix in the repo tags, but we want to remove it for the version in the files
+tagPrefix='v'
+
+first_match=""
+
+for file in "${files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    continue
+  fi
+  while IFS= read -r line; do
+    # Check both TypeScript and Gradle patterns
+    if [[ $line =~ $ts_regex ]] || [[ $line =~ $gradle_regex ]]; then
+      first_match="${BASH_REMATCH[1]}"
+      break 2
+    fi
+  done < "$file"
+done
+
+if [[ -z "$first_match" && "$1" != "get-repo" ]]; then
+  echo "Failed to find the Sentry Android Gradle Plugin version in any of the following files:"
+  for file in "${files[@]}"; do
+    echo "  - $file"
+  done
+  exit 1
+fi
+
+case $1 in
+get-version)
+  echo "$first_match"
+  ;;
+
+get-repo)
+  echo "https://github.com/getsentry/sentry-android-gradle-plugin"
+  ;;
+
+set-version)
+  if [ $# -ne 2 ]; then
+    echo "Usage: $0 set-version <new_version>"
+    exit 1
+  fi
+  new_version=$2
+  # remove $tagPrefix from the $version by skipping the first `strlen($tagPrefix)` characters
+  if [[ "$new_version" == "$tagPrefix"* ]]; then
+      new_version="${new_version:${#tagPrefix}}"
+  fi
+  for file in "${files[@]}"; do
+    if [[ ! -f "$file" ]]; then
+      echo "⚠️ File not found: $file"
+      continue
+    fi
+    updated=false
+    tmpfile=$(mktemp)
+    while IFS= read -r line; do
+      if [[ $line =~ $ts_regex ]]; then
+        new_line="export const sentryAndroidGradlePluginVersion = '${new_version}';"
+        echo "$new_line" >> "$tmpfile"
+        updated=true
+      elif [[ $line =~ $gradle_regex ]]; then
+        # Preserve the original quote style and indentation
+        quote_char="'"
+        if [[ $line == *\"* ]]; then
+          quote_char="\""
+        fi
+        # Extract indentation from the original line
+        indentation=$(echo "$line" | sed 's/[^ \t].*//')
+        new_line="${indentation}classpath(${quote_char}io.sentry:sentry-android-gradle-plugin:${new_version}${quote_char})"
+        echo "$new_line" >> "$tmpfile"
+        updated=true
+      else
+        echo "$line" >> "$tmpfile"
+      fi
+    done < "$file"
+    if $updated; then
+      mv "$tmpfile" "$file"
+      echo "✅ Updated $file to Sentry Android Gradle Plugin version: '$new_version'"
+    else
+      rm "$tmpfile"
+      echo "⚠️ No Sentry Android Gradle Plugin version found in $file"
+    fi
+  done
+  ;;
+
+*)
+  echo "Unknown argument $1"
+  echo "Usage: $0 {get-version|get-repo|set-version <new_version>}"
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Adds Sentry Android Gradle Plugin update script in the workflow

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed [an outdated version hardcoded](https://github.com/getsentry/sentry-react-native/blob/d18ddb18691fd5593a768f4edf8cc7e923d5e536/packages/core/plugin/src/withSentryAndroidGradlePlugin.ts#L32) as I was investigating another issue

## :green_heart: How did you test it?
- [Temporarily added the PR branch in the updater](https://github.com/getsentry/sentry-react-native/pull/4970/commits/990a349568522326ab7e04e0b41d0cc7b01262a0)
- [CI Run](https://github.com/getsentry/sentry-react-native/actions/runs/16071147298/job/45355884354?pr=4970)
- [PR Opened](https://github.com/getsentry/sentry-react-native/pull/4971)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog