### PR TITLE
chore(dx): Add PR Creation instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ feat(replay): Add mobile replay masking support
 fix(android): Fix crash on startup with Hermes
 ```
 
+## Pull Requests
+
+When asked to open a PR:
+- **Ask** if it should be a **draft** PR (default: draft).
+- Use the repo's PR template (`.github/pull_request_template.md`) for the body. Fill in the sections:
+  - **Type of change** — check the applicable boxes (Bugfix, New feature, Enhancement, Refactoring).
+  - **Description** — describe the changes in detail.
+  - **Motivation and Context** — why the change is needed, link related issues.
+  - **How did you test it?** — list tests added/run.
+  - **Checklist** — check the applicable boxes.
+  - **Next steps** — note any follow-up work, or leave empty.
+
 ## Pre-Commit Checklist
 
 - [ ] Code compiles without errors (`yarn build`)


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Add PR Creation instructions for agents

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I keep asking the agents to open draft PRs first following the repo template and thought it would be a good addition

## :green_heart: How did you test it?
Manual

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
#skip-changelog