### PR TITLE
chore(ci): Bumps old E2E RN version to 0.71.19 and deprecate macos-13 runner

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -179,7 +179,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.71.11', '0.81.0']
+        rn-version: ['0.71.19', '0.81.0']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -191,9 +191,9 @@ jobs:
             xcode-version: '16.4'
             runs-on: macos-15
           - platform: ios
-            rn-version: '0.71.11'
-            xcode-version: '14.2'
-            runs-on: macos-13
+            rn-version: '0.71.19'
+            xcode-version: '15.4'
+            runs-on: macos-14
           - platform: android
             runs-on: ubuntu-latest
         exclude:
@@ -201,13 +201,13 @@ jobs:
           - rn-version: '0.81.0'
             engine: 'jsc'
           # exclude all rn versions lower than 0.80.0 for new architecture
-          - rn-version: '0.71.11'
+          - rn-version: '0.71.19'
             rn-architecture: 'new'
           # exlude old rn version for use frameworks builds (to minimalize the matrix)
-          - rn-version: '0.71.11'
+          - rn-version: '0.71.19'
             platform: 'ios'
             ios-use-frameworks: 'static'
-          - rn-version: '0.71.11'
+          - rn-version: '0.71.19'
             platform: 'ios'
             ios-use-frameworks: 'dynamic'
           # use frameworks is ios only feature


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

Bumps:
- `macos-13` to `macos-14`
- `xcode 14.2` to `xcode 15.4` (xcode 14 is missing from the runner)
- RN `0.71.11` to `0.71.19` ([xcode 15 patch was added in 0.71.14](https://github.com/facebook/react-native/blob/main/CHANGELOG-0.7x.md#v07114) so I bumped to the latest 0.71.x)

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.
Related CI failed task https://github.com/getsentry/sentry-react-native/actions/runs/20059446491/job/57536759443?pr=5444

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog