### PR TITLE
ci: Disable iOS tests paralellization

### DIFF
--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/xcshareddata/xcschemes/RNSentryCocoaTester.xcscheme
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/xcshareddata/xcschemes/RNSentryCocoaTester.xcscheme
@@ -30,7 +30,7 @@
       <Testables>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES">
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3360898C29524164007C7730"


### PR DESCRIPTION
Using parallelization on UI Tests requires cloning the simulator, which seems to cause slow tests on `sentry-cocoa` integrations tests.

I guess this change will also benefit this repo