### PR TITLE
fix: iOS: Fixes Session Replay in Capture app start errors feature branch

### DIFF
--- a/packages/core/ios/RNSentryStart.m
+++ b/packages/core/ios/RNSentryStart.m
@@ -1,4 +1,5 @@
 #import "RNSentryStart.h"
+#import "RNSentryExperimentalOptions.h"
 #import "RNSentryReplay.h"
 #import "RNSentryVersion.h"
 
@@ -40,7 +41,9 @@
     NSMutableDictionary *mutableOptions = [options mutableCopy];
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
-    [RNSentryReplay updateOptions:mutableOptions];
+    BOOL isSessionReplayEnabled = [RNSentryReplay updateOptions:mutableOptions];
+#else
+    BOOL isSessionReplayEnabled = NO;
 #endif
 
     SentryOptions *sentryOptions = [SentryOptionsInternal initWithDict:mutableOptions
@@ -94,6 +97,11 @@
                 sentryOptions.spotlightUrl = defaultSpotlightUrl;
             }
         }
+    }
+
+    if (isSessionReplayEnabled) {
+        [RNSentryExperimentalOptions setEnableSessionReplayInUnreliableEnvironment:YES
+                                                                     sentryOptions:sentryOptions];
     }
 
     return sentryOptions;


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Fixes session replay issue on iOS due to [missing code](https://github.com/getsentry/sentry-react-native/blob/a06e222554643898a91fcafdbbada4dcb6a23b3a/packages/core/ios/SentrySDKWrapper.m#L112) in refactoring.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Broken SR functionality on iOS detected by the E2E test

## :green_heart: How did you test it?
CI, Manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog