### PR TITLE
fix(session-replay): Leave captureReplay logic to the native implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixes .env file loading in Expo sourcemap uploads ([#5210](https://github.com/getsentry/sentry-react-native/pull/5210))
 - Fixes the issue with changing immutable metadata structure in the contructor of `ReactNativeClient`. This structure is getting re-created instead of being modified to ensure IP address is only inferred by Relay if `sendDefaultPii` is `true` ([#5202](https://github.com/getsentry/sentry-react-native/pull/5202))
 - Removes usage of deprecated `SafeAreaView` ([#5241](https://github.com/getsentry/sentry-react-native/pull/5241))
+- Fixes session replay recording for uncaught errors ([#5243](https://github.com/getsentry/sentry-react-native/pull/5243))
 
 ### Dependencies
 

--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -137,19 +137,25 @@ export const mobileReplayIntegration = (initOptions: MobileReplayOptions = defau
       return event;
     }
 
+    const hardCrash = isHardCrash(event);
+
     const recordingReplayId = NATIVE.getCurrentReplayId();
-    if (recordingReplayId) {
+    if (!hardCrash && recordingReplayId) {
       debug.log(
         `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} assign already recording replay ${recordingReplayId} for event ${event.event_id}.`,
       );
       return event;
     }
 
-    const replayId = await NATIVE.captureReplay(isHardCrash(event));
+    const replayId = await NATIVE.captureReplay(hardCrash);
     if (!replayId) {
       debug.log(`[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} not sampled for event ${event.event_id}.`);
       return event;
     }
+
+    debug.log(
+      `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} Captured recording replay ${replayId} for event ${event.event_id}.`,
+    );
 
     return event;
   }

--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -149,7 +149,13 @@ export const mobileReplayIntegration = (initOptions: MobileReplayOptions = defau
 
     const replayId = await NATIVE.captureReplay(hardCrash);
     if (!replayId) {
-      debug.log(`[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} not sampled for event ${event.event_id}.`);
+      if (recordingReplayId) {
+        debug.log(
+          `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} assign already recorded replay ${recordingReplayId} for event ${event.event_id} since crash recording failed.`,
+        );
+      } else {
+        debug.log(`[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} not sampled for event ${event.event_id}.`);
+      }
       return event;
     }
 

--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -137,31 +137,21 @@ export const mobileReplayIntegration = (initOptions: MobileReplayOptions = defau
       return event;
     }
 
-    const hardCrash = isHardCrash(event);
-
-    const recordingReplayId = NATIVE.getCurrentReplayId();
-    if (!hardCrash && recordingReplayId) {
-      debug.log(
-        `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} assign already recording replay ${recordingReplayId} for event ${event.event_id}.`,
-      );
-      return event;
-    }
-
-    const replayId = await NATIVE.captureReplay(hardCrash);
+    const replayId = await NATIVE.captureReplay(isHardCrash(event));
     if (!replayId) {
+      const recordingReplayId = NATIVE.getCurrentReplayId();
       if (recordingReplayId) {
         debug.log(
-          `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} assign already recorded replay ${recordingReplayId} for event ${event.event_id} since crash recording failed.`,
+          `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} assign already recording replay ${recordingReplayId} for event ${event.event_id}.`,
         );
       } else {
         debug.log(`[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} not sampled for event ${event.event_id}.`);
       }
-      return event;
+    } else {
+      debug.log(
+        `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} Captured recording replay ${replayId} for event ${event.event_id}.`,
+      );
     }
-
-    debug.log(
-      `[Sentry] ${MOBILE_REPLAY_INTEGRATION_NAME} Captured recording replay ${replayId} for event ${event.event_id}.`,
-    );
 
     return event;
   }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Leaves captureReplay logic to [the native implementation](https://github.com/getsentry/sentry-react-native/pull/5243#discussion_r2410678941)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/getsentry/sentry-react-native/issues/5074

When `replaysSessionSampleRate: 0.0`, and with the steps below, I always got no recording attached to the event though I should have given that `replaysOnErrorSampleRate: 1.0`. I wasn't able to associate this behavior with the `reactNavigationIntegration` as the above issue states but the fix seems to make the the SR recording more reliable.

## :green_heart: How did you test it?

1. Set `replaysSessionSampleRate: 0.0` [in the sample app](https://github.com/getsentry/sentry-react-native/blob/0b647531c13884b6be72c6f652482d79c6d2d96f/samples/react-native/src/App.tsx#L160). Leave `replaysOnErrorSampleRate: 1.0`
2. Tap the `Uncaught Thrown Error`
3. Notice that a replay is attached to the crash

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
