### PR TITLE
ci: Add changelog preview flow

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -7,6 +7,7 @@ on:
     - reopened
     - edited
     - labeled
+    - unlabled
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
This PR adds the `unlabeled` trigger to the changelog preview workflow to ensure the preview is updated when a label is removed.