### PR TITLE
fix(span): Skip idle span creation when app is in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Skip idle span creation when app is in background ([#4995](https://github.com/getsentry/sentry-react-native/pull/4995))
+
 ### Dependencies
 
 - Bump JavaScript SDK from v8.54.0 to v8.55.0 ([#4981](https://github.com/getsentry/sentry-react-native/pull/4981))

--- a/packages/core/src/js/tracing/span.ts
+++ b/packages/core/src/js/tracing/span.ts
@@ -12,6 +12,7 @@ import {
   spanToJSON,
   startIdleSpan as coreStartIdleSpan,
 } from '@sentry/core';
+import { AppState } from 'react-native';
 
 import { isRootSpan } from '../utils/span';
 import { adjustTransactionDuration, cancelInBackground } from './onSpanEndUtils';
@@ -101,6 +102,12 @@ export const startIdleSpan = (
   const client = getClient();
   if (!client) {
     logger.warn(`[startIdleSpan] Can't create idle span, missing client.`);
+    return new SentryNonRecordingSpan();
+  }
+
+  const currentAppState = AppState.currentState;
+  if (currentAppState === 'background') {
+    logger.debug(`[startIdleSpan] App is already in background, not starting span for ${startSpanOption.name}`);
     return new SentryNonRecordingSpan();
   }
 

--- a/packages/core/test/tracing/idleNavigationSpan.test.ts
+++ b/packages/core/test/tracing/idleNavigationSpan.test.ts
@@ -35,6 +35,7 @@ describe('startIdleNavigationSpan', () => {
     jest.useFakeTimers();
     NATIVE.enableNative = true;
     mockedAppState.isAvailable = true;
+    mockedAppState.currentState = 'active';
     mockedAppState.addEventListener = (_, listener) => {
       mockedAppState.listener = listener;
       return {
@@ -80,6 +81,37 @@ describe('startIdleNavigationSpan', () => {
     jest.runAllTimers();
 
     expect(spanToJSON(transaction!).timestamp).toBeDefined();
+  });
+
+  it('Returns non-recording span when app is already in background', () => {
+    mockedAppState.currentState = 'background';
+
+    const span = startIdleNavigationSpan({
+      name: 'test',
+    });
+
+    // Non-recording spans don't become active
+    expect(getActiveSpan()).toBeUndefined();
+
+    // Verify it's a non-recording span
+    expect(span).toBeDefined();
+    expect(span.constructor.name).toBe('SentryNonRecordingSpan');
+
+    // No AppState listener should be set up for non-recording spans
+    expect(mockedAppState.removeSubscription).not.toHaveBeenCalled();
+  });
+
+  it('Does not set up AppState listener for background spans', () => {
+    mockedAppState.currentState = 'background';
+
+    startIdleNavigationSpan({
+      name: 'test',
+    });
+
+    mockedAppState.setState('active');
+
+    // No subscription removal should happen since no listener was set up
+    expect(mockedAppState.removeSubscription).not.toHaveBeenCalled();
   });
 
   describe('Start a new active root span (without parent)', () => {

--- a/packages/core/test/tracing/integrations/userInteraction.test.ts
+++ b/packages/core/test/tracing/integrations/userInteraction.test.ts
@@ -66,6 +66,7 @@ describe('User Interaction Tracing', () => {
     jest.useFakeTimers();
     NATIVE.enableNative = true;
     mockedAppState.isAvailable = true;
+    mockedAppState.currentState = 'active';
     mockedAppState.addEventListener = (_, listener) => {
       mockedAppState.listener = listener;
       return {
@@ -290,6 +291,18 @@ describe('User Interaction Tracing', () => {
         }),
       );
       expect(interactionTransactionContext!.timestamp).toBeLessThanOrEqual(routingTransactionContext!.start_timestamp!);
+    });
+
+    test('does not start UI span when app is in background', () => {
+      mockedAppState.currentState = 'background';
+
+      startUserInteractionSpan(mockedUserInteractionId);
+
+      // No active span should be created
+      expect(getActiveSpan()).toBeUndefined();
+
+      // No events should be queued
+      expect(client.eventQueue).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Skip idle span creation when app is in background.

This is a follow up to https://github.com/getsentry/sentry-react-native/pull/3307

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Client reports of transactions starting in the background resulting in (a small number of) unexplainable long transactions skewing the app statistics.

## :green_heart: How did you test it?
Manual, CI tests

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
