### PR TITLE
chore(ci): Use xcode 16.4 for all e2e builds

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -188,7 +188,7 @@ jobs:
         include:
           - platform: ios
             xcode-version: '16.4'
-            runs-on: macos-latest
+            runs-on: macos-15
           - platform: android
             runs-on: ubuntu-latest
         exclude:


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Bumps E2E tests to xcode 16.4 and macos-15.
This should make [the cocoa-v9 branch](https://github.com/getsentry/sentry-react-native/pull/5356) 🟢 🤞 but is not specific to cocoa-v9

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While investigating [a CI build issue for RN 0.71](https://github.com/getsentry/sentry-react-native/issues/5273#issuecomment-3581294743) I realized that we do no longer need the older xcode version for RN 0.71.19 (that seems to be the root of the failure) [since the CI checks pass](https://github.com/getsentry/sentry-react-native/actions/runs/20131347618/job/57776376359?pr=5455).

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog