### PR TITLE
Logs: enable iOS feature

### DIFF
--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.m
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.m
@@ -316,6 +316,50 @@ XCTAssertEqual(actualOptions.enableTracing, false, @"EnableTracing should not be
         enableUnhandledCPPExceptions, @"enableUnhandledCPPExceptionsV2 should default to disabled");
 }
 
+- (void)testCreateOptionsWithDictionaryEnableLogsEnabled
+{
+    RNSentry *rnSentry = [[RNSentry alloc] init];
+    NSError *error = nil;
+
+    NSDictionary *_Nonnull mockedReactNativeDictionary = @{
+        @"dsn" : @"https://abcd@efgh.ingest.sentry.io/123456",
+        @"enableLogs" : @YES,
+    };
+    SentryOptions *actualOptions = [rnSentry createOptionsWithDictionary:mockedReactNativeDictionary
+                                                                   error:&error];
+
+    XCTAssertNotNil(actualOptions, @"Did not create sentry options");
+    XCTAssertNil(error, @"Should not pass no error");
+
+    id experimentalOptions = [actualOptions valueForKey:@"experimental"];
+    XCTAssertNotNil(experimentalOptions, @"Experimental options should not be nil");
+
+    BOOL enableLogs = [[experimentalOptions valueForKey:@"enableLogs"] boolValue];
+    XCTAssertTrue(enableLogs, @"enableLogs should be enabled");
+}
+
+- (void)testCreateOptionsWithDictionaryEnableLogsDisabled
+{
+    RNSentry *rnSentry = [[RNSentry alloc] init];
+    NSError *error = nil;
+
+    NSDictionary *_Nonnull mockedReactNativeDictionary = @{
+        @"dsn" : @"https://abcd@efgh.ingest.sentry.io/123456",
+        @"enableLogs" : @NO,
+    };
+    SentryOptions *actualOptions = [rnSentry createOptionsWithDictionary:mockedReactNativeDictionary
+                                                                   error:&error];
+
+    XCTAssertNotNil(actualOptions, @"Did not create sentry options");
+    XCTAssertNil(error, @"Should not pass no error");
+
+    id experimentalOptions = [actualOptions valueForKey:@"experimental"];
+    XCTAssertNotNil(experimentalOptions, @"Experimental options should not be nil");
+
+    BOOL enableLogs = [[experimentalOptions valueForKey:@"enableLogs"] boolValue];
+    XCTAssertFalse(enableLogs, @"enableLogs should be disabled");
+}
+
 - (void)testPassesErrorOnWrongDsn
 {
     RNSentry *rnSentry = [[RNSentry alloc] init];

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -288,6 +288,13 @@ RCT_EXPORT_METHOD(initNativeSdk
         }
     }
 
+    if ([mutableOptions valueForKey:@"enableLogs"] != nil) {
+        id enableLogsValue = [mutableOptions valueForKey:@"enableLogs"];
+        if ([enableLogsValue isKindOfClass:[NSNumber class]]) {
+            [RNSentryExperimentalOptions setEnableLogs:[enableLogsValue boolValue]
+                                                             sentryOptions:sentryOptions];
+        }
+    }
     [self trySetIgnoreErrors:mutableOptions];
 
     // Enable the App start and Frames tracking measurements

--- a/packages/core/ios/RNSentryExperimentalOptions.h
+++ b/packages/core/ios/RNSentryExperimentalOptions.h
@@ -21,6 +21,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)getEnableUnhandledCPPExceptionsV2:(SentryOptions *)sentryOptions;
 
+/**
+ * Sets the enableLogs experimental option on SentryOptions
+ * @param sentryOptions The SentryOptions instance to configure
+ * @param enabled Whether logs from sentry Cocoa should be enabled
+ */
++ (void)setEnableLogs:(BOOL)enabled  sentryOptions:(SentryOptions *)sentryOptions;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/core/ios/RNSentryExperimentalOptions.m
+++ b/packages/core/ios/RNSentryExperimentalOptions.m
@@ -19,4 +19,12 @@
     return sentryOptions.experimental.enableUnhandledCPPExceptionsV2;
 }
 
++ (void)setEnableLogs:(BOOL)enabled  sentryOptions:(SentryOptions *)sentryOptions
+{
+    if (sentryOptions == nil) {
+        return;
+    }
+    sentryOptions.experimental.enableLogs = enabled;
+}
+
 @end

--- a/packages/core/test/wrapper.test.ts
+++ b/packages/core/test/wrapper.test.ts
@@ -335,8 +335,8 @@ describe('Tests Native Wrapper', () => {
         base64StringFromByteArray(
           utf8ToBytes(
             '{"event_id":"event0","sent_at":"123"}\n' +
-              '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":87}\n' +
-              '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
+            '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":87}\n' +
+            '{"event_id":"event0","message":"test","sdk":{"name":"test-sdk-name","version":"2.1.3"}}\n',
           ),
         ),
         { hardCrashed: false },
@@ -367,8 +367,8 @@ describe('Tests Native Wrapper', () => {
         base64StringFromByteArray(
           utf8ToBytes(
             '{"event_id":"event0","sent_at":"123"}\n' +
-              '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":93}\n' +
-              '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
+            '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":93}\n' +
+            '{"event_id":"event0","sdk":{"name":"test-sdk-name","version":"2.1.3"},"instance":{"value":0}}\n',
           ),
         ),
         { hardCrashed: false },
@@ -410,8 +410,8 @@ describe('Tests Native Wrapper', () => {
         base64StringFromByteArray(
           utf8ToBytes(
             '{"event_id":"event0","sent_at":"123"}\n' +
-              '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":50}\n' +
-              '{"event_id":"event0","message":{"message":"test"}}\n',
+            '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":50}\n' +
+            '{"event_id":"event0","message":{"message":"test"}}\n',
           ),
         ),
         { hardCrashed: false },
@@ -449,8 +449,8 @@ describe('Tests Native Wrapper', () => {
         base64StringFromByteArray(
           utf8ToBytes(
             '{"event_id":"event0","sent_at":"123"}\n' +
-              '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":124}\n' +
-              '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
+            '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":124}\n' +
+            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":true,"type":""}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
           ),
         ),
         { hardCrashed: false },
@@ -478,8 +478,8 @@ describe('Tests Native Wrapper', () => {
         base64StringFromByteArray(
           utf8ToBytes(
             '{"event_id":"event0","sent_at":"123"}\n' +
-              '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":58}\n' +
-              '{"event_id":"event0","breadcrumbs":[{"message":"crumb!"}]}\n',
+            '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":58}\n' +
+            '{"event_id":"event0","breadcrumbs":[{"message":"crumb!"}]}\n',
           ),
         ),
         { hardCrashed: false },
@@ -517,8 +517,8 @@ describe('Tests Native Wrapper', () => {
         base64StringFromByteArray(
           utf8ToBytes(
             '{"event_id":"event0","sent_at":"123"}\n' +
-              '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":132}\n' +
-              '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":"onerror"}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
+            '{"type":"event","content_type":"application/vnd.sentry.items.log+json","length":132}\n' +
+            '{"event_id":"event0","exception":{"values":[{"mechanism":{"handled":false,"type":"onerror"}}]},"breadcrumbs":[{"message":"crumb!"}]}\n',
           ),
         ),
         { hardCrashed: true },


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Still a bit experimental with nothing interesting to see at the moment, but we will enable the logs on the native side for iOS.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

enabling logs on all layers.

## :green_heart: How did you test it?

on a iOS device

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
