### PR TITLE
fix(tracing): Time To Initial Display / Time To Full Display: remove warning that it's unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+## Fixes
+
+- Remove the warning that used to indicate that Time To Initial Display and Time To Full Display are not supported ([#5081](https://github.com/getsentry/sentry-react-native/pull/5081))
+
 ## 6.20.0
 
 ### Features
@@ -17,7 +23,6 @@
 ### Fixes
 
 - Correct detection of whether turbo modules are available ([#5064](https://github.com/getsentry/sentry-react-native/pull/5064))
-- Remove the warning that used to indicate that Time To Initial Display and Time To Full Display are not supported ([#5081](https://github.com/getsentry/sentry-react-native/pull/5081))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - Correct detection of whether turbo modules are available ([#5064](https://github.com/getsentry/sentry-react-native/pull/5064))
+- Remove the warning that used to indicate that Time To Initial Display and Time To Full Display are not supported ([#5081](https://github.com/getsentry/sentry-react-native/pull/5081))
 
 ### Dependencies
 

--- a/packages/core/src/js/tracing/timetodisplay.tsx
+++ b/packages/core/src/js/tracing/timetodisplay.tsx
@@ -3,12 +3,9 @@ import { fill, getActiveSpan, getSpanDescendants, logger, SEMANTIC_ATTRIBUTE_SEN
 import * as React from 'react';
 import { useState } from 'react';
 
-import { isTurboModuleEnabled } from '../utils/environment';
 import { SPAN_ORIGIN_AUTO_UI_TIME_TO_DISPLAY, SPAN_ORIGIN_MANUAL_UI_TIME_TO_DISPLAY } from './origin';
-import { getRNSentryOnDrawReporter, nativeComponentExists } from './timetodisplaynative';
+import { getRNSentryOnDrawReporter } from './timetodisplaynative';
 import { setSpanDurationAsMeasurement, setSpanDurationAsMeasurementOnSpan } from './utils';
-
-let nativeComponentMissingLogged = false;
 
 /**
  * Flags of active spans with manual initial display.
@@ -62,17 +59,6 @@ function TimeToDisplay(props: {
   parentSpanId?: string;
 }): React.ReactElement {
   const RNSentryOnDrawReporter = getRNSentryOnDrawReporter();
-  const isNewArchitecture = isTurboModuleEnabled();
-
-  if (__DEV__ && (isNewArchitecture || (!nativeComponentExists && !nativeComponentMissingLogged))){
-    nativeComponentMissingLogged = true;
-    // Using setTimeout with a delay of 0 milliseconds to defer execution and avoid printing the React stack trace.
-    setTimeout(() => {
-      logger.warn(
-          'TimeToInitialDisplay and TimeToFullDisplay are not supported on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
-    }, 0);
-  }
-
   return (
     <>
       <RNSentryOnDrawReporter

--- a/packages/core/test/tracing/timetodisplay.test.tsx
+++ b/packages/core/test/tracing/timetodisplay.test.tsx
@@ -7,7 +7,6 @@ jest.mock('../../src/js/wrapper', () => mockWrapper);
 import * as mockedtimetodisplaynative from './mockedtimetodisplaynative';
 jest.mock('../../src/js/tracing/timetodisplaynative', () => mockedtimetodisplaynative);
 
-import { isTurboModuleEnabled } from '../../src/js/utils/environment';
 jest.mock('../../src/js/utils/environment', () => ({
   isWeb: jest.fn().mockReturnValue(false),
   isTurboModuleEnabled: jest.fn().mockReturnValue(false),
@@ -289,24 +288,6 @@ describe('TimeToDisplay', () => {
 
     expect(getInitialDisplaySpanJSON(client.event!.spans!)!.timestamp).toEqual(initialDisplayEndTimestampMs / 1_000);
     expect(getFullDisplaySpanJSON(client.event!.spans!)!.timestamp).toEqual(initialDisplayEndTimestampMs / 1_000);
-  });
-
-  test('should not log a warning if native component exists and not in new architecture', async () => {
-    (isTurboModuleEnabled as jest.Mock).mockReturnValue(false);
-
-    TestRenderer.create(<TimeToInitialDisplay record={true} />);
-    await jest.runOnlyPendingTimersAsync(); // Flush setTimeout.
-
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
-
-  test('should log a warning if in new architecture', async () => {
-    (isTurboModuleEnabled as jest.Mock).mockReturnValue(true);
-    TestRenderer.create(<TimeToInitialDisplay record={true} />);
-    await jest.runOnlyPendingTimersAsync(); // Flush setTimeout.
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      'TimeToInitialDisplay and TimeToFullDisplay are not supported on the web, Expo Go and New Architecture. Run native build or report an issue at https://github.com/getsentry/sentry-react-native');
   });
 });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

Partially fixes https://github.com/getsentry/sentry-react-native/issues/4705

## :scroll: Description
<!--- Describe your changes in detail -->
1) Even though in the docs we clearly state that TTID/TTFD is not supported, apparently it works if you disable all the checks in the SDK. I suspect it works since this PR got merged: https://github.com/getsentry/sentry-react-native/pull/4669
2) However, it is NOT packed as a Turbo Module which means all the standard disadvantages like extra overhead and higher latency due to serialization/deserialization and native modules being loaded into memory during app startup.

The solution for now is the following: we can now remove the checks in the SDK and basically make it work with the new architecture. However, we will need to implement TTID/TTFD as turbo modules to make it more efficient: https://github.com/getsentry/sentry-react-native/issues/4705

Here is the corresponding docs change: https://github.com/getsentry/sentry-docs/pull/14662

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed to not show message that it's not supported because it actually is supported :)

## :green_heart: How did you test it?
With the sample app:

<img width="1073" height="747" alt="Screenshot 2025-08-14 at 12 13 53" src="https://github.com/user-attachments/assets/6f91cff1-3ea0-449b-a09d-0674b45ef992" />

(not all the results are there because I did experiment with <Sentry.TimeToInitialDisplay /> and <Sentry.TimeToFullDisplay /> wrapper components on individual screens)

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
