### PR TITLE
Reverts bundler-plugins bump to 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@
 - Bump CLI from v2.47.0 to v2.47.1 ([#4993](https://github.com/getsentry/sentry-react-native/pull/4993))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2471)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.47.0...2.47.1)
-- Bump Bundler Plugins from v3.5.0 to v3.6.0 ([#4994](https://github.com/getsentry/sentry-react-native/pull/4994))
-  - [changelog](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/CHANGELOG.md#360)
-  - [diff](https://github.com/getsentry/sentry-javascript-bundler-plugins/compare/3.5.0...3.6.0)
 
 ## 6.17.0
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "react-native": ">=0.65.0"
   },
   "dependencies": {
-    "@sentry/babel-plugin-component-annotate": "3.6.0",
+    "@sentry/babel-plugin-component-annotate": "3.5.0",
     "@sentry/browser": "8.55.0",
     "@sentry/cli": "2.47.1",
     "@sentry/core": "8.55.0",

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.26.0",
-    "@sentry/babel-plugin-component-annotate": "3.6.0",
+    "@sentry/babel-plugin-component-annotate": "3.5.0",
     "@types/node": "20.10.4",
     "sentry-react-native-samples-utils": "workspace:^"
   },

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -55,7 +55,7 @@
     "@react-native/eslint-config": "0.77.1",
     "@react-native/metro-config": "0.77.1",
     "@react-native/typescript-config": "0.77.1",
-    "@sentry/babel-plugin-component-annotate": "3.6.0",
+    "@sentry/babel-plugin-component-annotate": "3.5.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.1",
     "@types/react": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8999,10 +8999,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/babel-plugin-component-annotate@npm:3.6.0":
-  version: 3.6.0
-  resolution: "@sentry/babel-plugin-component-annotate@npm:3.6.0"
-  checksum: dd4901b4d861dbcd3d1edf629da0b20d879b2c6daab70e00411dd1ecec34e4498896d82d1397788d9c1d5518e9901db3fbb6db94d98f4c1d29a604a0a549e814
+"@sentry/babel-plugin-component-annotate@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@sentry/babel-plugin-component-annotate@npm:3.5.0"
+  checksum: c5dd3c572e4ca83db859bf3d8ba976393361631f30eb977bc00a572d9981ccaae84f42cce5bf85bc425544245ad22923a66fe96bc2355d339e12ea3aa72d3b82
   languageName: node
   linkType: hard
 
@@ -9168,7 +9168,7 @@ __metadata:
     "@sentry-internal/eslint-config-sdk": 8.55.0
     "@sentry-internal/eslint-plugin-sdk": 8.55.0
     "@sentry-internal/typescript": 8.55.0
-    "@sentry/babel-plugin-component-annotate": 3.6.0
+    "@sentry/babel-plugin-component-annotate": 3.5.0
     "@sentry/browser": 8.55.0
     "@sentry/cli": 2.47.1
     "@sentry/core": 8.55.0
@@ -26707,7 +26707,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.26.0
     "@babel/preset-env": ^7.26.0
-    "@sentry/babel-plugin-component-annotate": 3.6.0
+    "@sentry/babel-plugin-component-annotate": 3.5.0
     "@sentry/react-native": 6.17.0
     "@types/node": 20.10.4
     "@types/react": ~19.0.10
@@ -26793,7 +26793,7 @@ __metadata:
     "@react-navigation/native": 7.1.8
     "@react-navigation/native-stack": 7.3.12
     "@react-navigation/stack": 7.3.1
-    "@sentry/babel-plugin-component-annotate": 3.6.0
+    "@sentry/babel-plugin-component-annotate": 3.5.0
     "@sentry/core": 8.55.0
     "@sentry/react-native": 6.17.0
     "@shopify/flash-list": 1.8.0


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Tests reverting https://github.com/getsentry/sentry-react-native/pull/4994 to see if this is responsible for the CI failures on iOS

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
