### PR TITLE
chore(deps): update Cocoa SDK to v8.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Dependencies
 
+- Bump Cocoa SDK from v8.53.2 to v8.54.0 ([#5036](https://github.com/getsentry/sentry-react-native/pull/5036))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8540)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.53.2...8.54.0)
 - Bump Android SDK from v8.17.0 to v8.18.0 ([#5034](https://github.com/getsentry/sentry-react-native/pull/5034))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8180)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.17.0...8.18.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Dependencies
 
-- Bump Cocoa SDK from v8.53.2 to v8.54.0 ([#5036](https://github.com/getsentry/sentry-react-native/pull/5036))
+- Bump Cocoa SDK from v8.53.2 to v8.54.0 ([#5047](https://github.com/getsentry/sentry-react-native/pull/5047))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8540)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.53.2...8.54.0)
 - Bump Android SDK from v8.17.0 to v8.18.0 ([#5034](https://github.com/getsentry/sentry-react-native/pull/5034))

--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
 
   s.compiler_flags = other_cflags
 
-  s.dependency 'Sentry/HybridSDK', '8.53.2'
+  s.dependency 'Sentry/HybridSDK', '8.40.0'
 
   if defined? install_modules_dependencies
     # Default React Native dependencies for 0.71 and above (new and legacy architecture)


### PR DESCRIPTION
This PR is required in order to enable the native logger on the iOS side.

Bumps scripts/update-cocoa.sh from 8.53.2 to 8.54.0.

Auto-generated by a [dependency updater](https://github.com/getsentry/github-workflows/blob/main/.github/workflows/updater.yml).
## Changelog
### 8.54.0

#### Features

- Add experimental support for capturing structured logs via `SentrySDK.logger` ([#5532](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5532), [#5593](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5593), [#5639](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5639), [#5628](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5628), [#5637](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5637), [#5643](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5643))
- Add `isiOSAppOnMac` and `isMacCatalystApp` from ProcessInfo to the runtime context ([#5570](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5570))
- The SDK will show a warning in the console if it detects it was loaded twice ([#5298](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5298))

#### Fixes

- Add null-handling for internal array sanitization ([#5722](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5722))
- Fix video replay crashes due to video writer inputs not marked as finished on cancellation ([#5608](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5608))
- Fix wrong flush timeout ([#5565](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5565)). When flush timed out before the SDK finished sending data, it always blocked the full flush timeout the next time being called. This is fixed now.
- Launch profiling now respects original configured options if they change on the next launch ([#5417](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5417))
- User feedback no longer subject to sample rates or `beforeSend` ([#5692](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5692))
- Build error in app extensions ([#5682](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5682))
- Fix frame metrics including time while in background ([#5681](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5681))

#### Improvements

- Extract video processing to a new class ([#5604](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5604))
- Move continuous profiling payload serialization off of the main thread ([#5613](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5613))
- Improve video generation using apple recommended loop ([#5612](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5612))
- Use -OSize for release builds ([#5721](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5721))
- Mark The `integrations` parameter of `SentryOptions` as deprecated rather than printing a warning ([#5749](https://github-redirect.dependabot.com/getsentry/sentry-cocoa/issues/5749))