### PR TITLE
test(e2e): Increase iOS E2E test timeout

### DIFF
--- a/samples/react-native/e2e/jest.config.ios.js
+++ b/samples/react-native/e2e/jest.config.ios.js
@@ -5,4 +5,5 @@ const baseConfig = require('./jest.config.base');
 module.exports = {
   ...baseConfig,
   globalSetup: path.resolve(__dirname, 'setup.ios.ts'),
+  testTimeout: 300000,
 };


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
 Increases iOS E2E test timeout to tackle `Test ios production REV2` test flakiness 🤞 

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`Test ios production REV2` seems to still be flaky and fail most of the time.

## :green_heart: How did you test it?
CI by re-running the multiple times (5/6 runs succeeded)

|[Test ios production REV2](https://github.com/getsentry/sentry-react-native/actions/runs/16513520521/job/46705465851?pr=5016#logs)|[Test ios production REV2](https://github.com/getsentry/sentry-react-native/actions/runs/16515668705?pr=5016) (after branch update)|
|---|---|
|<img width="380" height="266" alt="Screenshot 2025-07-25 at 9 43 43 AM" src="https://github.com/user-attachments/assets/98aa2b03-d1ce-4edd-b623-46d75326f31b" />|<img width="363" height="298" alt="Screenshot 2025-07-25 at 11 24 14 AM" src="https://github.com/user-attachments/assets/0c110330-f25b-4f59-92ed-55484ce284d7" />|

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog