### PR TITLE
chore(deps): Bump form-data to 4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "See: https://github.com/appium/appium-chromedriver/pull/424"
   ],
   "resolutions": {
-    "appium-chromedriver@npm:5.6.73/@xmldom/xmldom": "0.8.10"
+    "appium-chromedriver@npm:5.6.73/@xmldom/xmldom": "0.8.10",
+    "form-data": "4.0.4"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16944,26 +16944,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.0, form-data@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "form-data@npm:4.0.0"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    mime-types: "npm:^2.1.12"
-  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
-  languageName: node
-  linkType: hard
-
-"form-data@npm:4.0.2":
-  version: 4.0.2
-  resolution: "form-data@npm:4.0.2"
+"form-data@npm:4.0.4":
+  version: 4.0.4
+  resolution: "form-data@npm:4.0.4"
   dependencies:
     asynckit: ^0.4.0
     combined-stream: ^1.0.8
     es-set-tostringtag: ^2.1.0
+    hasown: ^2.0.2
     mime-types: ^2.1.12
-  checksum: e887298b22c13c7c9c5a8ba3716f295a479a13ca78bfd855ef11cbce1bcf22bc0ae2062e94808e21d46e5c667664a1a1a8a7f57d7040193c1fefbfb11af58aab
+  checksum: 9b7788836df9fa5a6999e0c02515b001946b2a868cfe53f026c69e2c537a2ff9fbfb8e9d2b678744628f3dc7a2d6e14e4e45dfaf68aa6239727f0bdb8ce0abf2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Bump form-data to `4.0.4`

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Security vulnerability in `form-data` that is being pulled in as a transitive dependency by `axios`, `appium/support`, `jsdom (via jest-environment-jsdom)`. Note that it is used only in tests and the sample app.

```
├─ @appium/support@npm:4.5.0
│  └─ form-data@npm:4.0.0 (via npm:4.0.0)
│
├─ @appium/support@npm:5.1.3
│  └─ form-data@npm:4.0.0 (via npm:4.0.0)
│
├─ @appium/support@npm:6.1.1
│  └─ form-data@npm:4.0.2 (via npm:4.0.2)
│
├─ axios@npm:1.6.3
│  └─ form-data@npm:4.0.0 (via npm:^4.0.0)
│
├─ axios@npm:1.7.2
│  └─ form-data@npm:4.0.0 (via npm:^4.0.0)
│
├─ axios@npm:1.7.3
│  └─ form-data@npm:4.0.0 (via npm:^4.0.0)
│
├─ axios@npm:1.8.2
│  └─ form-data@npm:4.0.0 (via npm:^4.0.0)
│
├─ axios@npm:1.8.4
│  └─ form-data@npm:4.0.0 (via npm:^4.0.0)
│
├─ axios@npm:1.9.0
│  └─ form-data@npm:4.0.0 (via npm:^4.0.0)
│
├─ jsdom@npm:20.0.3
│  └─ form-data@npm:4.0.0 (via npm:^4.0.0)
│
└─ jsdom@npm:20.0.3 [51f69]
   └─ form-data@npm:4.0.0 (via npm:^4.0.0)
```
```
├─ jest-environment-jsdom@npm:29.7.0
│  └─ jsdom@npm:20.0.3 (via npm:^20.0.0)
│
└─ jest-environment-jsdom@npm:29.7.0 [400e1]
   └─ jsdom@npm:20.0.3 [51f69] (via npm:^20.0.0 [51f69])
```


## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog