### PR TITLE
fix(metro): Fixes Metro 0.83.2 breakages

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -160,7 +160,7 @@ jobs:
       USE_FRAMEWORKS: ${{ matrix.ios-use-frameworks }}
       PRODUCTION: ${{ matrix.build-type == 'production' && '1' || '0' }}
       RCT_NEW_ARCH_ENABLED: ${{ matrix.rn-architecture == 'new' && '1' || '0' }}
-      SENTRY_DISABLE_AUTO_UPLOAD: 'false'
+      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -160,7 +160,7 @@ jobs:
       USE_FRAMEWORKS: ${{ matrix.ios-use-frameworks }}
       PRODUCTION: ${{ matrix.build-type == 'production' && '1' || '0' }}
       RCT_NEW_ARCH_ENABLED: ${{ matrix.rn-architecture == 'new' && '1' || '0' }}
-      SENTRY_DISABLE_AUTO_UPLOAD: 'true'
+      SENTRY_DISABLE_AUTO_UPLOAD: 'false'
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 - Vendor `metro/countLines` function to avoid issues with the private import ([#5185](https://github.com/getsentry/sentry-react-native/pull/5185))
+- Fix baseJSBundle and bundleToString TypeErrors with Metro 0.83.2 ([#5206](https://github.com/getsentry/sentry-react-native/pull/5206))
 
 ## 7.1.0
 

--- a/packages/core/src/js/tools/vendor/metro/utils.ts
+++ b/packages/core/src/js/tools/vendor/metro/utils.ts
@@ -58,12 +58,18 @@ try {
   }
 }
 
-let bundleToString: typeof bundleToStringType;
+let bundleToStringModule: any;
 try {
-  bundleToString = require('metro/private/lib/bundleToString');
-} catch (e) {
-  bundleToString = require('metro/src/lib/bundleToString');
+  bundleToStringModule = require('metro/private/lib/bundleToString');
+} catch {
+  bundleToStringModule = require('metro/src/lib/bundleToString');
 }
+
+const bundleToString: typeof bundleToStringType =
+  typeof bundleToStringModule === 'function'
+    ? bundleToStringModule
+    : // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      bundleToStringModule?.bundleToString ?? bundleToStringModule?.default;
 
 type NewSourceMapStringExport = {
   // Since Metro v0.80.10 https://github.com/facebook/metro/compare/v0.80.9...v0.80.10#diff-1b836d1729e527a725305eef0cec22e44605af2700fa413f4c2489ea1a03aebcL28

--- a/packages/core/src/js/tools/vendor/metro/utils.ts
+++ b/packages/core/src/js/tools/vendor/metro/utils.ts
@@ -31,12 +31,18 @@ import type * as sourceMapStringType from 'metro/private/DeltaBundler/Serializer
 import type * as bundleToStringType from 'metro/private/lib/bundleToString';
 import type { MetroSerializer } from '../../utils';
 
-let baseJSBundle: typeof baseJSBundleType;
+let baseJSBundleModule: any;
 try {
-  baseJSBundle = require('metro/private/DeltaBundler/Serializers/baseJSBundle');
-} catch (e) {
-  baseJSBundle = require('metro/src/DeltaBundler/Serializers/baseJSBundle');
+  baseJSBundleModule = require('metro/private/DeltaBundler/Serializers/baseJSBundle');
+} catch {
+  baseJSBundleModule = require('metro/src/DeltaBundler/Serializers/baseJSBundle');
 }
+
+const baseJSBundle: typeof baseJSBundleType =
+  typeof baseJSBundleModule === 'function'
+    ? baseJSBundleModule
+    : // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      baseJSBundleModule?.baseJSBundle ?? baseJSBundleModule?.default;
 
 let sourceMapString: typeof sourceMapStringType;
 try {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Fixes https://github.com/getsentry/sentry-react-native/issues/5180

* Fixes baseJSBundle and bundleToString TypeErrors with Metro [`0.83.2`](https://github.com/facebook/metro/releases/tag/v0.83.2)
* Also fixes the CI E2E test build issues that started with the metro bump ([tests pass in 0.83.1](https://github.com/getsentry/sentry-react-native/pull/5204))

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Breakage in metro `0.83.2`

## :green_heart: How did you test it?
CI, Manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
