### PR TITLE
fix(ci): Avoid unnecessary runner allocation by splitting platform matrix into separate jobs

### DIFF
--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -71,14 +71,6 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 1 # cache the installed gems
 
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
-
       - name: Setup Global Xcode Tools
         run: which xcbeautify || brew install xcbeautify
 
@@ -90,7 +82,7 @@ jobs:
 
       - name: Prebuild apps
         working-directory: samples/expo
-        run: npx expo prebuild
+        run: npx expo prebuild --platform ios
 
       - name: Install App Pods
         working-directory: samples/expo/ios
@@ -131,7 +123,7 @@ jobs:
       - name: Export Expo
         working-directory: samples/expo
         run: |
-          npx expo export
+          npx expo export -p ios
 
       - name: Upload logs
         if: ${{ always() }}
@@ -185,7 +177,7 @@ jobs:
 
       - name: Prebuild apps
         working-directory: samples/expo
-        run: npx expo prebuild
+        run: npx expo prebuild --platform android
 
       - name: Build Android App
         working-directory: samples/expo/android
@@ -200,7 +192,7 @@ jobs:
       - name: Export Expo
         working-directory: samples/expo
         run: |
-          npx expo export
+          npx expo export -p android
 
       - name: Upload logs
         if: ${{ always() }}
@@ -244,8 +236,3 @@ jobs:
         working-directory: samples/expo
         run: |
           npx expo export -p web
-
-      - name: Export Expo
-        working-directory: samples/expo
-        run: |
-          npx expo export

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -83,14 +83,6 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 1 # cache the installed gems
 
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
-
       - name: Setup Global Xcode Tools
         run: which xcbeautify || brew install xcbeautify
 
@@ -181,7 +173,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
 
       - name: Install SDK Dependencies
         run: yarn install
@@ -257,14 +249,6 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 1 # cache the installed gems
 
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'adopt'
-
-      - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
-
       - name: Setup Global Xcode Tools
         run: which xcbeautify || brew install xcbeautify
 
@@ -305,7 +289,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: build-sample-legacy-macos-${{ matrix.build-type }}-no-frameworks-logs
-          path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/macos/*.log
+          path: samples/react-native-macos/macos/*.log
 
   test-ios:
     name: Test ios production REV2


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Fixes https://github.com/getsentry/sentry-react-native/issues/5864

Updates runners in `sample-application.yaml` and `sample-application-expo.yaml` to not allocate any runners when the job is skipped. It also eliminates any need in `platform-check` — skip logic now moved to job-level if. The main benefit is cost savings — when a platform is skipped (e.g., a PR only touches Android native code), the iOS and web jobs won't allocate runners at all. The functional behavior is identical to how it was before.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes