### PR TITLE
chore: Remove use of deprecate integrations API

### DIFF
--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.m
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.m
@@ -133,8 +133,7 @@ XCTAssertEqual(actualOptions.enableTracing, false, @"EnableTracing should not be
                                                                    error:&error];
     XCTAssertNotNil(actualOptions, @"Did not create sentry options");
     XCTAssertNil(error, @"Should not pass no error");
-    XCTAssertEqual([actualOptions.integrations containsObject:@"SentryCrashIntegration"], false,
-        @"Did not disable native crash handling");
+    XCTAssertFalse(actualOptions.enableCrashHandler, @"Did not disable native crash handling");
 }
 
 - (void)testCreateOptionsWithDictionaryAutoPerformanceTracingDisabled

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -264,9 +264,7 @@ RCT_EXPORT_METHOD(initNativeSdk : (NSDictionary *_Nonnull)options resolve : (
         BOOL enableNativeCrashHandling = [mutableOptions[@"enableNativeCrashHandling"] boolValue];
 
         if (!enableNativeCrashHandling) {
-            NSMutableArray *integrations = sentryOptions.integrations.mutableCopy;
-            [integrations removeObject:@"SentryCrashIntegration"];
-            sentryOptions.integrations = integrations;
+            sentryOptions.enableCrashHandler = NO;
         }
     }
 


### PR DESCRIPTION
The `integrations` property is deprecated and will be removed in the next version of the cocoa sdk, we can update this calcite to use the non-deprecated API