### PR TITLE
Add sentry cli token mention to contributing docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ yarn test:watch
 
 ## Running the sample
 
+First, set up the Sentry CLI token.
+A recommended approach is to create a file named `.env.sentry-build-plugin` in the root folder of each sample and add:
+```sh
+SENTRY_AUTH_TOKEN=...
+```
+
+To obtain the correct token, log in to Sentry.io, then visit: `https://docs.sentry.io/cli/configuration/#to-authenticate-manually` From there, generate a token following the documentation.
+Note: If you are a Sentry contributor, be sure to select the sentry-sdks organization when creating the token.
+
 Now we can go into the sample project, install and build it:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,6 @@ SENTRY_AUTH_TOKEN=...
 ```
 
 To obtain the correct token, log in to Sentry.io, then visit: `https://docs.sentry.io/cli/configuration/#to-authenticate-manually` From there, generate a token following the documentation.
-Note: If you are a Sentry contributor, be sure to select the sentry-sdks organization when creating the token.
 
 Now we can go into the sample project, install and build it:
 


### PR DESCRIPTION
This is a nice to have contributing update, from time to time I have to set up the token so it's a nice to-do before trying the sample apps for the first time since this will fail the builds if not set.

#skip-changelog