### PR TITLE
fix(samples): v7: Remove `enableTracing` from sample apps

### DIFF
--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -84,8 +84,6 @@ Sentry.init({
   enableAutoSessionTracking: true,
   // For testing, session close when 5 seconds (instead of the default 30) in the background.
   sessionTrackingIntervalMillis: 5000,
-  // This will capture ALL TRACES and likely use up all your quota
-  enableTracing: true,
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost', /^\//, /^https:\/\//, /^http:\/\//],
   attachStacktrace: true,

--- a/samples/react-native-macos/src/App.tsx
+++ b/samples/react-native-macos/src/App.tsx
@@ -93,8 +93,6 @@ Sentry.init({
   enableAutoSessionTracking: true,
   // For testing, session close when 5 seconds (instead of the default 30) in the background.
   sessionTrackingIntervalMillis: 30000,
-  // This will capture ALL TRACES and likely use up all your quota
-  enableTracing: true,
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost', /^\//, /^https:\/\//, /^http:\/\//],
   attachStacktrace: true,

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -160,8 +160,6 @@ Sentry.init({
   enableAutoSessionTracking: true,
   // For testing, session close when 5 seconds (instead of the default 30) in the background.
   sessionTrackingIntervalMillis: 30000,
-  // This will capture ALL TRACES and likely use up all your quota
-  enableTracing: true,
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost', /^\//, /^https:\/\//, /^http:\/\//],
   attachStacktrace: true,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Removes `enableTracing` from sample apps since this has been removed

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This option has been removed in https://github.com/getsentry/sentry-react-native/releases/tag/7.0.0-beta.1

## :green_heart: How did you test it?
Manual, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog since this has been communicated in https://github.com/getsentry/sentry-react-native/blob/v7/CHANGELOG.md#700-beta1