### PR TITLE
Add better `needs_web` check to CI

### DIFF
--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -55,6 +55,9 @@ on:
       needs_sample_expo:
         description: 'Whether the Expo sample app workflow should run'
         value: ${{ jobs.changes.outputs.needs_sample_expo }}
+      needs_web:
+        description: 'Whether web jobs should run (sample builds)'
+        value: ${{ jobs.changes.outputs.needs_web }}
 
 jobs:
   changes:
@@ -74,6 +77,7 @@ jobs:
       needs_android: ${{ steps.evaluate.outputs.needs_android }}
       needs_sample_react_native: ${{ steps.evaluate.outputs.needs_sample_react_native }}
       needs_sample_expo: ${{ steps.evaluate.outputs.needs_sample_expo }}
+      needs_web: ${{ steps.evaluate.outputs.needs_web }}
     steps:
       - uses: actions/checkout@v4
 
@@ -167,4 +171,18 @@ jobs:
           else
             echo "needs_sample_expo=false" >> "$GITHUB_OUTPUT"
             echo "=> needs_sample_expo=false"
+          fi
+
+          # Web builds run when:
+          # - JS source changed (the web bundle depends on it)
+          # - CI config changed (need to validate workflows themselves)
+          # - Push to main or release branch (always run everything)
+          if [[ "$JS_SOURCE" == "true" \
+             || "$CI_CHANGED" == "true" \
+             || "$IS_MAIN_OR_RELEASE" == "true" ]]; then
+            echo "needs_web=true" >> "$GITHUB_OUTPUT"
+            echo "=> needs_web=true"
+          else
+            echo "needs_web=false" >> "$GITHUB_OUTPUT"
+            echo "=> needs_web=false"
           fi

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -73,9 +73,9 @@ jobs:
           elif [[ "${{ matrix.platform }}" == "android" && "${{ needs.detect-changes.outputs.needs_android }}" != "true" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipping Android — no relevant changes detected."
-          elif [[ "${{ matrix.platform }}" == "web" && "${{ needs.detect-changes.outputs.js_source }}" != "true" ]]; then
+          elif [[ "${{ matrix.platform }}" == "web" && "${{ needs.detect-changes.outputs.needs_web }}" != "true" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Skipping Web — no relevant JS changes detected."
+            echo "Skipping Web — no relevant changes detected."
           fi
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Recent changes to CI (https://github.com/getsentry/sentry-react-native/pull/5843) were merged with unclosed comment from Cursor (https://github.com/getsentry/sentry-react-native/pull/5843#discussion_r2974024906) saying that the `web` platform-check in `sample-application-expo.yml` only considers `js_source` to decide whether to skip which is not great because the `web` build could be incorrectly skipped. This PR fixes that .
## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
