### PR TITLE
fix(metro): vendor countLines from metro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Add mobile replay attributes to logs  ([#5165](https://github.com/getsentry/sentry-react-native/pull/5165))
 
+### Fixes
+
+- Vendor `metro/countLines` function to avoid issues with the private import ([#5185](https://github.com/getsentry/sentry-react-native/pull/5185))
+
 ## 7.1.0
 
 ### Fixes

--- a/packages/core/src/js/tools/utils.ts
+++ b/packages/core/src/js/tools/utils.ts
@@ -1,16 +1,8 @@
 import * as crypto from 'crypto';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import type { MixedOutput, Module, ReadOnlyGraph, SerializerOptions } from 'metro';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import type * as countLinesType from 'metro/private/lib/countLines';
 import type CountingSet from 'metro/src/lib/CountingSet'; // types are in src but exports are in private
-
-let countLines: typeof countLinesType;
-try {
-  countLines = require('metro/private/lib/countLines');
-} catch (e) {
-  countLines = require('metro/src/lib/countLines');
-}
+import countLines from './vendor/metro/countLines';
 
 // Variant of MixedOutput
 // https://github.com/facebook/metro/blob/9b85f83c9cc837d8cd897aa7723be7da5b296067/packages/metro/src/DeltaBundler/types.flow.js#L21

--- a/packages/core/src/js/tools/vendor/metro/countLines.ts
+++ b/packages/core/src/js/tools/vendor/metro/countLines.ts
@@ -1,0 +1,34 @@
+// Vendored from @facebook/metro
+
+// https://github.com/facebook/metro/blob/93d68cca249202fd3eb52672217e725d90e44eb4/packages/metro/src/lib/countLines.js
+
+// MIT License
+
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// This is exported as private from `metro` and as such breaking changes can appear anytime.
+// In the past these were related to the way the function is exported. Never to the function itself.
+// Thus it should be more stable to vendor it.
+
+const newline = /\r\n?|\n|\u2028|\u2029/g;
+
+export default (string: string): number =>
+  (string.match(newline) || []).length + 1;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Metro `0.83.2` changes exports from `cjs:module.exports` to `mjs:export(default)`.

The named exports should not cause any issue, but `modules.exports` to `export default` requires reading `.default`.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since there were multiple changes in recent Metro version I beleive vendoring simple modules like `countLine` will be more stable in the future. 

## :green_heart: How did you test it?



## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
