### PR TITLE
Fix changelog references to V7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,9 +127,8 @@ example:
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2530)
 - Bump Bundler Plugins to v4.2.0 ([#5113](https://github.com/getsentry/sentry-react-native/pull/5113), [#4805](https://github.com/getsentry/sentry-react-native/pull/4805))
   - [changelog](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/CHANGELOG.md#340)
-- Bump Cocoa SDK from v8.49.2 to v8.50.0 ([#4807](https://github.com/getsentry/sentry-react-native/pull/4807))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8500)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.49.2...8.50.0)
+- Bump Cocoa SDK to v8.53.2 ([#4986](https://github.com/getsentry/sentry-react-native/pull/4986))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8532)
 
 ## 7.0.0-rc.2
 
@@ -166,6 +165,9 @@ We apologize for any inconvenience caused!
 
 ### Dependencies
 
+- Bump Cocoa SDK from v8.53.1 to v8.53.2 ([#4986](https://github.com/getsentry/sentry-react-native/pull/4986))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8532)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.53.1...8.53.2)
 - Bump CLI from v2.47.0 to v2.50.2 ([#5007](https://github.com/getsentry/sentry-react-native/pull/5007))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2502)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.47.0...2.50.2)
@@ -215,6 +217,9 @@ example:
 - Bump Android SDK from v8.14.0 to v8.17.0 ([#4953](https://github.com/getsentry/sentry-react-native/pull/4953), [#4955](https://github.com/getsentry/sentry-react-native/pull/4955), [#4987](https://github.com/getsentry/sentry-react-native/pull/4987))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8170)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.14.0...8.17.0)
+- Bump Cocoa SDK from v8.52.1 to v8.53.1 ([#4950](https://github.com/getsentry/sentry-react-native/pull/4950))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8531)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.52.1...8.53.1)
 - Bump CLI from v2.46.0 to v2.47.0 ([#4979](https://github.com/getsentry/sentry-react-native/pull/4979))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2470)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.46.0...2.47.0)
@@ -302,6 +307,9 @@ Sentry.init({
 - Bump Android SDK from v8.13.2 to v8.14.0 ([#4929](https://github.com/getsentry/sentry-react-native/pull/4929), [#4934](https://github.com/getsentry/sentry-react-native/pull/4934))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8140)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.13.2...8.14.0)
+- Bump Cocoa SDK from v8.52.0 to v8.52.1 ([#4899](https://github.com/getsentry/sentry-react-native/pull/4899))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8521)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.52.0...8.52.1)
 
 ## 7.0.0-beta.0
 
@@ -361,6 +369,9 @@ Version 7 of the SDK is compatible with Sentry self-hosted versions 24.4.2 or hi
 - Bump Android SDK from v7.20.1 to v8.13.2 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490), [#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.13.2)
+- Bump Cocoa SDK from v8.50.0 to v8.52.0 ([#4887](https://github.com/getsentry/sentry-react-native/pull/4887))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8520)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.50.0...8.52.0)
 - Bump CLI from v2.43.0 to v2.46.0 ([#4866]([???](https://github.com/getsentry/sentry-react-native/pull/4866)))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2460)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.43.0...2.46.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,18 +117,16 @@ example:
 
 ### Dependencies
 
-- Bump JavaScript SDK from v8.54.0 to v10.8.0 ([#5123](https://github.com/getsentry/sentry-react-native/pull5123))
+- Bump JavaScript SDK from v8.55.0 to v10.8.0 ([#5123](https://github.com/getsentry/sentry-react-native/pull5123))
   - [changelog](https://github.com/getsentry/sentry-javascript/blob/develop/CHANGELOG.md#1080)
-  - [diff](https://github.com/getsentry/sentry-javascript/compare/8.54.0...10.8.0)
+  - [diff](https://github.com/getsentry/sentry-javascript/compare/8.55.0...10.8.0)
 - Bump Android SDK from v7.20.1 to v8.20.0 ([#5106](https://github.com/getsentry/sentry-react-native/pull/5106))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8200)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.20.0)
-- Bump CLI from v2.43.1 to v2.45.0 ([#4804](https://github.com/getsentry/sentry-react-native/pull/4804), [#4818](https://github.com/getsentry/sentry-react-native/pull/4818))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2450)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.43.1...2.45.0)
-- Bump Bundler Plugins from v3.3.1 to v3.4.0 ([#4805](https://github.com/getsentry/sentry-react-native/pull/4805))
+- Bump CLI to v2.53.0 ([5120](https://github.com/getsentry/sentry-react-native/pull/5120). [#4804](https://github.com/getsentry/sentry-react-native/pull/4804), [#4818](https://github.com/getsentry/sentry-react-native/pull/4818))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2530)
+- Bump Bundler Plugins to v4.2.0 ([#5113](https://github.com/getsentry/sentry-react-native/pull/5113), [#4805](https://github.com/getsentry/sentry-react-native/pull/4805))
   - [changelog](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/CHANGELOG.md#340)
-  - [diff](https://github.com/getsentry/sentry-javascript-bundler-plugins/compare/3.3.1...3.4.0)
 - Bump Cocoa SDK from v8.49.2 to v8.50.0 ([#4807](https://github.com/getsentry/sentry-react-native/pull/4807))
   - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8500)
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.49.2...8.50.0)
@@ -165,6 +163,15 @@ We apologize for any inconvenience caused!
 
 - fix(sdk): Set `{{auto}}` if `user.ip_address` is `undefined` and `sendDefaultPii: true` (#4466) by @krystofwoldrich
 - fix(appStart): Align span description with other platforms (#4636) by @krystofwoldrich
+
+### Dependencies
+
+- Bump CLI from v2.47.0 to v2.50.2 ([#5007](https://github.com/getsentry/sentry-react-native/pull/5007))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2502)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.47.0...2.50.2)
+- Bump Bundler Plugins from v3.5.0 to v4.0.2 ([#5030](https://github.com/getsentry/sentry-react-native/pull/5030))
+  - [changelog](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/CHANGELOG.md#402)
+  - [diff](https://github.com/getsentry/sentry-javascript-bundler-plugins/compare/3.5.0...4.0.2)
 
 ## 7.0.0-beta.2
 
@@ -208,6 +215,9 @@ example:
 - Bump Android SDK from v8.14.0 to v8.17.0 ([#4953](https://github.com/getsentry/sentry-react-native/pull/4953), [#4955](https://github.com/getsentry/sentry-react-native/pull/4955), [#4987](https://github.com/getsentry/sentry-react-native/pull/4987))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8170)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.14.0...8.17.0)
+- Bump CLI from v2.46.0 to v2.47.0 ([#4979](https://github.com/getsentry/sentry-react-native/pull/4979))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2470)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.46.0...2.47.0)
 
 ## 7.0.0-beta.1
 
@@ -351,6 +361,12 @@ Version 7 of the SDK is compatible with Sentry self-hosted versions 24.4.2 or hi
 - Bump Android SDK from v7.20.1 to v8.13.2 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490), [#4847](https://github.com/getsentry/sentry-react-native/pull/4847))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8132)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.13.2)
+- Bump CLI from v2.43.0 to v2.46.0 ([#4866]([???](https://github.com/getsentry/sentry-react-native/pull/4866)))
+  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2460)
+  - [diff](https://github.com/getsentry/sentry-cli/compare/2.43.0...2.46.0)
+- Bump Bundler Plugins from v3.4.0 to v3.5.0 ([#4850](https://github.com/getsentry/sentry-react-native/pull/4850))
+  - [changelog](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/CHANGELOG.md#350)
+  - [diff](https://github.com/getsentry/sentry-javascript-bundler-plugins/compare/3.4.0...3.5.0)
 
 ## 7.0.0-alpha.0
 
@@ -407,9 +423,6 @@ Version 7 of the SDK is compatible with Sentry self-hosted versions 24.4.2 or hi
 - Bump Android SDK from v7.20.1 to v8.11.1 ([#4490](https://github.com/getsentry/sentry-react-native/pull/4490))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8111)
   - [diff](https://github.com/getsentry/sentry-java/compare/7.20.1...8.11.1)
-- Bump CLI from v2.43.1 to v2.45.0 ([#4804](https://github.com/getsentry/sentry-react-native/pull/4804), [#4818](https://github.com/getsentry/sentry-react-native/pull/4818))
-  - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2450)
-  - [diff](https://github.com/getsentry/sentry-cli/compare/2.43.1...2.45.0)
 - Bump Bundler Plugins from v3.3.1 to v3.4.0 ([#4805](https://github.com/getsentry/sentry-react-native/pull/4805))
   - [changelog](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/CHANGELOG.md#340)
   - [diff](https://github.com/getsentry/sentry-javascript-bundler-plugins/compare/3.3.1...3.4.0)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Changelogs were a bit off for version 7. Some fields got lost when bumping packages on main and then syncing into V7. This PR aims to sync the missing/incorrect updates for each V7 Release.

Items without a `from X to Y` were replaced by `to Y` only since the versions matches the latest release of V6, they were left as a reference since people could be on older versions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog.