### PR TITLE
Ref: Add Claude task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,8 +95,9 @@ node_modules.bak
 # SwiftLint
 swiftlint/*
 
-# Sample app
+# Environment variables
 samples/*/.env
+.env
 
 # Local Claude Code settings that should not be committed
 .claude/settings.local.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
     {
       "label": "Claude",
       "type": "shell",
-      "command": "bash -ic claude",
+      "command": "CLAUDE_PATH=$(grep '^CLAUDE_PATH=' .env | cut -d '=' -f2 | tr -d '\"') && $CLAUDE_PATH",
       "icon": {
         "color": "terminal.ansiRed",
         "id": "robot"
@@ -30,7 +30,8 @@
       "group": {
         "kind": "none",
         "isDefault": true
-      }
+      },
+      "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

This is a nit PR where you can spawn claude as a task. The only requirement is to define "CLAUDE_PATH" on the root project inside of `.env` file (due to limitations on how vscode spawn things).

<img width="1265" height="464" alt="image" src="https://github.com/user-attachments/assets/b5782ae6-1957-47f3-b11c-650c21cdd705" />
<img width="2120" height="475" alt="image" src="https://github.com/user-attachments/assets/f991df81-fea3-4626-97d3-bdf420b16630" />

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Was manually spawning the task every time on terminal, so decided to make it more simpler.

## :green_heart: How did you test it?

Running the command on MacOS and Linux

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
