### PR TITLE
fix(android): Properly remove duplicated breadcrumbs

### DIFF
--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -868,18 +868,19 @@ public class RNSentryModuleImpl {
     final @NotNull Map<String, Object> serialized =
         InternalSentrySdk.serializeScope(context, (SentryAndroidOptions) options, currentScope);
 
-    if (serialized.containsKey("breadcrumbs")) {
-      final @Nullable var breadcrumbs = (List<Map<String, Object>>) serialized.get("breadcrumbs");
-      if (breadcrumbs != null) {
-        var filtered = new ArrayList<Map<String, Object>>();
-        for (Map<String, Object> b : breadcrumbs) {
-          if ("react-native".equals(b.getOrDefault("origin", ""))) {
-            continue;
+    final @Nullable Object serializedBreadcrumbs = serialized.get("breadcrumbs");
+    if (serializedBreadcrumbs instanceof List) {
+      final List<?> breadcrumbs = (List<?>) serializedBreadcrumbs;
+      List<Map<?, ?>> filtered = new ArrayList<>();
+      for (Object o : breadcrumbs) {
+        if (o instanceof Map) {
+          final Map<?, ?> breadcrumb = (Map<?, ?>) o;
+          if (!"react-native".equals(breadcrumb.get("origin"))) {
+            filtered.add(breadcrumb);
           }
-          filtered.add(b);
         }
-        serialized.put("breadcrumbs", filtered);
       }
+      serialized.put("breadcrumbs", filtered);
     }
 
     final @Nullable Object deviceContext = RNSentryMapConverter.convertToWritable(serialized);


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
This should fix duplicated breadcrumbs on Android.
- Sentry syncs breadcrumbs from JS and native
- In the past JS breadcrumbs was filtered out before sent to JS side
- This filter worked on iterator of native Scope and broke when Native Android SDK replaces raw Scope with some composite scope class which plays role of "view" to several downstream Scope objects
- This patch change filter to work on materialized breadcrumbs array just after serialization

## :bulb: Motivation and Context
We had duplicated breadcrumbs on Android.

## :green_heart: How did you test it?
We applied this patch with patch-package. After that our applications did not duplicate breadcrumbs.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
