### PR TITLE
fix(build): Update expo-handler sentry-android version in update script

### DIFF
--- a/scripts/update-android.sh
+++ b/scripts/update-android.sh
@@ -27,6 +27,12 @@ set-version)
     newContent=$(echo "$newContent" | sed -E "s/(io\.sentry:sentry-spotlight:)([0-9\.]+)/\1$2/g")
     echo "$newContent" >$file
 
+    # Update expo-handler to match
+    expoHandlerFile='expo-handler/build.gradle'
+    expoHandlerContent=$(cat $expoHandlerFile)
+    expoHandlerContent=$(echo "$expoHandlerContent" | sed -E "s/(io\.sentry:sentry-android:)([0-9\.]+)/\1$2/g")
+    echo "$expoHandlerContent" >$expoHandlerFile
+
     # Update replay-stubs to match
     cd $ORIGINAL_DIR
     ./update-android-stubs.sh set-version $2


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

The `scripts/update-android.sh` script now also updates the `sentry-android` dependency in `packages/core/android/expo-handler/build.gradle` when bumping the Android SDK version.

## :bulb: Motivation and Context

[The expo-handler `build.gradle`](https://github.com/getsentry/sentry-react-native/blob/main/packages/core/android/expo-handler/build.gradle) was not being updated by the automation script, causing version mismatches on every Android SDK bump (e.g. #5884).

## :green_heart: How did you test it?

Ran `scripts/update-android.sh set-version 8.36.0` locally and verified the expo-handler `build.gradle` was updated.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Once merged, re-trigger the Android SDK bump PR (#5884) so the expo-handler version is included.