### PR TITLE
feat: Add experimental flag `enableUnhandledCPPExceptionsV2` on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+### Features
+
+- Add experimental flag `enableUnhandledCPPExceptionsV2` on iOS ([#4975](https://github.com/getsentry/sentry-react-native/pull/4975))
+
+  ```js
+  import * as Sentry from '@sentry/react-native';
+
+  Sentry.init({
+    _experiments: {
+      enableUnhandledCPPExceptionsV2: true,
+    },
+  });
+  ```
+
 ## 6.16.1
 
 ### Fixes

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.mm
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.mm
@@ -239,6 +239,82 @@ XCTAssertEqual(actualOptions.enableTracing, false, @"EnableTracing should not be
     XCTAssertFalse(actualOptions.enableSpotlight, @"Did not disable spotlight");
 }
 
+- (void)testCreateOptionsWithDictionaryEnableUnhandledCPPExceptionsV2Enabled
+{
+    RNSentry *rnSentry = [[RNSentry alloc] init];
+    NSError *error = nil;
+
+    NSDictionary *_Nonnull mockedReactNativeDictionary = @{
+        @"dsn" : @"https://abcd@efgh.ingest.sentry.io/123456",
+        @"_experiments" : @ {
+            @"enableUnhandledCPPExceptionsV2" : @YES,
+        },
+    };
+    SentryOptions *actualOptions = [rnSentry createOptionsWithDictionary:mockedReactNativeDictionary
+                                                                   error:&error];
+
+    XCTAssertNotNil(actualOptions, @"Did not create sentry options");
+    XCTAssertNil(error, @"Should not pass no error");
+
+    id experimentalOptions = [actualOptions valueForKey:@"experimental"];
+    XCTAssertNotNil(experimentalOptions, @"Experimental options should not be nil");
+
+    BOOL enableUnhandledCPPExceptions =
+        [[experimentalOptions valueForKey:@"enableUnhandledCPPExceptionsV2"] boolValue];
+    XCTAssertTrue(
+        enableUnhandledCPPExceptions, @"enableUnhandledCPPExceptionsV2 should be enabled");
+}
+
+- (void)testCreateOptionsWithDictionaryEnableUnhandledCPPExceptionsV2Disabled
+{
+    RNSentry *rnSentry = [[RNSentry alloc] init];
+    NSError *error = nil;
+
+    NSDictionary *_Nonnull mockedReactNativeDictionary = @{
+        @"dsn" : @"https://abcd@efgh.ingest.sentry.io/123456",
+        @"_experiments" : @ {
+            @"enableUnhandledCPPExceptionsV2" : @NO,
+        },
+    };
+    SentryOptions *actualOptions = [rnSentry createOptionsWithDictionary:mockedReactNativeDictionary
+                                                                   error:&error];
+
+    XCTAssertNotNil(actualOptions, @"Did not create sentry options");
+    XCTAssertNil(error, @"Should not pass no error");
+
+    id experimentalOptions = [actualOptions valueForKey:@"experimental"];
+    XCTAssertNotNil(experimentalOptions, @"Experimental options should not be nil");
+
+    BOOL enableUnhandledCPPExceptions =
+        [[experimentalOptions valueForKey:@"enableUnhandledCPPExceptionsV2"] boolValue];
+    XCTAssertFalse(
+        enableUnhandledCPPExceptions, @"enableUnhandledCPPExceptionsV2 should be disabled");
+}
+
+- (void)testCreateOptionsWithDictionaryEnableUnhandledCPPExceptionsV2Default
+{
+    RNSentry *rnSentry = [[RNSentry alloc] init];
+    NSError *error = nil;
+
+    NSDictionary *_Nonnull mockedReactNativeDictionary = @{
+        @"dsn" : @"https://abcd@efgh.ingest.sentry.io/123456",
+    };
+    SentryOptions *actualOptions = [rnSentry createOptionsWithDictionary:mockedReactNativeDictionary
+                                                                   error:&error];
+
+    XCTAssertNotNil(actualOptions, @"Did not create sentry options");
+    XCTAssertNil(error, @"Should not pass no error");
+
+    // Test that when no _experiments are provided, the experimental option defaults to false
+    id experimentalOptions = [actualOptions valueForKey:@"experimental"];
+    XCTAssertNotNil(experimentalOptions, @"Experimental options should not be nil");
+
+    BOOL enableUnhandledCPPExceptions =
+        [[experimentalOptions valueForKey:@"enableUnhandledCPPExceptionsV2"] boolValue];
+    XCTAssertFalse(
+        enableUnhandledCPPExceptions, @"enableUnhandledCPPExceptionsV2 should default to disabled");
+}
+
 - (void)testPassesErrorOnWrongDsn
 {
     RNSentry *rnSentry = [[RNSentry alloc] init];

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -49,8 +49,8 @@
 #    import "RNSentryRNSScreen.h"
 #endif
 
-#import "RNSentryVersion.h"
 #import "RNSentryExperimentalOptions.h"
+#import "RNSentryVersion.h"
 
 @interface
 SentrySDK (RNSentry)

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -50,6 +50,7 @@
 #endif
 
 #import "RNSentryVersion.h"
+#import "RNSentryExperimentalOptions.h"
 
 @interface
 SentrySDK (RNSentry)
@@ -229,11 +230,8 @@ RCT_EXPORT_METHOD(initNativeSdk
     if (experiments != nil && [experiments isKindOfClass:[NSDictionary class]]) {
         BOOL enableUnhandledCPPExceptions =
             [experiments[@"enableUnhandledCPPExceptionsV2"] boolValue];
-        id experimentalOptions = [sentryOptions valueForKey:@"experimental"];
-        if (experimentalOptions) {
-            [experimentalOptions setValue:@(enableUnhandledCPPExceptions)
-                                   forKey:@"enableUnhandledCPPExceptionsV2"];
-        }
+        [RNSentryExperimentalOptions setEnableUnhandledCPPExceptionsV2:enableUnhandledCPPExceptions
+                                                         sentryOptions:sentryOptions];
     }
 
     return sentryOptions;

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -225,6 +225,17 @@ RCT_EXPORT_METHOD(initNativeSdk
     // Failed requests can only be enabled in one SDK to avoid duplicates
     sentryOptions.enableCaptureFailedRequests = NO;
 
+    NSDictionary *experiments = options[@"_experiments"];
+    if (experiments != nil && [experiments isKindOfClass:[NSDictionary class]]) {
+        BOOL enableUnhandledCPPExceptions =
+            [experiments[@"enableUnhandledCPPExceptionsV2"] boolValue];
+        id experimentalOptions = [sentryOptions valueForKey:@"experimental"];
+        if (experimentalOptions) {
+            [experimentalOptions setValue:@(enableUnhandledCPPExceptions)
+                                   forKey:@"enableUnhandledCPPExceptionsV2"];
+        }
+    }
+
     return sentryOptions;
 }
 

--- a/packages/core/ios/RNSentryExperimentalOptions.h
+++ b/packages/core/ios/RNSentryExperimentalOptions.h
@@ -1,0 +1,26 @@
+#import <Foundation/Foundation.h>
+
+@class SentryOptions;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNSentryExperimentalOptions : NSObject
+
+/**
+ * Sets the enableUnhandledCPPExceptionsV2 experimental option on SentryOptions
+ * @param sentryOptions The SentryOptions instance to configure
+ * @param enabled Whether to enable unhandled C++ exceptions V2
+ */
++ (void)setEnableUnhandledCPPExceptionsV2:(BOOL)enabled
+                            sentryOptions:(SentryOptions *)sentryOptions;
+
+/**
+ * Gets the current value of enableUnhandledCPPExceptionsV2 experimental option
+ * @param sentryOptions The SentryOptions instance to read from
+ * @return The current value of enableUnhandledCPPExceptionsV2
+ */
++ (BOOL)getEnableUnhandledCPPExceptionsV2:(SentryOptions *)sentryOptions;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/core/ios/RNSentryExperimentalOptions.m
+++ b/packages/core/ios/RNSentryExperimentalOptions.m
@@ -3,15 +3,16 @@
 
 @implementation RNSentryExperimentalOptions
 
-+ (void)setEnableUnhandledCPPExceptionsV2:(BOOL)enabled
-                            sentryOptions:(SentryOptions *)sentryOptions {
++ (void)setEnableUnhandledCPPExceptionsV2:(BOOL)enabled sentryOptions:(SentryOptions *)sentryOptions
+{
     if (sentryOptions == nil) {
         return;
     }
     sentryOptions.experimental.enableUnhandledCPPExceptionsV2 = enabled;
 }
 
-+ (BOOL)getEnableUnhandledCPPExceptionsV2:(SentryOptions *)sentryOptions {
++ (BOOL)getEnableUnhandledCPPExceptionsV2:(SentryOptions *)sentryOptions
+{
     if (sentryOptions == nil) {
         return NO;
     }

--- a/packages/core/ios/RNSentryExperimentalOptions.m
+++ b/packages/core/ios/RNSentryExperimentalOptions.m
@@ -1,0 +1,21 @@
+#import "RNSentryExperimentalOptions.h"
+@import Sentry;
+
+@implementation RNSentryExperimentalOptions
+
++ (void)setEnableUnhandledCPPExceptionsV2:(BOOL)enabled
+                            sentryOptions:(SentryOptions *)sentryOptions {
+    if (sentryOptions == nil) {
+        return;
+    }
+    sentryOptions.experimental.enableUnhandledCPPExceptionsV2 = enabled;
+}
+
++ (BOOL)getEnableUnhandledCPPExceptionsV2:(SentryOptions *)sentryOptions {
+    if (sentryOptions == nil) {
+        return NO;
+    }
+    return sentryOptions.experimental.enableUnhandledCPPExceptionsV2;
+}
+
+@end

--- a/packages/core/src/js/options.ts
+++ b/packages/core/src/js/options.ts
@@ -253,6 +253,17 @@ export interface BaseReactNativeOptions {
      * This will be removed in the next major version.
      */
     replaysOnErrorSampleRate?: number;
+
+    /**
+     * Experiment: A more reliable way to report unhandled C++ exceptions in iOS.
+     *
+     * This approach hooks into all instances of the `__cxa_throw` function, which provides a more comprehensive and consistent exception handling across an app’s runtime, regardless of the number of C++ modules or how they’re linked. It helps in obtaining accurate stack traces.
+     *
+     * - Note: The mechanism of hooking into `__cxa_throw` could cause issues with symbolication on iOS due to caching of symbol references.
+     *
+     * @default false
+     */
+    enableUnhandledCPPExceptionsV2?: boolean;
   };
 
   /**

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -171,6 +171,9 @@ Sentry.init({
   // This should be disabled when manually initializing the native SDK
   // Note that options from JS are not passed to the native SDKs when initialized manually
   autoInitializeNativeSdk: true,
+  _experiments: {
+    enableUnhandledCPPExceptionsV2: true,
+  },
 });
 
 const Stack = isMobileOs


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Add experimental flag `enableUnhandledCPPExceptionsV2` on iOS that provides a more reliable way to report unhandled C++ exceptions in iOS.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-react-native/issues/4966

## :green_heart: How did you test it?
Manual, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
