### PR TITLE
chore(test): Rename test cases due to deprecation of ExperimentalViewRenderer

### DIFF
--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
@@ -168,7 +168,7 @@ final class RNSentryReplayOptions: XCTestCase {
         XCTAssertEqual(actualOptions.sessionReplay.maskedViewClasses.count, 0)
     }
 
-    func testEnableExperimentalViewRendererDefault() {
+    func testEnableViewRendererV2Default() {
         let optionsDict = ([
             "dsn": "https://abc@def.ingest.sentry.io/1234567",
             "replaysOnErrorSampleRate": 0.75
@@ -181,7 +181,7 @@ final class RNSentryReplayOptions: XCTestCase {
         XCTAssertTrue(actualOptions.sessionReplay.enableViewRendererV2)
     }
 
-    func testEnableExperimentalViewRendererTrue() {
+    func testEnableViewRendererV2True() {
         let optionsDict = ([
             "dsn": "https://abc@def.ingest.sentry.io/1234567",
             "replaysOnErrorSampleRate": 0.75,
@@ -195,7 +195,7 @@ final class RNSentryReplayOptions: XCTestCase {
         XCTAssertTrue(actualOptions.sessionReplay.enableViewRendererV2)
     }
 
-    func testEnableExperimentalViewRendererFalse() {
+    func testEnableViewRendererV2False() {
         let optionsDict = ([
             "dsn": "https://abc@def.ingest.sentry.io/1234567",
             "replaysOnErrorSampleRate": 0.75,


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Renames test cases due to deprecation of ExperimentalViewRenderer as a follow up to https://github.com/getsentry/sentry-react-native/pull/5322

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
-

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog