### PR TITLE
chore(deps): bump minimatch to fix ReDoS vulnerabilities and tmp to ^0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "tar-fs": "^3.1.1",
     "on-headers": "^1.1.0",
     "diff": "^5.2.2",
-    "tar": "^7.5.8"
+    "tar": "^7.5.8",
+    "tmp": "^0.2.4"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27689,13 +27689,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
-  languageName: node
-  linkType: hard
-
 "outvariant@npm:^1.2.1, outvariant@npm:^1.4.0":
   version: 1.4.3
   resolution: "outvariant@npm:1.4.3"
@@ -32913,26 +32906,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: "npm:~1.0.2"
-  checksum: 902d7aceb74453ea02abbf58c203f4a8fc1cead89b60b31e354f74ed5b3fb09ea817f94fb310f884a5d16987dd9fa5a735412a7c2dd088dd3d415aa819ae3a28
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.1":
+"tmp@npm:^0.2.4":
   version: 0.2.5
   resolution: "tmp@npm:0.2.5"
   checksum: 9d18e58060114154939930457b9e198b34f9495bcc05a343bc0a0a29aa546d2c1c2b343dae05b87b17c8fde0af93ab7d8fe8574a8f6dc2cd8fd3f2ca1ad0d8e1
-  languageName: node
-  linkType: hard
-
-"tmp@npm:^0.2.3, tmp@npm:~0.2.1":
-  version: 0.2.3
-  resolution: "tmp@npm:0.2.3"
-  checksum: 73b5c96b6e52da7e104d9d44afb5d106bb1e16d9fa7d00dbeb9e6522e61b571fbdb165c756c62164be9a3bbe192b9b268c236d370a2a0955c7689cd2ae377b95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Patches `minimatch` ReDoS vulnerabilities across all affected major versions in the dependency tree using scoped Yarn resolutions.

| Alert | Range | Fixed to |
|-------|-------|----------|
| [#441](https://github.com/getsentry/sentry-react-native/security/dependabot/441) | `< 3.1.3` | `3.1.5` |
| [#440](https://github.com/getsentry/sentry-react-native/security/dependabot/440) | `>= 5.0.0, < 5.1.8` | `5.1.9` |
| [#439](https://github.com/getsentry/sentry-react-native/security/dependabot/439) | `>= 8.0.0, < 8.0.6` | `8.0.7` |
| [#438](https://github.com/getsentry/sentry-react-native/security/dependabot/438) | `>= 9.0.0, < 9.0.7` | `9.0.9` |
| [#437](https://github.com/getsentry/sentry-react-native/security/dependabot/437) / [#432](https://github.com/getsentry/sentry-react-native/security/dependabot/432) / [#428](https://github.com/getsentry/sentry-react-native/security/dependabot/428) | `>= 10.0.0, < 10.2.3` | `10.2.4` |


Also:
- Adds a `resolutions` entry to force `tmp` to `>=0.2.4`
- Fixes arbitrary temporary file/directory write via symbolic link `dir` parameter (affected range: `<= 0.2.3`)
- Consolidates both the `0.0.33` (from `@expo/devcert`, `external-editor`, `patch-package`) and `0.2.3` consumers onto the latest `0.2.x` series
- https://github.com/getsentry/sentry-react-native/security/dependabot/360

All affected packages are **dev-only** — none appear in the SDK's runtime dependencies.

## Why scoped resolutions?

Yarn 3 doesn't support range-keyed resolutions (e.g. `"minimatch@^3.x": "..."`) so an unscoped resolution would force all consumers onto a single major version, breaking incompatible consumers. Parent-scoped resolutions (e.g. `"lerna@npm:8.1.8/minimatch"`) are the canonical Yarn Berry approach for this case.

Notably, `lerna` and `@lerna/create` pin minimatch exactly at `3.0.5` — these are bumped to `3.1.5` via scoped resolutions. Verified this doesn't break lerna: `yarn build`, `yarn test`, and `yarn lint` all pass locally.