### PR TITLE
fix(core): Export addIntegration from core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed Sentry CLI executable path resolution that was causing iOS build script failures ([#5003](https://github.com/getsentry/sentry-react-native/pull/5003))
 - Fix for `sentry-cli` path discovery not working on Android ([#5009](https://github.com/getsentry/sentry-react-native/pull/5009))
+- Export `addIntegration` from `@sentry/core` ([#5020](https://github.com/getsentry/sentry-react-native/pull/5020))
 
 ### Features
 

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -18,6 +18,7 @@ export type {
 
 export {
   addBreadcrumb,
+  addIntegration,
   captureException,
   captureEvent,
   captureFeedback,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Export `addIntegration` from core

Note: [the docs](https://docs.sentry.io/platforms/react-native/integrations/plugin/#adding-an-integration) already mention this since version 6 that included the JS bump

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-react-native/issues/5017

## :green_heart: How did you test it?
Manual with the sample app

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
