### PR TITLE
fix(metro): Fixes TypeScript errors when using custom Metro configurations with Expo SDK 54

### DIFF
--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -44,7 +44,7 @@ export interface SentryExpoConfigOptions {
   /**
    * Pass a custom `getDefaultConfig` function to override the default Expo configuration getter.
    */
-  getDefaultConfig?: typeof getSentryExpoConfig;
+  getDefaultConfig?: (projectRoot: string, options?: Record<string, unknown>) => Record<string, unknown>;
 
   /**
    * For Expo Web, inject `release` and `version` options from `app.json`, the Expo Application Config.


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Fixes TypeScript errors when using custom Metro configurations with Expo SDK 54 by relaxing getDefaultConfig types

The `getDefaultConfig` option in `SentryExpoConfigOptions` now uses
flexible typing to accommodate Metro bundler type differences between
@expo/metro and the standalone metro package.

This fixes TypeScript errors when using custom Metro configurations
with Expo SDK 54, where Metro type definitions have diverged from
earlier versions.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes https://github.com/getsentry/sentry-react-native/issues/5176

## :green_heart: How did you test it?

Manual, CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
