### PR TITLE
chore(ci): Dynamically select available iPhone simulator for tests

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -58,8 +58,17 @@ jobs:
           SCHEME: RNSentryCocoaTester
           CONFIGURATION: Release
         run: |
-          # Find first available iPhone simulator
-          DEVICE_ID=$(xcrun simctl list devices available iPhone -j | jq -r '.devices | to_entries[].value[] | select(.isAvailable == true) | .udid' | head -1)
+          # Find first available iPhone simulator from latest iOS runtime
+          DEVICE_ID=$(xcrun simctl list devices available iPhone -j | jq -r '
+            .devices |
+            to_entries |
+            map(select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))) |
+            sort_by(.key) |
+            reverse |
+            .[0].value[] |
+            select(.isAvailable == true) |
+            .udid
+          ' | head -1)
           if [ -z "$DEVICE_ID" ]; then
             echo "No iPhone simulators available"
             exit 1


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Instead of hardcoding device name and OS version, dynamically find the first
available iPhone simulator using xcrun simctl. This prevents failures when
specific device/OS combinations aren't available on CI runners.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-react-native/issues/5572

## :green_heart: How did you test it?
CI, I've [run the native ios test twice and was](https://github.com/getsentry/sentry-react-native/actions/runs/21354957156/job/61465492202?pr=5577) 🟢 

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog