### PR TITLE
chore(deps): bump yaml to ^2.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
     "@expo/cli@npm:55.0.15/picomatch": "^4.0.4",
     "@expo/metro-config@npm:55.0.9/picomatch": "^4.0.4",
     "npm-run-all2@npm:8.0.4/picomatch": "^4.0.4",
-    "tinyglobby@npm:0.2.15/picomatch": "^4.0.4"
+    "tinyglobby@npm:0.2.15/picomatch": "^4.0.4",
+    "yaml": "^2.8.3"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34826,21 +34826,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:2.8.2, yaml@npm:^2.6.1":
-  version: 2.8.2
-  resolution: "yaml@npm:2.8.2"
+"yaml@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "yaml@npm:2.8.3"
   bin:
     yaml: bin.mjs
-  checksum: 5ffd9f23bc7a450129cbd49dcf91418988f154ede10c83fd28ab293661ac2783c05da19a28d76a22cbd77828eae25d4bd7453f9a9fe2d287d085d72db46fd105
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^2.2.1, yaml@npm:^2.2.2":
-  version: 2.5.0
-  resolution: "yaml@npm:2.5.0"
-  bin:
-    yaml: bin.mjs
-  checksum: a116dca5c61641d9bf1f1016c6e71daeb1ed4915f5930ed237d45ab7a605aa5d92c332ff64879a6cd088cabede008c778774e3060ffeb4cd617d28088e4b2d83
+  checksum: 6e33fa9a8a31a8ed7472fbafc83e587956611594ca6ae4dbc1ab0c8a3ad4f6ff061a9842ca34bbb2e7affa9df93322cf0d132fd34338bec308d984495432c905
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Unscoped resolution to bump yaml from 2.5.0/2.8.2 to 2.8.3, fixing stack overflow via deeply nested YAML collections.

Dev-only dependency.

https://github.com/getsentry/sentry-react-native/security/dependabot/476