### PR TITLE
Correct 'Fix' to 'Fixes' in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
     });
     ```
 
-### Fix
+### Fixes
 
 - Sync `user.geo` from `SetUser` to the native layer ([#5302](https://github.com/getsentry/sentry-react-native/pull/5302))
 


### PR DESCRIPTION
Changelog was using an incorrect header

#skip-changelog.
