### PR TITLE
Update Twitter badge to X badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ If you are coming from `react-native-sentry` which was our SDK `< 1.0` you shoul
 - [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)
 - [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
 - [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-sentry-green.svg)](https://github.com/getsentry/.github/blob/main/CODE_OF_CONDUCT.md)
-- [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
+- [![X Follow](https://img.shields.io/twitter/follow/sentry?label=sentry&style=social)](https://x.com/intent/follow?screen_name=sentry)


### PR DESCRIPTION
Links were updated, previous one was pointing to a strange page
<img width="720" height="631" alt="image" src="https://github.com/user-attachments/assets/ecb412b8-bda1-47b4-a767-308003bb6623" />
