### PR TITLE
Fix React Native 81 Hermes Runtime Access Pattern

### DIFF
--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -832,7 +832,14 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, startProfiling : (BOOL)platf
 {
 #if SENTRY_PROFILING_ENABLED
     try {
+#    ifdef NEW_HERMES_RUNTIME
+        auto* hermesAPI = facebook::jsi::castInterface<facebook::hermes::IHermesRootAPI>(facebook::hermes::makeHermesRootAPI());
+        if (hermesAPI) {
+            hermesAPI->enableSamplingProfiler();
+        }
+#    else
         facebook::hermes::HermesRuntime::enableSamplingProfiler();
+#    endif
         if (nativeProfileTraceId == nil && nativeProfileStartTime == 0 && platformProfilers) {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
             nativeProfileTraceId = [RNSentryId newId];
@@ -892,10 +899,18 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, stopProfiling)
         nativeProfileTraceId = nil;
         nativeProfileStartTime = 0;
 
-        facebook::hermes::HermesRuntime::disableSamplingProfiler();
         std::stringstream ss;
+#    ifdef NEW_HERMES_RUNTIME
+        auto* hermesAPI = facebook::jsi::castInterface<facebook::hermes::IHermesRootAPI>(facebook::hermes::makeHermesRootAPI());
+        if (hermesAPI) {
+            hermesAPI->disableSamplingProfiler();
+            hermesAPI->dumpSampledTraceToStream(ss);
+        }
+#    else
+        facebook::hermes::HermesRuntime::disableSamplingProfiler();
         // Before RN 0.69 Hermes used llvh::raw_ostream (profiling is supported for 0.69 and newer)
         facebook::hermes::HermesRuntime::dumpSampledTraceToStream(ss);
+#    endif
 
         std::string s = ss.str();
         NSString *data = [NSString stringWithCString:s.c_str()

--- a/packages/core/scripts/sentry_utils.rb
+++ b/packages/core/scripts/sentry_utils.rb
@@ -36,3 +36,7 @@ end
 def should_use_folly_flags(rn_version)
   return (rn_version[:major] == 0 && rn_version[:minor] < 80)
 end
+
+def is_new_hermes_runtime(rn_version)
+  return (rn_version[:major] >= 1 || (rn_version[:major] == 0 && rn_version[:minor] >= 81))
+end


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
In React Native 81 Hermes changes their runtime access pattern.


## :bulb: Motivation and Context
In React Native 81 Hermes changes their runtime access pattern.
so this checks if new hermes runtime is available it uses it, otherwise it uses old code.


## :green_heart: How did you test it?


## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
