### PR TITLE
chore(gh): Update GH issue templates for Linear compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,7 +1,6 @@
 name: '🐞 Bug Report'
 description: "Tell us about something that's not working the way we (probably) intend."
-labels: ['Platform: React-Native', 'Type: 🪲 Bug']
-type: Bug
+labels: ['React-Native', 'Bug']
 body:
   - type: dropdown
     id: environment
@@ -53,11 +52,11 @@ body:
         'Output of the command `npx react-native@latest info` or manully describe your development environment?'
       value: |-
         ````
-        ⬇  Place the `npx react-native@latest info` output here. ⬇ 
-        
-        
-        
-        
+        ⬇  Place the `npx react-native@latest info` output here. ⬇
+
+
+
+
         ````
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,7 +1,6 @@
 name: 💡 Feature Request
 description: Tell us about a problem our SDK could solve but doesn't.
-labels: ['Platform: React-Native', 'enhancement']
-type: Feature
+labels: ['React-Native', 'Feature']
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,6 +1,6 @@
 name: Blank Issue
 description: Blank Issue. Reserved for maintainers.
-labels: ["Platform: React-Native"]
+labels: ['React-Native']
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
replaces usage of GH issue type and platform label to Linear-compatible labels

GH issue types will be deprecated internally by August 14

#skip-changelog