### PR TITLE
chore: bump action-app-sdk-overhead-metrics SHA

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -205,7 +205,7 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Collect apps metrics
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        uses: getsentry/action-app-sdk-overhead-metrics@ecce2e2718b6d97ad62220fca05627900b061ed5
+        uses: getsentry/action-app-sdk-overhead-metrics@44fb5489ac4ac252c87d84811972dc93a1e490b8
         with:
           name: ${{ matrix.name }} (${{ matrix.rn-architecture }})
           config: ./performance-tests/metrics-${{ matrix.platform }}.yml


### PR DESCRIPTION
## Description

Bump `getsentry/action-app-sdk-overhead-metrics` to `44fb5489ac4ac252c87d84811972dc93a1e490b8`.

This improves the workflow iteration to filter on the backend instead of locally, which should reduce flakiness when downloading previous data.

See: https://github.com/getsentry/action-app-sdk-overhead-metrics/pull/30

#skip-changelog