### PR TITLE
chore(ci): Temporarily disable auto-upload for E2E build

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -160,7 +160,7 @@ jobs:
       USE_FRAMEWORKS: ${{ matrix.ios-use-frameworks }}
       PRODUCTION: ${{ matrix.build-type == 'production' && '1' || '0' }}
       RCT_NEW_ARCH_ENABLED: ${{ matrix.rn-architecture == 'new' && '1' || '0' }}
-      SENTRY_DISABLE_AUTO_UPLOAD: 'false'
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
⚠️ **Temporarily** disables auto-upload for E2E builds to fix [the failing tests](https://github.com/getsentry/sentry-react-native/actions/runs/17948547237/job/51052942120).
The failure cause should be investigated further and fix **TODO: create issue**


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

[Android failure](https://github.com/getsentry/sentry-react-native/actions/runs/17948547237/job/51052942120)
```
Execution failed for task ':app:createBundleReleaseJsAndAssets_SentryUpload_e2e-refs-heads-main_0.81.0-legacy-hermes-android-production-no-72d7b607'.
> Process 'command '/home/runner/work/sentry-react-native/sentry-react-native/dev-packages/e2e-tests/react-native-versions/0.81.0/RnDiffApp/node_modules/@sentry/cli/bin/sentry-cli'' finished with non-zero exit value 1
```
[iOS failure](https://github.com/getsentry/sentry-react-native/actions/runs/17948547237/job/51052941582)
```
Error: error: sentry-cli - To disable source maps auto upload, set SENTRY_DISABLE_AUTO_UPLOAD=true in your environment variables. Or to allow failing upload, set SENTRY_ALLOW_FAILURE=true
Error: error: sentry-cli -   INFO    2025-09-23 14:20:16.737839 +00:00 Loaded file referenced by SENTRY_PROPERTIES (sentry.properties)
```

## :green_heart: How did you test it?
CI, Locally

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog