### PR TITLE
Revert "chore(deps): update Sentry Android Gradle Plugin to v5.9.0"

### DIFF
--- a/packages/core/plugin/src/withSentryAndroidGradlePlugin.ts
+++ b/packages/core/plugin/src/withSentryAndroidGradlePlugin.ts
@@ -13,7 +13,7 @@ export interface SentryAndroidGradlePluginOptions {
   includeSourceContext?: boolean;
 }
 
-export const sentryAndroidGradlePluginVersion = '5.9.0';
+export const sentryAndroidGradlePluginVersion = '5.8.1';
 
 /**
  * Adds the Sentry Android Gradle Plugin to the project.

--- a/samples/react-native/android/build.gradle
+++ b/samples/react-native/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        classpath("io.sentry:sentry-android-gradle-plugin:5.9.0")
+        classpath("io.sentry:sentry-android-gradle-plugin:5.8.1")
     }
 }
 


### PR DESCRIPTION
Reverts getsentry/sentry-react-native#5067

This seems to have broken the CI since I consistently see the integrity check failing on main https://github.com/getsentry/sentry-react-native/actions/runs/16932865189/job/47982954586