### PR TITLE
fix(expo-upload): Rename `--dump-sourcemap` to `--source-maps`

### DIFF
--- a/packages/core/scripts/expo-upload-sourcemaps.js
+++ b/packages/core/scripts/expo-upload-sourcemaps.js
@@ -234,7 +234,7 @@ if (numAssetsUploaded === totalAssets) {
   console.log('✅ Uploaded bundles and sourcemaps to Sentry successfully.');
 } else {
   console.warn(
-    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--dump-sourcemap` flag.' : ''
+    `⚠️  Uploaded ${numAssetsUploaded} of ${totalAssets} bundles and sourcemaps. ${numAssetsUploaded === 0 ? 'Ensure you are running `expo export` with the `--source-maps` flag.' : ''
     }`,
   );
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [x] Enhancement


## :scroll: Description
<!--- Describe your changes in detail -->
The flag was renamed in (~2 yers ago). The old flag still works, it's just hidden. But mentioning it might be confusing to users.

- https://github.com/expo/expo/pull/25303

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes
#skip-changelog.