### PR TITLE
fix(spotlight): Add Sentry Spotlight dependency for debug builds

### DIFF
--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -56,4 +56,5 @@ dependencies {
     compileOnly files('libs/replay-stubs.jar')
     implementation 'com.facebook.react:react-native:+'
     api 'io.sentry:sentry-android:8.32.0'
+    debugImplementation 'io.sentry:sentry-spotlight:8.32.0'
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Since 8.32.0 spotlight was separated into a different module, we now have to explicitly include it into the consuming project (when enabling spotlight in the Android SDK). The recommended way is to only do that for debug builds and not ship the artifact to production. See Flutter: https://github.com/getsentry/sentry-dart/blob/main/packages/flutter/android/build.gradle#L66

I haven't tested it, but afaik RN works in similar ways as Flutter, so the android project (from sentry-react-native) will be added as includedBuild locally to our customers' projects so this should suffice. But would be great if you can verify it on the sample app

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
