### PR TITLE
Fix: Fix compile error in v7

### DIFF
--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -467,7 +467,11 @@ RCT_EXPORT_METHOD(fetchNativeLogAttributes
             contexts[@"os"] = os;
         }
 
-        NSString *releaseName = [SentrySDK options].releaseName;
+#if CROSS_PLATFORM_TEST
+        NSString *releaseName = SentrySDKInternal.options.releaseName;
+#else
+              NSString *releaseName = [SentrySDK options].releaseName;
+#endif
         if (releaseName) {
             contexts[@"release"] = releaseName;
         }

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -470,7 +470,7 @@ RCT_EXPORT_METHOD(fetchNativeLogAttributes
 #if CROSS_PLATFORM_TEST
         NSString *releaseName = SentrySDKInternal.options.releaseName;
 #else
-         NSString *releaseName = [SentrySDK options].releaseName;
+        NSString *releaseName = [SentrySDK options].releaseName;
 #endif
         if (releaseName) {
             contexts[@"release"] = releaseName;

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -470,7 +470,7 @@ RCT_EXPORT_METHOD(fetchNativeLogAttributes
 #if CROSS_PLATFORM_TEST
         NSString *releaseName = SentrySDKInternal.options.releaseName;
 #else
-              NSString *releaseName = [SentrySDK options].releaseName;
+         NSString *releaseName = [SentrySDK options].releaseName;
 #endif
         if (releaseName) {
             contexts[@"release"] = releaseName;


### PR DESCRIPTION
The latest v7 release is causing CI to break in sentry-cocoa, this should fix it

#skip-changelog