### PR TITLE
refactor(core): Extract playground modal styles to separate file

### DIFF
--- a/packages/core/src/js/playground/modal.styles.ts
+++ b/packages/core/src/js/playground/modal.styles.ts
@@ -1,0 +1,141 @@
+import { StyleSheet } from 'react-native';
+
+export const defaultDarkStyles = StyleSheet.create({
+  welcomeText: { color: 'rgb(246, 245, 250)', fontSize: 24, fontWeight: 'bold' },
+  background: {
+    flex: 1,
+    backgroundColor: 'rgb(26, 20, 31)',
+    width: '100%',
+    minHeight: '100%',
+    alignItems: 'center', // Center content horizontally
+    justifyContent: 'center', // Center content vertically
+  },
+  container: {
+    flex: 1,
+    flexDirection: 'column',
+    padding: 12,
+    marginTop: 20,
+    width: '100%',
+    alignItems: 'center', // Center image and button container
+    justifyContent: 'space-evenly', // Center image and button container
+  },
+  buttonContainer: {
+    flexDirection: 'row', // Arrange buttons horizontally
+    marginTop: 20, // Add some space above the buttons
+  },
+  listContainer: {
+    backgroundColor: 'rgb(39, 36, 51)',
+    width: '100%',
+    flexDirection: 'column',
+    marginTop: 20, // Add some space above the buttons
+    borderColor: 'rgb(7, 5, 15)',
+    borderWidth: 1,
+    borderRadius: 8,
+  },
+  rowTitle: {
+    color: 'rgb(246, 245, 250)',
+    fontSize: 14,
+    fontWeight: 'bold',
+    textAlign: 'left',
+    fontFamily: 'Menlo',
+  },
+  rowContainer: {
+    overflow: 'hidden',
+    flexDirection: 'row',
+    justifyContent: 'space-between', // Space between buttons
+    paddingTop: 16,
+    paddingBottom: 10,
+    paddingHorizontal: 10,
+    borderColor: 'rgb(7, 5, 15)',
+    borderBottomWidth: 1,
+  },
+  lastRowContainer: {
+    borderBottomWidth: 0, // Remove border for the last row
+  },
+  buttonCommon: {
+    borderRadius: 8,
+  },
+  buttonBottomLayer: {
+    backgroundColor: 'rgb(7, 5, 15)',
+  },
+  buttonMainContainer: {
+    paddingVertical: 8,
+    paddingHorizontal: 13,
+    backgroundColor: 'rgb(117, 83, 255)',
+    transform: [{ translateY: -4 }],
+    borderWidth: 1,
+    borderColor: 'rgb(7, 5, 15)',
+  },
+  buttonSecondaryContainer: {
+    backgroundColor: 'rgb(39, 36, 51)',
+  },
+  buttonSecondaryBottomLayer: {},
+  buttonSecondaryText: {},
+  buttonMainContainerPressed: {
+    transform: [{ translateY: 0 }],
+  },
+  buttonText: {
+    color: 'rgb(246, 245, 250)',
+    fontSize: 16,
+    fontWeight: 'bold',
+    textAlign: 'center',
+  },
+  buttonDisabledText: {
+    color: 'rgb(146, 130, 170)',
+  },
+  buttonDisabledContainer: {
+    transform: [{ translateY: -2 }],
+    backgroundColor: 'rgb(39, 36, 51)',
+  },
+});
+
+export const lightStyles: typeof defaultDarkStyles = StyleSheet.create({
+  ...defaultDarkStyles,
+  welcomeText: {
+    ...defaultDarkStyles.welcomeText,
+    color: 'rgb(24, 20, 35)',
+  },
+  background: {
+    ...defaultDarkStyles.background,
+    backgroundColor: 'rgb(251, 250, 255)',
+  },
+  buttonMainContainer: {
+    ...defaultDarkStyles.buttonMainContainer,
+    backgroundColor: 'rgb(117, 83, 255)',
+    borderColor: 'rgb(85, 61, 184)',
+  },
+  buttonBottomLayer: {
+    backgroundColor: 'rgb(85, 61, 184)',
+  },
+  buttonSecondaryContainer: {
+    backgroundColor: 'rgb(255, 255, 255)',
+    borderColor: 'rgb(218, 215, 229)',
+  },
+  buttonSecondaryBottomLayer: {
+    backgroundColor: 'rgb(218, 215, 229)',
+  },
+  buttonText: {
+    ...defaultDarkStyles.buttonText,
+  },
+  buttonSecondaryText: {
+    ...defaultDarkStyles.buttonText,
+    color: 'rgb(24, 20, 35)',
+  },
+  rowTitle: {
+    ...defaultDarkStyles.rowTitle,
+    color: 'rgb(24, 20, 35)',
+  },
+  rowContainer: {
+    ...defaultDarkStyles.rowContainer,
+    borderColor: 'rgb(218, 215, 229)',
+  },
+  listContainer: {
+    ...defaultDarkStyles.listContainer,
+    borderColor: 'rgb(218, 215, 229)',
+    backgroundColor: 'rgb(255, 255, 255)',
+  },
+  buttonDisabledContainer: {
+    ...defaultDarkStyles.buttonDisabledContainer,
+    backgroundColor: 'rgb(238, 235, 249)',
+  },
+});

