### PR TITLE
chore(deps): bump @xmldom/xmldom to fix XML injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "See: https://github.com/appium/appium-chromedriver/pull/424"
   ],
   "resolutions": {
-    "appium-chromedriver@npm:8.2.19/@xmldom/xmldom": "0.8.10",
+    "appium-chromedriver@npm:8.2.19/@xmldom/xmldom": "0.8.12",
     "@istanbuljs/load-nyc-config@npm:1.1.0/js-yaml": "^3.14.2",
     "@yarnpkg/parsers@npm:3.0.0-rc.46/js-yaml": "^3.14.2",
     "cosmiconfig@npm:5.2.1/js-yaml": "^3.14.2",
@@ -115,7 +115,13 @@
     "minimatch@npm:10.2.4/brace-expansion": "^5.0.5",
     "@appium/base-driver@npm:10.2.2/path-to-regexp": "^8.4.0",
     "router@npm:2.2.0/path-to-regexp": "^8.4.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "@expo/plist@npm:0.1.3/@xmldom/xmldom": "^0.8.12",
+    "@expo/plist@npm:0.3.4/@xmldom/xmldom": "^0.8.12",
+    "@expo/plist@npm:0.5.2/@xmldom/xmldom": "^0.8.12",
+    "plist@npm:3.1.0/@xmldom/xmldom": "^0.8.12",
+    "appium-ios-remotexpc@npm:0.36.0/@xmldom/xmldom": "^0.9.9",
+    "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.9"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12121,31 +12121,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:0.8.10, @xmldom/xmldom@npm:^0.8.8":
-  version: 0.8.10
-  resolution: "@xmldom/xmldom@npm:0.8.10"
-  checksum: 4c136aec31fb3b49aaa53b6fcbfe524d02a1dc0d8e17ee35bd3bf35e9ce1344560481cd1efd086ad1a4821541482528672306d5e37cdbd187f33d7fadd3e2cf0
+"@xmldom/xmldom@npm:0.8.12, @xmldom/xmldom@npm:^0.8.12":
+  version: 0.8.12
+  resolution: "@xmldom/xmldom@npm:0.8.12"
+  checksum: 609bbcd6f31fa24023f5cc836e804d49c60e3df83ca73f744da9caff7fed516221dcf2f23de44e5289d715951781ec35fa90adf57008c3eae944a7550c39e325
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.9.8":
-  version: 0.9.8
-  resolution: "@xmldom/xmldom@npm:0.9.8"
-  checksum: f8d16ad3c8083312575850fa4f2c13a2b884a37021dbb0146c6b2575bd3ddbf4c900530b49a55a7f62088ecf9809173fd7138985e7e58ddab786578970e09c59
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:^0.x":
-  version: 0.9.0
-  resolution: "@xmldom/xmldom@npm:0.9.0"
-  checksum: a6352e40c248f052dacefd30c8c287721eb94341f7b4f50cf0378726ae4dd2247a95e858e5914a3a85355fef884711bda4615980fbca6d98eaf2843d4d8dc5a2
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:~0.7.7":
-  version: 0.7.13
-  resolution: "@xmldom/xmldom@npm:0.7.13"
-  checksum: b4054078530e5fa8ede9677425deff0fce6d965f4c477ca73f8490d8a089e60b8498a15560425a1335f5ff99ecb851ed2c734b0a9a879299a5694302f212f37a
+"@xmldom/xmldom@npm:^0.9.9":
+  version: 0.9.9
+  resolution: "@xmldom/xmldom@npm:0.9.9"
+  checksum: 73bd69379f70b29cdef742eb834c299ef13268e9ce42ea6384a78ade1083c3e0c71c764019d3c8d860a76147c6c84b4cba5e6e5b2123ed2cd806d8621c4c9559
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Scoped resolutions to patch @xmldom/xmldom XML injection via unsafe CDATA serialization:
- 0.8.x consumers (expo/plist, plist, appium-chromedriver): → 0.8.12
- 0.9.x consumers (appium-ios-remotexpc, appium-ios-simulator): → 0.9.9

Dev-only dependencies.

https://github.com/getsentry/sentry-react-native/security/dependabot/488
https://github.com/getsentry/sentry-react-native/security/dependabot/489