### PR TITLE
chore: Add error monitoring solution question to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -33,6 +33,25 @@ body:
         - 'sentry.io (SaS)'
         - 'on-premise (Self-Hosted)'
 
+  - type: dropdown
+    id: other_error_monitoring
+    validations:
+      required: true
+    attributes:
+      label: 'Are you using any other error monitoring solution alongside Sentry?'
+      description: 'Select exactly one option.'
+      options:
+        - "Yes"
+        - "No"
+
+  - type: input
+    id: other_error_monitoring_name
+    validations:
+      required: false
+    attributes:
+      label: 'Other Error Monitoring Solution Name'
+      description: "If you're using another error monitoring solution side-by-side, please enter the name of the other solution."
+
   - type: input
     id: version
     validations:


### PR DESCRIPTION
## Description

Adds a new dropdown and optional input field to the React Native bug report issue template asking users if they are using any other error monitoring solution alongside Sentry, and if so, which one.

## Motivation and Context

Other error monitoring SDKs can interfere with Sentry's error reporting in React Native apps. Knowing upfront whether a user has another solution installed helps triage bugs faster.

## How did you test it?

Reviewed the YAML template manually.

#skip-changelog