### PR TITLE
chore: Remove deprecated user property

### DIFF
--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryUserTests.m
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryUserTests.m
@@ -14,7 +14,6 @@
     [expected setIpAddress:@"192.168.1.1"];
     [expected setEmail:@"test@example.com"];
     [expected setUsername:@"testuser"];
-    [expected setSegment:@"testsegment"];
     [expected setData:@{
         @"foo" : @"bar",
         @"baz" : @123,
@@ -26,7 +25,6 @@
         @"ip_address" : @"192.168.1.1",
         @"email" : @"test@example.com",
         @"username" : @"testuser",
-        @"segment" : @"testsegment",
     }
                               otherUserKeys:@{
                                   @"foo" : @"bar",
@@ -67,7 +65,6 @@
         @"ip_address" : @ {},
         @"email" : @ {},
         @"username" : @ {},
-        @"segment" : @[],
     }
                               otherUserKeys:nil];
 
@@ -84,7 +81,6 @@
         @"ip_address" : @ {},
         @"email" : @ {},
         @"username" : @ {},
-        @"segment" : @[],
     }
                               otherUserKeys:nil];
 
@@ -100,7 +96,6 @@
         @"ip_address" : [NSNull null],
         @"email" : [NSNull null],
         @"username" : [NSNull null],
-        @"segment" : [NSNull null],
     }
                               otherUserKeys:nil];
 

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -723,10 +723,6 @@ RCT_EXPORT_METHOD(setUser : (NSDictionary *)userKeys otherUserKeys : (NSDictiona
         if ([username isKindOfClass:NSString.class]) {
             [userInstance setUsername:username];
         }
-        id segment = [userKeys valueForKey:@"segment"];
-        if ([segment isKindOfClass:NSString.class]) {
-            [userInstance setSegment:segment];
-        }
 
         if ([userDataKeys isKindOfClass:NSDictionary.class]) {
             [userInstance setData:userDataKeys];


### PR DESCRIPTION
This property is deprecated and the next version of the iOS SDK will remove it entirely, so this deletes it from the RN code so that it will be compatible with the next iOS version 

#skip-changelog