### PR TITLE
fix(deps): Remove usage of deprecated SafeAreaView in the playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Updates `sentry-xcode.sh` and the default settings for the `project.pbxproj` to fix the issue with escape patterns in Xcode that leaded to errors during "Bundle React Native code and images" stage ([#5221](https://github.com/getsentry/sentry-react-native/pull/5221))
 - Fixes .env file loading in Expo sourcemap uploads ([#5210](https://github.com/getsentry/sentry-react-native/pull/5210))
 - Fixes the issue with changing immutable metadata structure in the contructor of `ReactNativeClient`. This structure is getting re-created instead of being modified to ensure IP address is only inferred by Relay if `sendDefaultPii` is `true` ([#5202](https://github.com/getsentry/sentry-react-native/pull/5202))
+- Removes usage of deprecated `SafeAreaView` ([#5241](https://github.com/getsentry/sentry-react-native/pull/5241))
 
 ### Dependencies
 

--- a/packages/core/src/js/playground/modal.tsx
+++ b/packages/core/src/js/playground/modal.tsx
@@ -7,7 +7,6 @@ import {
   Modal,
   Platform,
   Pressable,
-  SafeAreaView,
   StyleSheet,
   Text,
   useColorScheme,
@@ -116,7 +115,7 @@ export const SentryPlayground = ({
         setShow(false);
       }}
     >
-      <SafeAreaView style={styles.background}>
+      <View style={styles.background}>
         <View style={styles.container}>
           <Text style={styles.welcomeText}>Welcome to Sentry Playground!</Text>
           <Animated.View
@@ -185,7 +184,7 @@ export const SentryPlayground = ({
             />
           </View>
         </View>
-      </SafeAreaView>
+      </View>
     </Modal>
   );
 };

--- a/packages/core/test/playground/__snapshots__/modal.test.tsx.snap
+++ b/packages/core/test/playground/__snapshots__/modal.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`PlaygroundComponent matches the snapshot with no props 1`] = `
   presentationStyle="formSheet"
   visible={true}
 >
-  <RCTSafeAreaView
+  <View
     style={
       {
         "alignItems": "center",
@@ -765,7 +765,7 @@ exports[`PlaygroundComponent matches the snapshot with no props 1`] = `
         </View>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </View>
 </Modal>
 `;
 
@@ -777,7 +777,7 @@ exports[`PlaygroundComponent matches the snapshot with project id and organizati
   presentationStyle="formSheet"
   visible={true}
 >
-  <RCTSafeAreaView
+  <View
     style={
       {
         "alignItems": "center",
@@ -1534,6 +1534,6 @@ exports[`PlaygroundComponent matches the snapshot with project id and organizati
         </View>
       </View>
     </View>
-  </RCTSafeAreaView>
+  </View>
 </Modal>
 `;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes https://github.com/getsentry/sentry-react-native/issues/5189

Removes usage of deprecated `SafeAreaView` in the playground and replaces it by using a simple `View`. Adding `react-native-safe-area-context` as suggested by the warning would be be desirable since it would add a third party dependency in core.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?
Used the Expo app by uncommenting [these lines](https://github.com/getsentry/sentry-react-native/blob/170d5ea6d79574b6fbd714f6593879220b7d3380/samples/expo/app/_layout.tsx#L152) and verified that the app behavior and appearance does not change

|iOS|Android|
|---|---|
|<img width="1008" height="2244" alt="Screenshot_20251006_124952" src="https://github.com/user-attachments/assets/dbdb818f-effb-4178-b593-fa0dbc1a7cce" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-06 at 12 39 33" src="https://github.com/user-attachments/assets/a7a392ef-2232-461b-b3bf-c71409833422" />|

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
