### PR TITLE
feat(workflow): use Volta to simplify the environment setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,25 +10,21 @@ This repository contains mono repository structure with multiple React Native an
 - /dev-packages -> dev packages, ts-3.8 test runner, e2e tests components and runner
 - /performance-tests -> applications used for measuring performance in CI
 
-# Requirements
+# Setting up an Environment
 
-- nodejs 18 (with corepack globally installed)
-- yarn version specified in `package.json` (at the moment version 3.6)
+We use [Volta](https://volta.sh/) to ensure we use consistent versions of node and yarn.
 
-## Building
+`sentry-react-native` is a monorepo containing several packages, and we use `lerna` to manage them. To get started,
+install all dependencies, and then perform an initial build, so TypeScript can read all of the linked type definitions.
 
-Install dependencies using:
-
-```sh
-yarn
+```
+$ yarn
+$ yarn build
 ```
 
-Once deps are installed, you can build the project:
+With that, the repo is fully set up and you are ready to run all commands.
 
-```sh
-yarn build
-
-# Or in watch mode, for development of the SDK core
+# Watch mode, for development of the SDK core
 
 cd packages/core
 yarn build:sdk:watch

--- a/package.json
+++ b/package.json
@@ -56,6 +56,10 @@
     "Appium has a dependency on @xmldom/xmldom@^0.x, which causes chromedrive build to fail yarn install",
     "See: https://github.com/appium/appium-chromedriver/pull/424"
   ],
+  "volta": {
+    "node": "18.20.8",
+    "yarn": "3.6.4"
+  },
   "resolutions": {
     "appium-chromedriver@npm:5.6.73/@xmldom/xmldom": "0.8.10",
     "form-data": "4.0.4"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
This PR updates the `package.json` with information about the required versions of `node` and `npm`. This makes it easier to set things up.

## :bulb: Motivation and Context
Other JS SDKs and tools (such as https://github.com/getsentry/sentry-javascript or https://github.com/getsentry/sentry-javascript-bundler-plugins) use Volta to manage command-line tools, so there is no reason why `sentry-react-native` doesn't.

## :green_heart: How did you test it?

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes
