### PR TITLE
Updates to EAS build hooks

### DIFF
--- a/packages/core/scripts/eas-build-hook.js
+++ b/packages/core/scripts/eas-build-hook.js
@@ -148,6 +148,9 @@ const HOOK_CONFIGS = {
       successMessage: 'SENTRY_EAS_BUILD_SUCCESS_MESSAGE',
       captureSuccessfulBuilds: 'SENTRY_EAS_BUILD_CAPTURE_SUCCESS',
     },
+    // When a user explicitly configures the on-success hook, they intend to
+    // capture successful builds, so default captureSuccessfulBuilds to true.
+    defaults: { captureSuccessfulBuilds: true },
     method: 'captureEASBuildSuccess',
   },
 };
@@ -169,11 +172,17 @@ async function runEASBuildHook(hookName) {
   loadEnv();
 
   const hooks = loadHooksModule();
-  const options = parseBaseOptions();
+  const options = {
+    ...parseBaseOptions(),
+    ...config.defaults,
+  };
 
   for (const [optionKey, envKey] of Object.entries(config.envKeys)) {
     if (optionKey === 'captureSuccessfulBuilds') {
-      options[optionKey] = process.env[envKey] === 'true';
+      // Only override the default when the env var is explicitly set
+      if (process.env[envKey] !== undefined) {
+        options[optionKey] = process.env[envKey] === 'true';
+      }
     } else if (process.env[envKey] !== undefined) {
       options[optionKey] = process.env[envKey];
     }

--- a/packages/core/src/js/tools/easBuildHooks.ts
+++ b/packages/core/src/js/tools/easBuildHooks.ts
@@ -14,6 +14,7 @@
 
 import type { DsnComponents } from '@sentry/core';
 import { dsnToString, makeDsn, uuid4 } from '@sentry/core';
+import { SDK_VERSION } from '../version';
 
 const SENTRY_DSN_ENV = 'SENTRY_DSN';
 const EAS_BUILD_ENV = 'EAS_BUILD';
@@ -179,7 +180,7 @@ function createBaseEvent(
     release: getReleaseFromEASEnv(env),
     tags: { ...createEASBuildTags(env), ...customTags },
     contexts: { eas_build: createEASBuildContext(env), runtime: { name: 'node', version: process.version } },
-    sdk: { name: 'sentry.javascript.react-native.eas-build-hooks', version: '1.0.0' },
+    sdk: { name: 'sentry.javascript.react-native.eas-build-hooks', version: SDK_VERSION },
   };
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Two small fixes to EAS build hooks:
- When a user explicitly adds up sentry-eas-build-on-success, it now does the right thing without needing an extra env var
- Dynamic version of SDK gets attached to `sentry.javascript.react-native.eas-build-hooks` SDK name


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

#skip-changelog