### PR TITLE
fix(newArch): fixes how the availability of Turbo Modules is being detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Support New Hermes Runtime Access Pattern ([#5051](https://github.com/getsentry/sentry-react-native/pull/5051))
 - Support Metro 0.83 ([#5035](https://github.com/getsentry/sentry-react-native/pull/5035))
 
+### Fixes
+
+- Correct detection of whether turbo modules are available ([#5064](https://github.com/getsentry/sentry-react-native/pull/5064))
+
 ### Dependencies
 
 - Bump CLI from v2.50.2 to v2.51.1 ([#5053](https://github.com/getsentry/sentry-react-native/pull/5053), [#5058](https://github.com/getsentry/sentry-react-native/pull/5058))

--- a/packages/core/src/js/utils/environment.ts
+++ b/packages/core/src/js/utils/environment.ts
@@ -11,6 +11,7 @@ export function isHermesEnabled(): boolean {
 
 /** Checks if the React Native TurboModules are enabled */
 export function isTurboModuleEnabled(): boolean {
+  // Reference: https://github.com/facebook/react-native/blob/641a79dc5137b69a3c0813413b9fb82d0b9df783/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js#L110
   return RN_GLOBAL_OBJ.RN$Bridgeless === true || RN_GLOBAL_OBJ.__turboModuleProxy != null;
 }
 

--- a/packages/core/src/js/utils/environment.ts
+++ b/packages/core/src/js/utils/environment.ts
@@ -11,7 +11,7 @@ export function isHermesEnabled(): boolean {
 
 /** Checks if the React Native TurboModules are enabled */
 export function isTurboModuleEnabled(): boolean {
-  return RN_GLOBAL_OBJ.__turboModuleProxy != null;
+  return RN_GLOBAL_OBJ.RN$Bridgeless === true || RN_GLOBAL_OBJ.__turboModuleProxy != null;
 }
 
 /** Checks if the React Native Fabric renderer is running */

--- a/packages/core/src/js/utils/worldwide.ts
+++ b/packages/core/src/js/utils/worldwide.ts
@@ -20,6 +20,7 @@ export interface ReactNativeInternalGlobal extends InternalGlobal {
   };
   Promise: unknown;
   __turboModuleProxy: unknown;
+  RN$Bridgeless: unknown;
   nativeFabricUIManager: unknown;
   ErrorUtils?: ErrorUtils;
   expo?: ExpoGlobalObject;


### PR DESCRIPTION
During an investigation of our support of the new architecture I accidentally found that the way we detect turbo modules is outdated since `__turboModuleProxy` was removed from React Native in bridgeless mode. 
Here is where I found that: https://github.com/facebook/react-native/pull/48362
Here is more information about bridgeless mode in React Native: https://github.com/reactwg/react-native-new-architecture/discussions/154

And, finally, here is how React Native itself detects if Turbo Modules are available: https://github.com/facebook/react-native/blob/641a79dc5137b69a3c0813413b9fb82d0b9df783/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js#L110

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Basically this change implements the same mechanism for detecting Turbo Modules that's already used in React Native (see link above).


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Solving how we detect the usage of the new architecture is crucial for correct usage of corresponding native modules.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
