### PR TITLE
docs(core): Add changelog for supabase PostgREST nullish response fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixes
 
+- Fix crash caused by nullish response in supabase PostgREST handler ([#5938](https://github.com/getsentry/sentry-react-native/pull/5938))
 - Fix iOS crash (EXC_BAD_ACCESS) in time-to-initial-display when navigating between screens ([#5887](https://github.com/getsentry/sentry-react-native/pull/5887))
 
 ### Dependencies


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Adds a changelog entry for the supabase PostgREST nullish response fix that was included in the JavaScript SDK v10.47.0 bump ([#5938](https://github.com/getsentry/sentry-react-native/pull/5938)).

The fix guards a nullish `res` before accessing `res.error` in `instrumentPostgRESTFilterBuilder`, which caused crashes in React Native.

- Upstream fix: [getsentry/sentry-javascript#20033](https://github.com/getsentry/sentry-javascript/pull/20033)
- Upstream issue: [getsentry/sentry-javascript#20032](https://github.com/getsentry/sentry-javascript/issues/20032)

## :bulb: Motivation and Context

The fix is RN-specific (the nullish response only happens in React Native environments), so it deserves a changelog callout.

## :green_heart: How did you test it?

Changelog only.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps