### PR TITLE
Move task operations out of onVariants to fix AGP Artifacts API confl…

### DIFF
--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -119,7 +119,7 @@ plugins.withId('com.android.application') {
                 //     .join('\n')
 
                 def currentVariants = extractCurrentVariants(bundleTask, v)
-                if (currentVariants == null) return
+                if (currentVariants == null || currentVariants.isEmpty()) return
 
                 def previousCliTask = null
                 def applicationVariant = null
@@ -328,9 +328,10 @@ plugins.withId('com.android.application') {
                 previousCliTask.configure { finalizedBy cliCleanUpTask }
 
                 def packageTasks = tasks.matching {
-                    task -> ("package${applicationVariant}".equalsIgnoreCase(task.name) || "package${applicationVariant}Bundle".equalsIgnoreCase(task.name)) && task.enabled
+                    task -> ("package${applicationVariant}".equalsIgnoreCase(task.name) || "package${applicationVariant}Bundle".equalsIgnoreCase(task.name))
                 }
                 packageTasks.configureEach { packageTask ->
+                    if (!packageTask.enabled) return
                     packageTask.dependsOn modulesTask
                     packageTask.finalizedBy modulesCleanUpTask
                 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fixes issue where calling tasks.matching{}.each{} inside androidComponents.onVariants()
forces task realization during AGP's variant configuration phase, disrupting the
Artifacts API transform chain used by other plugins (e.g. Fullstory).

This caused APK transforms from other plugins to output to build/intermediates/
instead of build/outputs/, breaking downstream tooling that expects APKs in the
standard location.

The fix:
- Collect only variant metadata (name, outputs) in onVariants callback
- Move all task-level operations (tasks.matching, tasks.register, etc.) into
  project.afterEvaluate within the plugins.withId block
- Update extractCurrentVariants to accept pre-collected data instead of live variant

This ensures the AGP Artifacts API transform chain is fully established before
Sentry accesses any tasks, preventing interference with other plugins.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is currently conflicting with the Fullstory plugin


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
