### PR TITLE
fix(core): Always re-initialize native SDK from JS in dev builds

### DIFF
--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -140,9 +140,11 @@ export function init(passedOptions: ReactNativeOptions): void {
     initialScope: safeFactory(userOptions.initialScope, { loggerMessage: 'The initialScope threw an error' }),
   };
 
-  if (!('autoInitializeNativeSdk' in userOptions) && RN_GLOBAL_OBJ.__SENTRY_OPTIONS__) {
-    // Options file is present, native SDK is expected to be initialized
+  if (!('autoInitializeNativeSdk' in userOptions) && RN_GLOBAL_OBJ.__SENTRY_OPTIONS__ && !__DEV__) {
+    // Options file is present in a release build, native SDK is expected to be initialized
     // before JS from the native app entry point (e.g. AppDelegate, MainApplication).
+    // In dev builds, we always re-initialize from JS to set up the native log bridge
+    // and provide runtime values (devServerUrl, defaultSidecarUrl, etc.).
     // eslint-disable-next-line no-console
     console.info('[Sentry] Using options file. Native SDK is expected to be initialized before JS, skipping automatic native initialization from JS.');
     options.autoInitializeNativeSdk = false;

--- a/packages/core/test/sdk.test.ts
+++ b/packages/core/test/sdk.test.ts
@@ -135,10 +135,34 @@ describe('Tests the SDK functionality', () => {
         expect(usedOptions()?.dsn).toBe('https://key@example.io/code');
       });
 
-      it('initializing with __SENTRY_OPTIONS__ disabled native auto initialization', () => {
-        RN_GLOBAL_OBJ.__SENTRY_OPTIONS__ = {};
-        init({});
-        expect(usedOptions()?.autoInitializeNativeSdk).toBe(false);
+      it('does not disable native auto initialization in dev builds even with __SENTRY_OPTIONS__', () => {
+        // @ts-expect-error __DEV__ is a global
+        const originalDev = globalThis.__DEV__;
+        // @ts-expect-error __DEV__ is a global
+        globalThis.__DEV__ = true;
+        try {
+          RN_GLOBAL_OBJ.__SENTRY_OPTIONS__ = {};
+          init({});
+          expect(usedOptions()?.autoInitializeNativeSdk).toBe(true);
+        } finally {
+          // @ts-expect-error __DEV__ is a global
+          globalThis.__DEV__ = originalDev;
+        }
+      });
+
+      it('disables native auto initialization in release builds with __SENTRY_OPTIONS__', () => {
+        // @ts-expect-error __DEV__ is a global
+        const originalDev = globalThis.__DEV__;
+        // @ts-expect-error __DEV__ is a global
+        globalThis.__DEV__ = false;
+        try {
+          RN_GLOBAL_OBJ.__SENTRY_OPTIONS__ = {};
+          init({});
+          expect(usedOptions()?.autoInitializeNativeSdk).toBe(false);
+        } finally {
+          // @ts-expect-error __DEV__ is a global
+          globalThis.__DEV__ = originalDev;
+        }
       });
 
       it('initializing without __SENTRY_OPTIONS__ enables native auto initialization', () => {
@@ -155,7 +179,7 @@ describe('Tests the SDK functionality', () => {
         expect(usedOptions()?.autoInitializeNativeSdk).toBe(true);
       });
 
-      it('initializing with __SENTRY_OPTIONS__ keeps native auto initialization false if set', () => {
+      it('respects explicit autoInitializeNativeSdk false even with __SENTRY_OPTIONS__', () => {
         RN_GLOBAL_OBJ.__SENTRY_OPTIONS__ = {};
         init({
           autoInitializeNativeSdk: false,


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

When `sentry.options.json` exists (generated by the Expo config plugin with `useNativeInit: true` and `options`), the Metro serializer injects `__SENTRY_OPTIONS__` into the JS bundle. The SDK then sets `autoInitializeNativeSdk = false`, skipping the JS-side `initNativeSdk` call entirely.

This prevents the native log bridge (`rnLogger.setReactContext`) and runtime values (`devServerUrl`, `defaultSidecarUrl`, `mobileReplayOptions`) from being configured, resulting in **zero envelopes being sent** to sentry.io in development builds.

The fix adds a `!__DEV__` guard so that:
- **Dev builds**: JS always calls `initNativeSdk`, which re-initializes native (the native SDK handles this gracefully: `"Sentry has been already initialized. Previous configuration will be overwritten."`). The log bridge and runtime values are properly set up.
- **Release builds**: Behavior is preserved — `autoInitializeNativeSdk = false` keeps the native-only init for app start crash capture.

## :bulb: Motivation and Context

Closes #5734

**Reproduction**: With `sentry.options.json` in the project root, the Expo sample sends zero envelopes to sentry.io (events only appear in Spotlight). Without the file, everything works — JS re-initializes native and envelopes are sent successfully.

The root cause: when `autoInitializeNativeSdk = false`, the JS wrapper's `initNativeSdk` returns early at line 250-257 without ever calling `RNSentry.initNativeSdk()`. The native module never receives the JS options, the React context isn't set on the logger, and `captureEnvelope` calls from JS don't result in envelopes being delivered.

## :green_heart: How did you test it?

1. **Unit tests**: Added tests for both `__DEV__=true` and `__DEV__=false` modes, verifying `autoInitializeNativeSdk` is set correctly in each case
2. **On-device verification** (Android emulator):
   - Created `sentry.options.json` in the Expo sample project root
   - **Before fix**: `didCallNativeInit: false`, zero `Envelope sent successfully` in logs
   - **After fix**: `didCallNativeInit: true`, multiple `Envelope sent successfully.` in logs
3. **All 1172 existing tests pass**, build and lint clean

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog since this only affects the development workflow