### PR TITLE
chore(deps): bump fast-xml-parser to ^5.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@sentry-internal/eslint-config-sdk@npm:10.45.0/@typescript-eslint/parser": "^8.0.0",
     "eslint-plugin-ft-flow": "^3.0.0",
     "axios": "^1.13.5",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": "^5.5.7",
     "form-data": "4.0.5",
     "qs": "^6.14.2",
     "lodash": "^4.17.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20292,22 +20292,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-xml-builder@npm:1.0.0"
-  checksum: d6fb6d860ebb67c0dbec4c91a5cde3bf3e4cc40407db249539fe0d4e98e5c1bc09b3d45e5cbc412aaee8dd16605467f8c054c104fbccba23cf78ec15ff8767ab
+"fast-xml-builder@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "fast-xml-builder@npm:1.1.4"
+  dependencies:
+    path-expression-matcher: ^1.1.3
+  checksum: 90b019ed6f52cb30342a58d4bf8726a7723b4110cb9c0fd3fa2031e87506e8b18740fd349472926c9e2925d22ca6637b6d46a20eda537473cf63366970db4d7b
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^5.3.6":
-  version: 5.4.1
-  resolution: "fast-xml-parser@npm:5.4.1"
+"fast-xml-parser@npm:^5.5.7":
+  version: 5.5.8
+  resolution: "fast-xml-parser@npm:5.5.8"
   dependencies:
-    fast-xml-builder: ^1.0.0
-    strnum: ^2.1.2
+    fast-xml-builder: ^1.1.4
+    path-expression-matcher: ^1.2.0
+    strnum: ^2.2.0
   bin:
     fxparser: src/cli/cli.js
-  checksum: 98b8d2f208dea6be10740509e4ef59dc175584cfb29cb3f82849f0a79645ccaf40916589533029c30b4b47a78e744e8fc08ff468f214a231f450e51f0d8d32c6
+  checksum: 58261aaaeb355a325dc1b27ae28e6f8da55e9f8e0560dd752c8a39a4adbaebe560cbbfe924efb44ebf991dbdff76ae6f80a4900d1d03fd720509cb323263bf13
   languageName: node
   linkType: hard
 
@@ -28660,6 +28663,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.1.3, path-expression-matcher@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "path-expression-matcher@npm:1.2.0"
+  checksum: 2811aab3269c288893aef09e5127124d3c434bfc7e1352fea6b7dd81ed20260001b072ff60bdcaaa393d50a4333725290dbad47bb612d95f5448e499b4ac887f
+  languageName: node
+  linkType: hard
+
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -33000,10 +33010,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "strnum@npm:2.1.2"
-  checksum: 755e8327ee68201d700169ceee097ea52da7b675f4521442a8dbd1517021f89a91399213c446d1bf3d1123ca1896a76f0ff076d04c88ffe6056e78828ce6f60a
+"strnum@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "strnum@npm:2.2.1"
+  checksum: 23173b1b849859b9aca0288dde36d16095b07d81995de2e2fe29ae070f2e7b4933049f2e211ba03e48152a9281108ba7d4db826a3878f099bff52a3b81f5e273
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps the existing `fast-xml-parser` resolution from `^5.3.6` to `^5.5.7` to fix entity expansion bypass vulnerabilities.

Dev-only dependency.

https://github.com/getsentry/sentry-react-native/security/dependabot/454
https://github.com/getsentry/sentry-react-native/security/dependabot/456