--- a/packages/core/src/js/playground/modal.tsx
+++ b/packages/core/src/js/playground/modal.tsx
@@ -1,13 +1,13 @@
-/* oxlint-disable eslint(max-lines) */
 import { debug } from '@sentry/core';
 import * as React from 'react';
-import { Animated, Image, Modal, Platform, Pressable, StyleSheet, Text, useColorScheme, View } from 'react-native';
+import { Animated, Image, Modal, Platform, Pressable, Text, useColorScheme, View } from 'react-native';
 
 import { getDevServer } from '../integrations/debugsymbolicatorutils';
 import { isExpo, isExpoGo, isWeb } from '../utils/environment';
 import { bug as bugAnimation, hi as hiAnimation, thumbsup as thumbsupAnimation } from './animations';
 import { nativeCrashExample, tryCatchExample, uncaughtErrorExample } from './examples';
 import { bug as bugImage, hi as hiImage, thumbsup as thumbsupImage } from './images';
+import { defaultDarkStyles, lightStyles } from './modal.styles';
 
 /**
  * Wrapper to add Sentry Playground to your application
@@ -269,146 +269,6 @@ const Button = ({
     </View>
   );
 };
-
-const defaultDarkStyles = StyleSheet.create({
-  welcomeText: { color: 'rgb(246, 245, 250)', fontSize: 24, fontWeight: 'bold' },
-  background: {
-    flex: 1,
-    backgroundColor: 'rgb(26, 20, 31)',
-    width: '100%',
-    minHeight: '100%',
-    alignItems: 'center', // Center content horizontally
-    justifyContent: 'center', // Center content vertically
-  },
-  container: {
-    flex: 1,
-    flexDirection: 'column',
-    padding: 12,
-    marginTop: 20,
-    width: '100%',
-    alignItems: 'center', // Center image and button container
-    justifyContent: 'space-evenly', // Center image and button container
-  },
-  buttonContainer: {
-    flexDirection: 'row', // Arrange buttons horizontally
-    marginTop: 20, // Add some space above the buttons
-  },
-  listContainer: {
-    backgroundColor: 'rgb(39, 36, 51)',
-    width: '100%',
-    flexDirection: 'column',
-    marginTop: 20, // Add some space above the buttons
-    borderColor: 'rgb(7, 5, 15)',
-    borderWidth: 1,
-    borderRadius: 8,
-  },
-  rowTitle: {
-    color: 'rgb(246, 245, 250)',
-    fontSize: 14,
-    fontWeight: 'bold',
-    textAlign: 'left',
-    fontFamily: 'Menlo',
-  },
-  rowContainer: {
-    overflow: 'hidden',
-    flexDirection: 'row',
-    justifyContent: 'space-between', // Space between buttons
-    paddingTop: 16,
-    paddingBottom: 10,
-    paddingHorizontal: 10,
-    borderColor: 'rgb(7, 5, 15)',
-    borderBottomWidth: 1,
-  },
-  lastRowContainer: {
-    borderBottomWidth: 0, // Remove border for the last row
-  },
-  buttonCommon: {
-    borderRadius: 8,
-  },
-  buttonBottomLayer: {
-    backgroundColor: 'rgb(7, 5, 15)',
-  },
-  buttonMainContainer: {
-    paddingVertical: 8,
-    paddingHorizontal: 13,
-    backgroundColor: 'rgb(117, 83, 255)',
-    transform: [{ translateY: -4 }],
-    borderWidth: 1,
-    borderColor: 'rgb(7, 5, 15)',
-  },
-  buttonSecondaryContainer: {
-    backgroundColor: 'rgb(39, 36, 51)',
-  },
-  buttonSecondaryBottomLayer: {},
-  buttonSecondaryText: {},
-  buttonMainContainerPressed: {
-    transform: [{ translateY: 0 }],
-  },
-  buttonText: {
-    color: 'rgb(246, 245, 250)',
-    fontSize: 16,
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-  buttonDisabledText: {
-    color: 'rgb(146, 130, 170)',
-  },
-  buttonDisabledContainer: {
-    transform: [{ translateY: -2 }],
-    backgroundColor: 'rgb(39, 36, 51)',
-  },
-});
-
-const lightStyles: typeof defaultDarkStyles = StyleSheet.create({
-  ...defaultDarkStyles,
-  welcomeText: {
-    ...defaultDarkStyles.welcomeText,
-    color: 'rgb(24, 20, 35)',
-  },
-  background: {
-    ...defaultDarkStyles.background,
-    backgroundColor: 'rgb(251, 250, 255)',
-  },
-  buttonMainContainer: {
-    ...defaultDarkStyles.buttonMainContainer,
-    backgroundColor: 'rgb(117, 83, 255)',
-    borderColor: 'rgb(85, 61, 184)',
-  },
-  buttonBottomLayer: {
-    backgroundColor: 'rgb(85, 61, 184)',
-  },
-  buttonSecondaryContainer: {
-    backgroundColor: 'rgb(255, 255, 255)',
-    borderColor: 'rgb(218, 215, 229)',
-  },
-  buttonSecondaryBottomLayer: {
-    backgroundColor: 'rgb(218, 215, 229)',
-  },
-  buttonText: {
-    ...defaultDarkStyles.buttonText,
-  },
-  buttonSecondaryText: {
-    ...defaultDarkStyles.buttonText,
-    color: 'rgb(24, 20, 35)',
-  },
-  rowTitle: {
-    ...defaultDarkStyles.rowTitle,
-    color: 'rgb(24, 20, 35)',
-  },
-  rowContainer: {
-    ...defaultDarkStyles.rowContainer,
-    borderColor: 'rgb(218, 215, 229)',
-  },
-  listContainer: {
-    ...defaultDarkStyles.listContainer,
-    borderColor: 'rgb(218, 215, 229)',
-    backgroundColor: 'rgb(255, 255, 255)',
-  },
-  buttonDisabledContainer: {
-    ...defaultDarkStyles.buttonDisabledContainer,
-    backgroundColor: 'rgb(238, 235, 249)',
-  },
-});
 
 function openURLInBrowser(url: string): void {
   const devServer = getDevServer();


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description

Extract `StyleSheet.create` definitions from `playground/modal.tsx` into a new `playground/modal.styles.ts` file. This brings the file from 427 lines down to 287 — under the `max-lines` limit of 300 — and removes the `oxlint-disable` for `max-lines`.

No logic changes, only moving style definitions to a separate file.

## :bulb: Motivation and Context

Follow-up from [#5867 review comment](https://github.com/getsentry/sentry-react-native/pull/5867#discussion_r3001311204) suggesting the file could be refactored instead of keeping the `max-lines` disable.

## :green_heart: How did you test it?

- `yarn build` passes
- All 1179 tests pass (103 suites)
- `oxlint` reports 0 errors, 0 warnings
- `oxfmt --check` passes

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps