### PR TITLE
chore(deps): bump activesupport to >= 7.2.3.1

### DIFF
--- a/performance-tests/TestAppPlain/Gemfile
+++ b/performance-tests/TestAppPlain/Gemfile
@@ -5,7 +5,7 @@ ruby ">= 2.6.10"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.2.3.1', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'
 

--- a/performance-tests/TestAppSentry/Gemfile
+++ b/performance-tests/TestAppSentry/Gemfile
@@ -5,7 +5,7 @@ ruby ">= 2.6.10"
 
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
-gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'activesupport', '>= 7.2.3.1', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'
 


### PR DESCRIPTION
Raises the minimum activesupport version in performance test Gemfiles from `>= 6.1.7.5` to `>= 7.2.3.1` to fix XSS, ReDoS, and DoS vulnerabilities.

Affects `performance-tests/TestAppPlain/Gemfile` and `performance-tests/TestAppSentry/Gemfile` only.

https://github.com/getsentry/sentry-react-native/security/dependabot/464
https://github.com/getsentry/sentry-react-native/security/dependabot/465
https://github.com/getsentry/sentry-react-native/security/dependabot/466
https://github.com/getsentry/sentry-react-native/security/dependabot/467
https://github.com/getsentry/sentry-react-native/security/dependabot/468
https://github.com/getsentry/sentry-react-native/security/dependabot/469