### PR TITLE
Remove JSC support from CI

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -232,7 +232,7 @@ jobs:
         platform: ['android', 'ios']
         build-type: ['production']
         ios-use-frameworks: ['no', 'static', 'dynamic']
-        engine: ['hermes', 'jsc']
+        engine: ['hermes']
         include:
           # Use Xcode 16 for older RN versions
           - platform: ios
@@ -245,9 +245,6 @@ jobs:
           - platform: android
             runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
         exclude:
-          # exclude JSC for new RN versions (keeping the matrix manageable)
-          - rn-version: '0.84.0'
-            engine: 'jsc'
           # exclude all rn versions lower than 0.80.0 for new architecture
           - rn-version: '0.71.19'
             rn-architecture: 'new'


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
As we've recently verified, JSC is used in about 0,03% of all events we receive, and in addition it's being phased out and no longer used with React Native. Time to remove an extra job from our CI as well!

Fixes https://github.com/getsentry/sentry-react-native/issues/5768
Fixes https://github.com/getsentry/sentry-react-native/issues/5313

#skip-changelog

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
