### PR TITLE
fix(ci): Update Appium version to fix Sauce Labs metrics tests

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -167,7 +167,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Collect apps metrics
-        uses: getsentry/action-app-sdk-overhead-metrics@9396b8b69e780b763dbbe7c718fee2e35fee57e6
+        uses: getsentry/action-app-sdk-overhead-metrics@ecce2e2718b6d97ad62220fca05627900b061ed5
         with:
           name: ${{ matrix.name }} (${{ matrix.rn-architecture }})
           config: ./performance-tests/metrics-${{ matrix.platform }}.yml


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description

Updates `getsentry/action-app-sdk-overhead-metrics` to a commit that changes the Appium version from `stable` to `latest`. Sauce Labs removed the `stable` version, breaking all metrics tests.

This points to an unmerged commit from https://github.com/getsentry/action-app-sdk-overhead-metrics/pull/29 to verify the fix. Once that PR merges, we'll update the SHA to the merge commit.

## Motivation and Context

Fixes #5834

## How did you test it?

This PR itself is the test — the metrics CI jobs should pass with the updated action.