### PR TITLE
chore(deps): Reverts bump getsentry/github-workflows from 2 to 3

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   danger:
-    uses: getsentry/github-workflows/.github/workflows/danger.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   android:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-android.sh
       name: Android SDK
@@ -20,7 +20,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   android-stubs:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-android-stubs.sh
       name: Android SDK Stubs
@@ -29,7 +29,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   cocoa:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-cocoa.sh
       name: Cocoa SDK
@@ -38,7 +38,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   javascript:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-javascript.sh
       name: JavaScript SDK
@@ -47,7 +47,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   wizard:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-wizard.sh
       name: Wizard
@@ -57,7 +57,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   cli:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-cli.sh
       name: CLI
@@ -66,7 +66,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   bundler-plugins:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-bundler-plugins.sh
       name: Bundler Plugins
@@ -75,7 +75,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   sample-rn:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-rn.sh
       name: React Native
@@ -86,7 +86,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   maestro:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-maestro.sh
       name: Maestro
@@ -97,7 +97,7 @@ jobs:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 
   sentry-android-gradle-plugin:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@v3
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@v2
     with:
       path: scripts/update-sentry-android-gradle-plugin.sh
       name: Sentry Android Gradle Plugin


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Reverts the changes in https://github.com/getsentry/sentry-react-native/pull/5216 due to the [introduced breakages](https://github.com/getsentry/github-workflows/releases/tag/3.0.0) preventing the flows from running correctly.

The bump will be tackled with https://github.com/getsentry/sentry-react-native/pull/5218 after the issues are fixed

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog