### PR TITLE
fix(core): Improve native init log message clarity

### DIFF
--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -141,9 +141,10 @@ export function init(passedOptions: ReactNativeOptions): void {
   };
 
   if (!('autoInitializeNativeSdk' in userOptions) && RN_GLOBAL_OBJ.__SENTRY_OPTIONS__) {
-    // We expect users to use the file options only in combination with manual native initialization
+    // Options file is present, native SDK is expected to be initialized
+    // before JS from the native app entry point (e.g. AppDelegate, MainApplication).
     // eslint-disable-next-line no-console
-    console.info('Initializing Sentry JS with the options file. Expecting manual native initialization before JS. Native will not be initialized automatically.');
+    console.info('[Sentry] Using options file. Native SDK is expected to be initialized before JS, skipping automatic native initialization from JS.');
     options.autoInitializeNativeSdk = false;
   }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

Improves the `console.info` message shown when `sentry.options.json` is detected and automatic native initialization is skipped from JS.

**Before:**
```
Initializing Sentry JS with the options file. Expecting manual native initialization before JS. Native will not be initialized automatically.
```

**After:**
```
[Sentry] Using options file. Native SDK is expected to be initialized before JS, skipping automatic native initialization from JS.
```

## :bulb: Motivation and Context

Fixes #5798

The previous message sounded like a warning that something was broken, causing users to think native init wasn't working. The new message clarifies this is the expected flow when using `useNativeInit: true` with the Expo plugin.

## :green_heart: How did you test it?

- Existing tests in `sdk.test.ts` pass (`initialization from sentry.options.json` suite)
- Reproduced locally with a fresh Expo project using `useNativeInit: true`

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps