### PR TITLE
chore(ci): Handle GH runner image deprecations

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -173,7 +173,7 @@ jobs:
           - platform: ios
             rn-version: '0.80.2'
             xcode-version: '16.2'
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: ios
             rn-version: '0.65.3'
             xcode-version: '14.2'
@@ -310,7 +310,7 @@ jobs:
         include:
           - platform: ios
             rn-version: '0.80.2'
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: ios
             rn-version: '0.65.3'
             runs-on: macos-15

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -16,7 +16,7 @@ env:
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   MAESTRO_VERSION: '1.41.0'
   IOS_DEVICE: 'iPhone 16'
-  IOS_VERSION: '18.6'
+  IOS_VERSION: '18.1'
 
 jobs:
   diff_check:

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -16,7 +16,7 @@ env:
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   MAESTRO_VERSION: '1.41.0'
   IOS_DEVICE: 'iPhone 16'
-  IOS_VERSION: '18.1'
+  IOS_VERSION: '18.6'
 
 jobs:
   diff_check:

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -35,7 +35,7 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: android
             runs-on: ubuntu-latest
           - platform: web

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -35,6 +35,7 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
+            xcode-version: '16.2'
             runs-on: macos-14
           - platform: android
             runs-on: ubuntu-latest
@@ -69,6 +70,9 @@ jobs:
 
       - name: Gradle cache
         uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+
+      - run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer
+        if: ${{ matrix.platform == 'ios' }}
 
       - name: Setup Global Xcode Tools
         if: ${{ matrix.platform == 'ios' }}

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -19,7 +19,7 @@ env:
   ANDROID_APP_ARCHIVE_PATH: sentry-react-native-sample.apk.zip
   REACT_NATIVE_SAMPLE_PATH: samples/react-native
   IOS_DEVICE: 'iPhone 16'
-  IOS_VERSION: '18.6'
+  IOS_VERSION: '18.1'
   ANDROID_API_LEVEL: '30'
 
 jobs:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -19,7 +19,7 @@ env:
   ANDROID_APP_ARCHIVE_PATH: sentry-react-native-sample.apk.zip
   REACT_NATIVE_SAMPLE_PATH: samples/react-native
   IOS_DEVICE: 'iPhone 16'
-  IOS_VERSION: '18.1'
+  IOS_VERSION: '18.6'
   ANDROID_API_LEVEL: '30'
 
 jobs:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -43,7 +43,7 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: macos
             runs-on: macos-15
           - platform: android
@@ -218,7 +218,7 @@ jobs:
       matrix:
         include:
           - platform: ios
-            runs-on: macos-15
+            runs-on: macos-14
             rn-architecture: 'new'
             ios-use-frameworks: 'no-frameworks'
             build-type: 'production'


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Temporarily downgrades the affected iOS runners to `macos-14` to handle the environment change linked below. The tooling (xcode 16.2) remained the same and there should be no effect in the validity of the CI checks/tests.

An issue was opened to revisit this: https://github.com/getsentry/sentry-react-native/issues/5082

Other solutions considered:
- Updating the projects to later iOS versions: this is not simple in all cases. E.g the [RnDiffApp is specific to the RN version](https://github.com/getsentry/sentry-react-native/blob/e2fa43d707d0eb4267bdac55de308874a6fb139e/.github/workflows/e2e-v2.yml#L270) and probably needs to be patched after download to achieve the desired.
- Installing the missing platforms with [tools like xcodes](https://github.com/XcodesOrg/xcodes?tab=readme-ov-file#install-runtimes-) will increase the CI time a lot.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Deprecations in https://github.com/actions/runner-images/pull/12734 resulted in:

* The [RnDiffApp for the specific React Native version](https://github.com/getsentry/sentry-react-native/blob/e2fa43d707d0eb4267bdac55de308874a6fb139e/.github/workflows/e2e-v2.yml#L270) was [failing to build](https://github.com/getsentry/sentry-react-native/actions/runs/16956441562/job/48060538543?pr=5038) due to missing `18.2` platform
* [Expo sample failing due to missing `18.0` platform](https://github.com/getsentry/sentry-react-native/actions/runs/16956441588/job/48060560282?pr=5038)
* [RN Sample failing due to missing `18.0` platform](https://github.com/getsentry/sentry-react-native/actions/runs/16956441579/job/48060542118?pr=5038)

## :green_heart: How did you test it?

CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog