### PR TITLE
Ref: remove yarn from stub update

### DIFF
--- a/scripts/update-android-stubs.sh
+++ b/scripts/update-android-stubs.sh
@@ -21,7 +21,6 @@ set-version)
     newValue="${BASH_REMATCH[1]}$2"
     echo "${content/${BASH_REMATCH[0]}/$newValue}" >$file
 
-cd android/replay-stubs && ./gradlew jar
     # Rebuild the stubs jar and JS types
     cd replay-stubs
     echo "Building Stub"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->

There are issues with calling yarn so since it only calls a one line script to build the stubs I replaced it with that.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix the stub build command

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
