### PR TITLE
chore(ci): v7: Handle GH runner image deprecations

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -173,7 +173,7 @@ jobs:
           - platform: ios
             rn-version: '0.80.2'
             xcode-version: '16.2'
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: ios
             rn-version: '0.65.3'
             xcode-version: '14.2'
@@ -310,10 +310,10 @@ jobs:
         include:
           - platform: ios
             rn-version: '0.80.2'
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: ios
             rn-version: '0.65.3'
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: android
             runs-on: ubuntu-latest
         exclude:

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -18,7 +18,7 @@ jobs:
 
   test-ios:
     name: ios
-    runs-on: macos-15
+    runs-on: macos-14
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -35,7 +35,7 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: android
             runs-on: ubuntu-latest
           - platform: web

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -43,7 +43,7 @@ jobs:
         build-type: ['dev', 'production']
         include:
           - platform: ios
-            runs-on: macos-15
+            runs-on: macos-14
           - platform: macos
             runs-on: macos-15
           - platform: android
@@ -218,7 +218,7 @@ jobs:
       matrix:
         include:
           - platform: ios
-            runs-on: macos-15
+            runs-on: macos-14
             rn-architecture: 'new'
             ios-use-frameworks: 'no-frameworks'
             build-type: 'production'

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -14,7 +14,7 @@ jobs:
 
   upload_to_testflight:
     name: Build and Upload React Native Sample to Testflight
-    runs-on: macos-15
+    runs-on: macos-14
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Similar to https://github.com/getsentry/sentry-react-native/pull/5079

Proper handling will be investigated in https://github.com/getsentry/sentry-react-native/issues/5082

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
