### PR TITLE
chore(deps): bump lodash to ^4.17.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "resolutions": {
     "appium-chromedriver@npm:5.6.73/@xmldom/xmldom": "0.8.10",
     "form-data": "4.0.4",
+    "lodash": "^4.17.23",
     "tar-fs": "^3.1.1",
     "tar": "^7.5.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -24574,10 +24574,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.0.0, lodash@npm:^4.17.11, lodash@npm:^4.17.12, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.2.1":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+"lodash@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds a `resolutions` entry to force `lodash` to `>=4.17.23`
- Fixes prototype pollution vulnerability in `_.unset` and `_.omit` (affected range: `>= 4.0.0, <= 4.17.22`)

## Dependabot alerts

- https://github.com/getsentry/sentry-react-native/security/dependabot/396

## Test plan

- [x] `yarn install` resolves `lodash` to `4.17.23`
- [x] `yarn build` passes
- [x] `yarn test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)