### PR TITLE
chore(android): Increase Android diffMax to 5.5 MB

### DIFF
--- a/performance-tests/metrics-android.yml
+++ b/performance-tests/metrics-android.yml
@@ -13,4 +13,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 1 MiB
-  diffMax: 5.0 MiB
+  diffMax: 5.5 MiB


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

⚠️ Based on https://github.com/getsentry/sentry-react-native/pull/5539

## :scroll: Description
<!--- Describe your changes in detail -->
Updated the threshold to 5.5 MiB. This will pass since the actual difference is 5.44 MiB, and it provides a tighter limit with a small buffer (~62 KB) for minor fluctuations.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Opened a separate PR to keep track of the change since [the binary size check failed](https://github.com/getsentry/sentry-react-native/actions/runs/21030357158/job/60472951104?pr=5539) in the [8.30.0 Android bump](https://github.com/getsentry/sentry-react-native/pull/5539)

```
BinarySizeTest > app size() STANDARD_ERROR
    Jan 15, 2026 1:34:36 PM BinarySizeTest app size
    INFO: App com.testappplain  size is 43.94 MiB
    Jan 15, 2026 1:34:36 PM BinarySizeTest app size
    INFO: App com.testappsentry size is 49.38 MiB
    Jan 15, 2026 1:34:36 PM BinarySizeTest app size
    INFO: App com.testappsentry is 5.44 MiB larger than app com.testappplain

BinarySizeTest > app size() FAILED
    java.lang.AssertionError: 5705106 should be < 5242880
        at BinarySizeTest.app size(BinarySizeTest.kt:37)
```

## :green_heart: How did you test it?
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog