### PR TITLE
fix(ci): Bump Node to 22 in size-analysis and testflight workflows

### DIFF
--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           package-manager-cache: false
-          node-version: 18
+          node-version: 22
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           package-manager-cache: false
-          node-version: 18
+          node-version: 22
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           package-manager-cache: false
-          node-version: 18
+          node-version: 22
           cache: 'yarn'
           cache-dependency-path: yarn.lock
       - name: Install Dependencies


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

Bump `node-version` from 18 to 22 in `size-analysis.yml` and `testflight.yml` workflows.

These two workflows build the RN sample app but were missed in the RN 0.84.1 bump PR (#5941), which only updated `sample-application.yml` and `buildandtest.yml`.

## :bulb: Motivation and Context

RN 0.84.1 ships `metro-config@0.82.2` which uses `Array.prototype.toReversed()` — a method not available in Node 18. This causes both workflows to fail with:

```
TypeError: configs.toReversed is not a function
```

Failing runs:
- [Size Analysis](https://github.com/getsentry/sentry-react-native/actions/runs/23903493398/job/69710695805)
- [Testflight](https://github.com/getsentry/sentry-react-native/actions/runs/23903493488/job/69711457595)

## :green_heart: How did you test it?

CI will validate — the failing workflows should pass with this change.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps