### PR TITLE
fix: Update Sentry Craft action version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - name: Prepare release
-        uses: getsentry/craft@39ee616a6a58dc64797feecb145d66770492b66c # v2
+        uses: getsentry/craft@1c58bfd57bfd6a967b6f3fc92bead2c42ee698ce # v2
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
         with:


### PR DESCRIPTION
Updates craft, fixing release issue introduced by https://github.com/getsentry/sentry-react-native/pull/5519

#skip-changelog