### PR TITLE
ci: Cancel in-progress CI jobs when a PR is closed or merged

### DIFF
--- a/.github/workflows/cancel-pr-workflows.yml
+++ b/.github/workflows/cancel-pr-workflows.yml
@@ -36,12 +36,16 @@ jobs:
               if (run.id === context.runId) {
                 continue;
               }
-              console.log(`Cancelling run ${run.id} (${run.name})`);
-              await github.rest.actions.cancelWorkflowRun({
-                owner,
-                repo,
-                run_id: run.id,
-              });
+              try {
+                console.log(`Cancelling run ${run.id} (${run.name})`);
+                await github.rest.actions.cancelWorkflowRun({
+                  owner,
+                  repo,
+                  run_id: run.id,
+                });
+              } catch (error) {
+                console.log(`Failed to cancel run ${run.id}: ${error.message}`);
+              }
             }
 
             console.log(`Cancelled ${runs.length > 1 ? runs.length - 1 : 0} workflow run(s) for branch ${branch}`);


### PR DESCRIPTION
## Summary

- When a PR is merged (or closed), all in-progress and queued CI workflow runs for that PR's branch are now automatically cancelled

## Problem

The existing concurrency groups use `github.ref`, which for PRs resolves to `refs/pull/<number>/merge`. When a PR is merged, the push to main creates a **different** concurrency group (`refs/heads/main`), so the still-running PR workflows are never cancelled. This wastes CI resources, especially for expensive jobs like native tests, E2E, and sample app builds.

## Solution

A new lightweight workflow that:
1. Triggers on `pull_request: closed` (fires on both merge and manual close)
2. Lists all `in_progress` and `queued` workflow runs for the PR's head branch
3. Cancels each one via the GitHub API

The workflow uses `actions/github-script` with the default `GITHUB_TOKEN` — no extra permissions needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)