### PR TITLE
 Fix the issue with changing immutable metadata structure in the contructor of `ReactNativeClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Fixes
 
 - Fixes .env file loading in Expo sourcemap uploads ([#5210](https://github.com/getsentry/sentry-react-native/pull/5210))
-- Fixes the issue with changing immutable metadata structure in the contructor of `ReactNativeClient`. This structure is getting re-created instead of being modified to ensure IP address is only inferred by Relay if `sendDefaultPii` is `true`.
+- Fixes the issue with changing immutable metadata structure in the contructor of `ReactNativeClient`. This structure is getting re-created instead of being modified to ensure IP address is only inferred by Relay if `sendDefaultPii` is `true` ([#5202](https://github.com/getsentry/sentry-react-native/pull/5202))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 - Fixes .env file loading in Expo sourcemap uploads ([#5210](https://github.com/getsentry/sentry-react-native/pull/5210))
+- Fixes the issue with changing immutable metadata structure in the contructor of `ReactNativeClient`. This structure is getting re-created instead of being modified to ensure IP address is only inferred by Relay if `sendDefaultPii` is `true`.
 
 ### Dependencies
 

--- a/packages/core/src/js/client.ts
+++ b/packages/core/src/js/client.ts
@@ -49,16 +49,17 @@ export class ReactNativeClient extends Client<ReactNativeClientOptions> {
    */
   public constructor(options: ReactNativeClientOptions) {
     ignoreRequireCycleLogs(ReactNativeLibraries.ReactNativeVersion?.version);
-    options._metadata = options._metadata || {};
-    options._metadata.sdk = options._metadata.sdk || defaultSdkInfo;
-
-    // Only allow IP inferral by Relay if sendDefaultPii is true
-    if (options._metadata?.sdk) {
-      options._metadata.sdk.settings = {
-        infer_ip: options.sendDefaultPii ? 'auto' : 'never',
-        ...options._metadata.sdk.settings,
-      };
-    }
+    options._metadata = {
+      ...options._metadata,
+      sdk: {
+        ...(options._metadata?.sdk || defaultSdkInfo),
+        settings: {
+          // Only allow IP inferral by Relay if sendDefaultPii is true
+          infer_ip: options.sendDefaultPii ? 'auto' : 'never',
+          ...options._metadata?.sdk?.settings,
+        }
+      }
+    };
 
     // We default this to true, as it is the safer scenario
     options.parentSpanIsAlwaysRootSpan =

--- a/packages/core/src/js/client.ts
+++ b/packages/core/src/js/client.ts
@@ -57,8 +57,8 @@ export class ReactNativeClient extends Client<ReactNativeClientOptions> {
           // Only allow IP inferral by Relay if sendDefaultPii is true
           infer_ip: options.sendDefaultPii ? 'auto' : 'never',
           ...options._metadata?.sdk?.settings,
-        }
-      }
+        },
+      },
     };
 
     // We default this to true, as it is the safer scenario

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -679,7 +679,7 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
-    test('adds ip_address {{auto}} to user if set to undefined', () => {
+    test("doesn't change infer_ip if the ip_address is set to undefined", () => {
       client.captureEvent({
         user: {
           ip_address: undefined,
@@ -692,13 +692,13 @@ describe('Tests ReactNativeClient', () => {
       expect(mockTransportSend.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload].sdk).toEqual(
         expect.objectContaining({
           settings: {
-            infer_ip: 'never',
+            infer_ip: 'auto',
           },
         }),
       );
     });
 
-    test('adds ip_address undefined to user if not set', () => {
+    test("doesn't change infer_ip if the user is not set", () => {
       client.captureEvent({
         user: {},
       });
@@ -707,20 +707,20 @@ describe('Tests ReactNativeClient', () => {
       expect(mockTransportSend.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload].sdk).toEqual(
         expect.objectContaining({
           settings: {
-            infer_ip: 'never',
+            infer_ip: 'auto',
           },
         }),
       );
     });
 
-    test('leaves ip_address undefined to undefined user', () => {
+    test("doesn't change infer_ip if the event is empty", () => {
       client.captureEvent({});
 
       expect(mockTransportSend.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload].user).toBeUndefined();
       expect(mockTransportSend.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload].sdk).toEqual(
         expect.objectContaining({
           settings: {
-            infer_ip: 'never',
+            infer_ip: 'auto',
           },
         }),
       );

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -679,7 +679,7 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
-    test('doesn\'t change infer_ip if the ip_address is set to undefined', () => {
+    test("doesn't change infer_ip if the ip_address is set to undefined", () => {
       client.captureEvent({
         user: {
           ip_address: undefined,
@@ -698,7 +698,7 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
-    test('doesn\'t change infer_ip if the user is not set', () => {
+    test("doesn't change infer_ip if the user is not set", () => {
       client.captureEvent({
         user: {},
       });
@@ -713,7 +713,7 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
-    test('doesn\'t change infer_ip if the event is empty', () => {
+    test("doesn't change infer_ip if the event is empty", () => {
       client.captureEvent({});
 
       expect(mockTransportSend.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload].user).toBeUndefined();

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -679,7 +679,7 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
-    test("doesn't change infer_ip if the ip_address is set to undefined", () => {
+    test('doesn\'t change infer_ip if the ip_address is set to undefined', () => {
       client.captureEvent({
         user: {
           ip_address: undefined,
@@ -698,7 +698,7 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
-    test("doesn't change infer_ip if the user is not set", () => {
+    test('doesn\'t change infer_ip if the user is not set', () => {
       client.captureEvent({
         user: {},
       });
@@ -713,7 +713,7 @@ describe('Tests ReactNativeClient', () => {
       );
     });
 
-    test("doesn't change infer_ip if the event is empty", () => {
+    test('doesn\'t change infer_ip if the event is empty', () => {
       client.captureEvent({});
 
       expect(mockTransportSend.mock.calls[0][firstArg][envelopeItems][0][envelopeItemPayload].user).toBeUndefined();


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fixes #5187

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
