### PR TITLE
chore: Bump sample app to React Native 0.85.1

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -227,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.71.19', '0.85.0']
+        rn-version: ['0.71.19', '0.84.0']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -240,7 +240,7 @@ jobs:
             runs-on: ["ghcr.io/cirruslabs/macos-sequoia-xcode:16.4", "runner_group_id:10"]
           # Use Xcode 26 for newer RN versions (0.83.0)
           - platform: ios
-            rn-version: '0.85.0'
+            rn-version: '0.84.0'
             runs-on: ["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]
           - platform: android
             runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
@@ -383,7 +383,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.85.0']
+        rn-version: ['0.84.0']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -391,7 +391,7 @@ jobs:
         engine: ['hermes']
         include:
           - platform: ios
-            rn-version: '0.85.0'
+            rn-version: '0.84.0'
             runs-on: ["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]
           - platform: android
             runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -227,7 +227,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.71.19', '0.84.0']
+        rn-version: ['0.71.19', '0.85.0']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -240,7 +240,7 @@ jobs:
             runs-on: ["ghcr.io/cirruslabs/macos-sequoia-xcode:16.4", "runner_group_id:10"]
           # Use Xcode 26 for newer RN versions (0.83.0)
           - platform: ios
-            rn-version: '0.84.0'
+            rn-version: '0.85.0'
             runs-on: ["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]
           - platform: android
             runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
@@ -383,7 +383,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ['0.84.0']
+        rn-version: ['0.85.0']
         rn-architecture: ['legacy', 'new']
         platform: ['android', 'ios']
         build-type: ['production']
@@ -391,7 +391,7 @@ jobs:
         engine: ['hermes']
         include:
           - platform: ios
-            rn-version: '0.84.0'
+            rn-version: '0.85.0'
             runs-on: ["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]
           - platform: android
             runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]

--- a/samples/react-native/android/build.gradle
+++ b/samples/react-native/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.1.20"
     }
     repositories {
         google()

--- a/samples/react-native/android/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/react-native/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/react-native/jest.config.js
+++ b/samples/react-native/jest.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
-  preset: 'react-native',
+  preset: '@react-native/jest-preset',
   testMatch: [
     '<rootDir>/__tests__/**/*-test.ts',
     '<rootDir>/__tests__/**/*-test.tsx',

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -61,7 +61,7 @@
     "react-native-reanimated": "4.3.0",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-screens": "^4.13.1",
-    "react-native-svg": "^15.12.1",
+    "react-native-svg": "^15.15.4",
     "react-native-webview": "^13.15.0",
     "react-native-worklets": "0.8.1",
     "react-redux": "^9.2.0",

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@react-native-vector-icons/ionicons": "^12.3.0",
-    "@react-native/new-app-screen": "0.84.1",
+    "@react-native/new-app-screen": "0.85.1",
     "@react-navigation/bottom-tabs": "^7.4.5",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.24",
@@ -53,7 +53,7 @@
     "@shopify/flash-list": "^2.0.2",
     "delay": "^6.0.0",
     "react": "19.2.3",
-    "react-native": "0.84.1",
+    "react-native": "0.85.1",
     "react-native-build-config": "^0.3.2",
     "react-native-gesture-handler": "^2.28.0",
     "react-native-image-picker": "^8.2.1",
@@ -74,9 +74,10 @@
     "@react-native-community/cli": "20.1.0",
     "@react-native-community/cli-platform-android": "20.1.0",
     "@react-native-community/cli-platform-ios": "20.1.0",
-    "@react-native/babel-preset": "0.84.1",
-    "@react-native/metro-config": "0.84.1",
-    "@react-native/typescript-config": "0.84.1",
+    "@react-native/babel-preset": "0.85.1",
+    "@react-native/jest-preset": "0.85.1",
+    "@react-native/metro-config": "0.85.1",
+    "@react-native/typescript-config": "0.85.1",
     "@sentry/babel-plugin-component-annotate": "5.2.0",
     "@testing-library/react-native": "^13.2.2",
     "@types/jest": "^29.5.14",
@@ -91,7 +92,7 @@
     "react-test-renderer": "19.2.3",
     "sentry-react-native-samples-utils": "workspace:^",
     "ts-jest": "^29.3.1",
-    "typescript": "5.0.4"
+    "typescript": "5.8.3"
   },
   "engines": {
     "node": ">=22.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9285,10 +9285,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/assets-registry@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/assets-registry@npm:0.84.1"
-  checksum: 1d5eef3d5b1090261c6adeccc04d6c975be487f0f9558a134975cb9d79186a54abac395f79d69a9a79ec27a6b87ead4b1c0b35f8a4fa2f59d1a7aec0efdec3fc
+"@react-native/assets-registry@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/assets-registry@npm:0.85.1"
+  checksum: d8544ef934183d8e873950af228d76bf7fd48a14562d8d5cb97866ec0da1e2b0b2c2580b640b97e0487266a3f7498b7225e75a8d4d96aa0cb395285136cf74cf
   languageName: node
   linkType: hard
 
@@ -9351,13 +9351,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/babel-plugin-codegen@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/babel-plugin-codegen@npm:0.84.1"
+"@react-native/babel-plugin-codegen@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/babel-plugin-codegen@npm:0.85.1"
   dependencies:
-    "@babel/traverse": ^7.25.3
-    "@react-native/codegen": 0.84.1
-  checksum: c1046e9f8fd064072aa68c278631cd4cfa5c3a89642211cce8840763f34ca4cbd3d3a1b0beff5f9be73ce0f2ea78b660dd9f6d2e2233d68e1d74ab5b0009d9af
+    "@babel/traverse": ^7.29.0
+    "@react-native/codegen": 0.85.1
+  checksum: c31d222430eab355d4c06f33ee627fda0970afbaabc11595fe8a22dbebcde1b4374873550e9440b687ded3ddc52d6a1f7621100ceb2597b5ef50949d0af3c9c0
   languageName: node
   linkType: hard
 
@@ -9688,9 +9688,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/babel-preset@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/babel-preset@npm:0.84.1"
+"@react-native/babel-preset@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/babel-preset@npm:0.85.1"
   dependencies:
     "@babel/core": ^7.25.2
     "@babel/plugin-proposal-export-default-from": ^7.24.7
@@ -9721,13 +9721,13 @@ __metadata:
     "@babel/plugin-transform-runtime": ^7.24.7
     "@babel/plugin-transform-typescript": ^7.25.2
     "@babel/plugin-transform-unicode-regex": ^7.24.7
-    "@react-native/babel-plugin-codegen": 0.84.1
-    babel-plugin-syntax-hermes-parser: 0.32.0
+    "@react-native/babel-plugin-codegen": 0.85.1
+    babel-plugin-syntax-hermes-parser: 0.33.3
     babel-plugin-transform-flow-enums: ^0.0.2
     react-refresh: ^0.14.0
   peerDependencies:
     "@babel/core": "*"
-  checksum: 7754d20da6f17a1fa2749f7d45fdd741ba4b0e82069294b963e3bec0095b3cf731320cf202c9850c49702583930b1c892b7a6c0d67d27f9da97e4ea2bcaab9f2
+  checksum: b61582a88a9b1a13554b301d668926dec5d28888f3bfbb54bd2a9b1b9e4d8d69aca93e6005614fb124722b96f5ba565792c6bd49920155d8090a886ff4ba4898
   languageName: node
   linkType: hard
 
@@ -9842,20 +9842,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/codegen@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/codegen@npm:0.84.1"
+"@react-native/codegen@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/codegen@npm:0.85.1"
   dependencies:
     "@babel/core": ^7.25.2
-    "@babel/parser": ^7.25.3
-    hermes-parser: 0.32.0
+    "@babel/parser": ^7.29.0
+    hermes-parser: 0.33.3
     invariant: ^2.2.4
     nullthrows: ^1.1.1
     tinyglobby: ^0.2.15
     yargs: ^17.6.2
   peerDependencies:
     "@babel/core": "*"
-  checksum: eaaeeab9ca8cfdcfbd2c6febea5129c80c9e05c1b0cf84a2ae4915d231ceeb5c0f9aa0846129cda34764331646c2d10df4d5e945e2cd93fa459325e34af3897c
+  checksum: cdf5341f2de9199a616ff2c7f46b1314e22bddbee43951569bb2b50b5d72a0fb02745c702e4552d406b95b1c9ad9a2d9dcfe0e839d24b35fa80434e7899370a1
   languageName: node
   linkType: hard
 
@@ -9985,26 +9985,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/community-cli-plugin@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/community-cli-plugin@npm:0.84.1"
+"@react-native/community-cli-plugin@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/community-cli-plugin@npm:0.85.1"
   dependencies:
-    "@react-native/dev-middleware": 0.84.1
+    "@react-native/dev-middleware": 0.85.1
     debug: ^4.4.0
     invariant: ^2.2.4
-    metro: ^0.83.3
-    metro-config: ^0.83.3
-    metro-core: ^0.83.3
+    metro: ^0.84.0
+    metro-config: ^0.84.0
+    metro-core: ^0.84.0
     semver: ^7.1.3
   peerDependencies:
     "@react-native-community/cli": "*"
-    "@react-native/metro-config": "*"
+    "@react-native/metro-config": 0.85.1
   peerDependenciesMeta:
     "@react-native-community/cli":
       optional: true
     "@react-native/metro-config":
       optional: true
-  checksum: fed784d0c295dc62097a74b9321251530a7f5b85663a8fe170c5665ded8f806ac4b6ecf238a819f956cf926a8d90dce4f86ce0c2afb4f6cb8b243cda245742f5
+  checksum: 9b93f3d08047a0dfca1654d82b0d82a1affeb87511d8be5047650f0dee3282c2ea6f281827a253c8d1efacd0a97a067bee185ba7390d2df0a4420ff2e887793a
   languageName: node
   linkType: hard
 
@@ -10050,10 +10050,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/debugger-frontend@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/debugger-frontend@npm:0.84.1"
-  checksum: 8b7f502b4010f0a7e49a88aa8e5b56e6c2b50a095a7b7c5b7bd437dd3f53a2d77a6deccedc61ac3c003a0a6d9adab98c43e3e1a7afb5ba7960210a75d42ce961
+"@react-native/debugger-frontend@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/debugger-frontend@npm:0.85.1"
+  checksum: 8e82d004a0ef238366db832ebf2c0d555ad77c39c044727d2fc5a041cb4e15ad5365dd55bba8db95dcacf8e946ace64d12b767992c54ab020150d39f7f325524
   languageName: node
   linkType: hard
 
@@ -10067,14 +10067,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/debugger-shell@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/debugger-shell@npm:0.84.1"
+"@react-native/debugger-shell@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/debugger-shell@npm:0.85.1"
   dependencies:
     cross-spawn: ^7.0.6
     debug: ^4.4.0
     fb-dotslash: 0.5.8
-  checksum: 073e9a0bf939ef92d2f92237cc0a1f834b537c27301a8592cf5597bb9bb86b36e03a05814db1e6cbd6770b91a51b4f0d137ea65bd861299599ad3d34ca7192e2
+  checksum: ba42e19ffdf2d8ce6c42e1b7cc98c3b0748d4569d8f5f1b49927c4ae84a8e3cbb16cf5b83ea5135090b249f6bc81b6b90506ae7dfc3360498da2b60c63a82e07
   languageName: node
   linkType: hard
 
@@ -10194,15 +10194,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/dev-middleware@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/dev-middleware@npm:0.84.1"
+"@react-native/dev-middleware@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/dev-middleware@npm:0.85.1"
   dependencies:
     "@isaacs/ttlcache": ^1.4.1
-    "@react-native/debugger-frontend": 0.84.1
-    "@react-native/debugger-shell": 0.84.1
+    "@react-native/debugger-frontend": 0.85.1
+    "@react-native/debugger-shell": 0.85.1
     chrome-launcher: ^0.15.2
-    chromium-edge-launcher: ^0.2.0
+    chromium-edge-launcher: ^0.3.0
     connect: ^3.6.5
     debug: ^4.4.0
     invariant: ^2.2.4
@@ -10210,7 +10210,7 @@ __metadata:
     open: ^7.0.3
     serve-static: ^1.16.2
     ws: ^7.5.10
-  checksum: 768a74008db59208801f975a67043f4f9975b202ea6d0462c721b1c2ded3070e651ab497d1c55d81df9eb95e3c0aa53cc822fc676ec465a55e5d3ca839c9f5a9
+  checksum: d0279cc17767b948820c3835a6f5c44ec618e5d43675faca1c3516188f59f62c55ba2758d861ca367a472c9fea25dbf56d720959d5d050352ed0942feaafd678
   languageName: node
   linkType: hard
 
@@ -10249,10 +10249,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/gradle-plugin@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/gradle-plugin@npm:0.84.1"
-  checksum: 694126927f628753eeff7ebf0678ddd4a3baf01782c01eac576f0c4090d8315899da65857bb3da5d9ed94b512012b7cf07fe7494094e3a3dc4ffd920e15c718f
+"@react-native/gradle-plugin@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/gradle-plugin@npm:0.85.1"
+  checksum: 443fd6ac241f3182b7ef89a83173d5d15646c35c6cd05e1b9d16c9ec4bb1680c17906f6be8262c16e37877eda9f8c707044e621aa427a1a5445231264f7b9e18
+  languageName: node
+  linkType: hard
+
+"@react-native/jest-preset@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/jest-preset@npm:0.85.1"
+  dependencies:
+    "@jest/create-cache-key-function": ^29.7.0
+    "@react-native/js-polyfills": 0.85.1
+    babel-jest: ^29.7.0
+    jest-environment-node: ^29.7.0
+    regenerator-runtime: ^0.13.2
+  peerDependencies:
+    react: ^19.2.3
+  checksum: c1866403578a842a3e89fc00147464c51c6e5cbb9f76e32425ab94be2050869e4852d78a572f7a26b4a2aec41b0d0dda6c22c644a568fd3c22354b66ac2cf689
   languageName: node
   linkType: hard
 
@@ -10291,10 +10306,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/js-polyfills@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/js-polyfills@npm:0.84.1"
-  checksum: 3aa46bffbf155a20172503b64beaf7bd60a20f562d3a8bf2abc3d994e5f1868d5eda8b3e35bf3b374eff31da1c1320d43acf4660633e318767f919a2eafaf167
+"@react-native/js-polyfills@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/js-polyfills@npm:0.85.1"
+  checksum: d29ae07b414db6f8e811b14e877105b03c87516428b1aae388206f724d6de8ec5ede2d27700f3ed12c08cda72c9019f197698e621343939a11e67e1b0ae3dacf
   languageName: node
   linkType: hard
 
@@ -10340,17 +10355,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/metro-babel-transformer@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/metro-babel-transformer@npm:0.84.1"
+"@react-native/metro-babel-transformer@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/metro-babel-transformer@npm:0.85.1"
   dependencies:
     "@babel/core": ^7.25.2
-    "@react-native/babel-preset": 0.84.1
-    hermes-parser: 0.32.0
+    "@react-native/babel-preset": 0.85.1
+    hermes-parser: 0.33.3
     nullthrows: ^1.1.1
   peerDependencies:
     "@babel/core": "*"
-  checksum: b551437f53a9269cddd5a89cad5db2c83fe1139003d22f2c90ee82fbff54ae3444486242adf67579903023b5a6b77a1dfde95154e0eb81ed38fe82100e457352
+  checksum: d4e03243cc4ff73d98f0a74859bd131d3ced6acea9ad44a4b2352e0fe7696346b1fa5365ec32adc0c137e3639e80990e9121928d9245cffd0064f6dd109e35eb
   languageName: node
   linkType: hard
 
@@ -10378,15 +10393,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/metro-config@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/metro-config@npm:0.84.1"
+"@react-native/metro-config@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/metro-config@npm:0.85.1"
   dependencies:
-    "@react-native/js-polyfills": 0.84.1
-    "@react-native/metro-babel-transformer": 0.84.1
-    metro-config: ^0.83.3
-    metro-runtime: ^0.83.3
-  checksum: 0637fe16d5e1fa7fcfd729dbfa3842b9ead126c1eb6ebe8ff4bcdc959f92a71bc5e0e9bdeb103a33fb04bb3a53dd3ee219736508acee89963aea6fb9db2901c2
+    "@react-native/js-polyfills": 0.85.1
+    "@react-native/metro-babel-transformer": 0.85.1
+    metro-config: ^0.84.0
+    metro-runtime: ^0.84.0
+  checksum: 68fa920c5457e486d508a37848d1a1c04c66e77d9adc2e791cb28a463c125a1d394a84ba8dd6b583a06a1224bb62d6a78b292aefacb4d92a01925c6f0191e3fa
   languageName: node
   linkType: hard
 
@@ -10404,17 +10419,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/new-app-screen@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/new-app-screen@npm:0.84.1"
+"@react-native/new-app-screen@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/new-app-screen@npm:0.85.1"
   peerDependencies:
     "@types/react": ^19.1.0
     react: "*"
-    react-native: "*"
+    react-native: 0.85.1
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 701294e249e9eae7cde6d099af4ff906ce8098c2b1dcf74dd3c32a23d18f9a68b165281459eb842105e1281b924552f9b7d01be915acac076332148d8c151956
+  checksum: 829e7acb54bb7694c124be6a774337ed545fb8a9c04476225383494bf84e0bb916eb9eb2fcb48f5250e67a7133808cfab5682e20a8ee65b06de878e8371ee099
   languageName: node
   linkType: hard
 
@@ -10467,10 +10482,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/normalize-colors@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/normalize-colors@npm:0.84.1"
-  checksum: 69c9958a70f9489e804c07543d623df178c6d8f8afa56a1a0190e37b39b6b6a2f2f36ef4ede4c67439fd5ccb28e60d10d4403a3d50a77224ee4458464752a4d0
+"@react-native/normalize-colors@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/normalize-colors@npm:0.85.1"
+  checksum: 4986c5b658782ac02816a140f6e0a8b80f8272bbdde534e935327155e2fed056d775568616e6d4a80ac0be316db7eb0f32da4da90fdab2c3ce462e3228628670
   languageName: node
   linkType: hard
 
@@ -10495,10 +10510,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/typescript-config@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/typescript-config@npm:0.84.1"
-  checksum: 6616765f8cf7702818ef251168522aeb68fb9baddcfc8235cd00731d0b4158131bf3fb12680b725c851002832c6fa604bee66b059bb15d35362b437b39615fa0
+"@react-native/typescript-config@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/typescript-config@npm:0.85.1"
+  checksum: 8fbcba9f552fa1c31016ec1dda4070efa6714e50ab69a0d91c21cdf228fda44f0ca495b86975d6be950045210f94cb894dcaf2fd4ee08eae459382885ef26e5b
   languageName: node
   linkType: hard
 
@@ -10582,20 +10597,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native/virtualized-lists@npm:0.84.1":
-  version: 0.84.1
-  resolution: "@react-native/virtualized-lists@npm:0.84.1"
+"@react-native/virtualized-lists@npm:0.85.1":
+  version: 0.85.1
+  resolution: "@react-native/virtualized-lists@npm:0.85.1"
   dependencies:
     invariant: ^2.2.4
     nullthrows: ^1.1.1
   peerDependencies:
     "@types/react": ^19.2.0
     react: "*"
-    react-native: "*"
+    react-native: 0.85.1
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 77b247f3c0a1b60c8d7ca3548ba3fa23e124b5a7e9b09e6020a8630cb9129bc9649644ab629b423e5ca1bc938f436cd9c8362d88904e37665d98a1a487471b37
+  checksum: 2f3452499019c8aafe4718503a1db60476ba3e7bf48f5918ba684970d3c0b419efdf19380dcc47c97fb9a8519f84d78dbd3d6248381402e1dda4fa0f357173c0
   languageName: node
   linkType: hard
 
@@ -13710,6 +13725,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-syntax-hermes-parser@npm:0.33.3":
+  version: 0.33.3
+  resolution: "babel-plugin-syntax-hermes-parser@npm:0.33.3"
+  dependencies:
+    hermes-parser: 0.33.3
+  checksum: 250394dbe9fc7b6b2235ed7d0eaed287c811fbb79ab122a6d1a74f212dd85307273a06ae72e0b7f164f908f57d93f45f06183236f51d9fc704083cc67bce78c6
+  languageName: node
+  linkType: hard
+
 "babel-plugin-syntax-hermes-parser@npm:^0.32.0":
   version: 0.32.1
   resolution: "babel-plugin-syntax-hermes-parser@npm:0.32.1"
@@ -14796,6 +14820,19 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: 9b56d1f8f18e84e34d6da89a4d97787ef323a1ade6551dcc83a6899af17c1bfc27a844c23422a29f51c6a315d1e04e2ad12595aaf07d3822335c2fce15914feb
+  languageName: node
+  linkType: hard
+
+"chromium-edge-launcher@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "chromium-edge-launcher@npm:0.3.0"
+  dependencies:
+    "@types/node": "*"
+    escape-string-regexp: ^4.0.0
+    is-wsl: ^2.2.0
+    lighthouse-logger: ^1.0.0
+    mkdirp: ^1.0.4
+  checksum: 23992453ad683c950dd3e532b491cdf6188b09d1495b012829c4ed52e2b37450ef1c7011e9ceed75a53669e4bae9444bde783bfb693fa43486b423acb7cc13e3
   languageName: node
   linkType: hard
 
@@ -19544,10 +19581,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-compiler@npm:250829098.0.9":
-  version: 250829098.0.9
-  resolution: "hermes-compiler@npm:250829098.0.9"
-  checksum: cb888da33d8e97a515e25912827bbfc7bebd0d065f51cf6e20a269c91558e811451f78bd2f06c2494e1af0555ff3428a87745648bdcfcc4e75393625815302dd
+"hermes-compiler@npm:250829098.0.10":
+  version: 250829098.0.10
+  resolution: "hermes-compiler@npm:250829098.0.10"
+  checksum: f93576d06b607695d91654eba622b1fcf4c389567091802b141854587b0df3cd123717809526bbd18901f9a954fe221dd1b1dfb17973a366cabacf7bdd560fb0
   languageName: node
   linkType: hard
 
@@ -19611,6 +19648,13 @@ __metadata:
   version: 0.33.3
   resolution: "hermes-estree@npm:0.33.3"
   checksum: b4cdd1b3d818378500a5512bf5a73b63b397b8fa5721051ed29ae7e36561150ce4e4ad1994d2d3261d5e5e1b15cd30eae52f6845ace363a742a3ceb518cfee72
+  languageName: node
+  linkType: hard
+
+"hermes-estree@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-estree@npm:0.35.0"
+  checksum: da25f2f5a9aedf1ca0844a64fad21aa3262f4998ee584da4237408d8bc08562ff6a3923b1bf52aa85b9a9c5b2b29ce54d00c61fe9f2424dae9e67261441d73ac
   languageName: node
   linkType: hard
 
@@ -19692,6 +19736,15 @@ __metadata:
   dependencies:
     hermes-estree: 0.33.3
   checksum: eee873a3efce23b1cfdcd185fbbfc3554b1a0fc2513bd74bbb687dab744e3613279e7191f8d920b988677404f14bb1d2143bd679add55fd88ab07cfea59eea11
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-parser@npm:0.35.0"
+  dependencies:
+    hermes-estree: 0.35.0
+  checksum: 097572045fc574afc7a1d35ab3304651605408770371f8eb74ef7a971b48b0e3cf82e45156fa431ba60bf5ee196100c69d4fa107e6fc2d4e18757aa0a1ae0382
   languageName: node
   linkType: hard
 
@@ -23158,6 +23211,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-babel-transformer@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-babel-transformer@npm:0.84.3"
+  dependencies:
+    "@babel/core": ^7.25.2
+    flow-enums-runtime: ^0.0.6
+    hermes-parser: 0.35.0
+    metro-cache-key: 0.84.3
+    nullthrows: ^1.1.1
+  checksum: 45c10c24a39b9e42d274cd32f7cd48c3a2989c7b5fd10bf0d79db3f0e594f58ba3045bee89cae1236f714832962cb7beac3bb0854159306336aad0e5cc944ba3
+  languageName: node
+  linkType: hard
+
 "metro-cache-key@npm:0.80.10":
   version: 0.80.10
   resolution: "metro-cache-key@npm:0.80.10"
@@ -23218,6 +23284,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 704d0d8e06e8477d20c700cd5f729356aaa704999d4b80882b85aa21ccf7da13959dcd0760f9a456931466bf77dffe688f2a11f468aae5c074f74667957c6608
+  languageName: node
+  linkType: hard
+
+"metro-cache-key@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-cache-key@npm:0.84.3"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: 8a7a112a16af41fae91bc87359a164ed88c0a3b474861abfda5fcbe9e91afc359e7a126ece005611b1bc5102d1962529a56923ea55da1dec302bc2285663726c
   languageName: node
   linkType: hard
 
@@ -23300,6 +23375,18 @@ __metadata:
     https-proxy-agent: ^7.0.5
     metro-core: 0.83.5
   checksum: a217d4f93cd5d4ad7d3b73e80a9b10984d0fad8584c42beb77880bb7d1eca72409d01ad531b72330e5a1dffdc8d516944111990372a6302444ea190f747a2bfe
+  languageName: node
+  linkType: hard
+
+"metro-cache@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-cache@npm:0.84.3"
+  dependencies:
+    exponential-backoff: ^3.1.1
+    flow-enums-runtime: ^0.0.6
+    https-proxy-agent: ^7.0.5
+    metro-core: 0.84.3
+  checksum: a77aa976d6c9757d1653c51b1d372356acf6de258469b3e823e1095c892007ee34f6028fa3b5175f24e3178994a35cae8f9d8e3feb6d4f3f5230378169c6e44f
   languageName: node
   linkType: hard
 
@@ -23415,6 +23502,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-config@npm:0.84.3, metro-config@npm:^0.84.0":
+  version: 0.84.3
+  resolution: "metro-config@npm:0.84.3"
+  dependencies:
+    connect: ^3.6.5
+    flow-enums-runtime: ^0.0.6
+    jest-validate: ^29.7.0
+    metro: 0.84.3
+    metro-cache: 0.84.3
+    metro-core: 0.84.3
+    metro-runtime: 0.84.3
+    yaml: ^2.6.1
+  checksum: e25b3b4c867f853f9121950d0178ba46d3696e7f157dce087a24901f6e794d692b8337d39220970122dc2f7220a41c3aae68611c2b617f1e57e759ca5e6c9426
+  languageName: node
+  linkType: hard
+
 "metro-core@npm:0.80.10, metro-core@npm:^0.80.3":
   version: 0.80.10
   resolution: "metro-core@npm:0.80.10"
@@ -23489,6 +23592,17 @@ __metadata:
     lodash.throttle: ^4.1.1
     metro-resolver: 0.83.5
   checksum: 9421cb6cac3d71aea4d4e6ab6d90e0021e28f7088e4efcb2dfe21f4444efc31e55141a1f61a6a7102474aec96de543b1128f49e747141e544f871ad73d60c481
+  languageName: node
+  linkType: hard
+
+"metro-core@npm:0.84.3, metro-core@npm:^0.84.0":
+  version: 0.84.3
+  resolution: "metro-core@npm:0.84.3"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    lodash.throttle: ^4.1.1
+    metro-resolver: 0.84.3
+  checksum: bbe105e8c287cbcb2429137e04e8615c02cc673942cafe99916403f244c7069afcd5e79814a40d351f7019476c3c94284cef804458eb86ec2928e1ea5b0e2d83
   languageName: node
   linkType: hard
 
@@ -23623,6 +23737,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-file-map@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-file-map@npm:0.84.3"
+  dependencies:
+    debug: ^4.4.0
+    fb-watchman: ^2.0.0
+    flow-enums-runtime: ^0.0.6
+    graceful-fs: ^4.2.4
+    invariant: ^2.2.4
+    jest-worker: ^29.7.0
+    micromatch: ^4.0.4
+    nullthrows: ^1.1.1
+    walker: ^1.0.7
+  checksum: b5d32a0719586e765e8e8cf38295002eb7453c868a8632b15a9f537a513af637452469a07165d02ad2009d38daebfc6248cd2ef76e78dfa43ad646e884658333
+  languageName: node
+  linkType: hard
+
 "metro-minify-terser@npm:0.80.10":
   version: 0.80.10
   resolution: "metro-minify-terser@npm:0.80.10"
@@ -23690,6 +23821,16 @@ __metadata:
     flow-enums-runtime: ^0.0.6
     terser: ^5.15.0
   checksum: b9e257b5a74343a271e89603479775ed76b9c5e7b28015bafbce2afb4d7507acf36e897fc78c2ee571ad89951ba0ca708188ecb33fff0b947d1cee0ea8fd7837
+  languageName: node
+  linkType: hard
+
+"metro-minify-terser@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-minify-terser@npm:0.84.3"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    terser: ^5.15.0
+  checksum: 7372c8570c4fc7d0c5f455f63ae2a5ed1707ab657bc0bb464b861bb15c2148689de3458b487c29d65ca270d0b542d455ad03c435c9187bf449f09a9d4f25ca5d
   languageName: node
   linkType: hard
 
@@ -23805,6 +23946,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-resolver@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-resolver@npm:0.84.3"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: da0bdce0bf062771d494159114bf654e292cfc66c9504d4daf3dc13534d9a2e3c6c2dfdf6588c80a2225a7e9d5dcc6d5acede83301aa85580a0179def69458bb
+  languageName: node
+  linkType: hard
+
 "metro-runtime@npm:0.80.10, metro-runtime@npm:^0.80.3":
   version: 0.80.10
   resolution: "metro-runtime@npm:0.80.10"
@@ -23872,6 +24022,16 @@ __metadata:
     "@babel/runtime": ^7.25.0
     flow-enums-runtime: ^0.0.6
   checksum: 1ffe108ca5d10ecdddff0fce1ff81f1e8cd256acfee5c9c6974d8696ed14e84b034c7d421d6bd507b042c2b6426d6089c790f48d9dbd127d4e51600b942f495f
+  languageName: node
+  linkType: hard
+
+"metro-runtime@npm:0.84.3, metro-runtime@npm:^0.84.0":
+  version: 0.84.3
+  resolution: "metro-runtime@npm:0.84.3"
+  dependencies:
+    "@babel/runtime": ^7.25.0
+    flow-enums-runtime: ^0.0.6
+  checksum: 4d60af2907e59abf8c6a470aa94209b1e63c6758591712dbc6088f7c4a460b855fd9da13ba5a81cccd1de5027c3d651bdc9af597c0697ec4b402b49b67a618cc
   languageName: node
   linkType: hard
 
@@ -23999,6 +24159,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-source-map@npm:0.84.3, metro-source-map@npm:^0.84.0":
+  version: 0.84.3
+  resolution: "metro-source-map@npm:0.84.3"
+  dependencies:
+    "@babel/traverse": ^7.29.0
+    "@babel/types": ^7.29.0
+    flow-enums-runtime: ^0.0.6
+    invariant: ^2.2.4
+    metro-symbolicate: 0.84.3
+    nullthrows: ^1.1.1
+    ob1: 0.84.3
+    source-map: ^0.5.6
+    vlq: ^1.0.0
+  checksum: 879249a6bdcb686eeccca5893e28a95ec33b3eea57955891886b25587299f4177368e675f2c5e0d9d9d63aeaf7a005530977699081279b4506d01ffa1b14dbb5
+  languageName: node
+  linkType: hard
+
 "metro-symbolicate@npm:0.80.10":
   version: 0.80.10
   resolution: "metro-symbolicate@npm:0.80.10"
@@ -24113,6 +24290,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-symbolicate@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-symbolicate@npm:0.84.3"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+    invariant: ^2.2.4
+    metro-source-map: 0.84.3
+    nullthrows: ^1.1.1
+    source-map: ^0.5.6
+    vlq: ^1.0.0
+  bin:
+    metro-symbolicate: src/index.js
+  checksum: 0dca68d2dac15a1ede39811a4ab8da3cf42363d93d8f9789d9274323472202dbc70a20caf8f95f8f202b4bdfac9d8cf4160bfcc396caba5c1dba692ad7abb99b
+  languageName: node
+  linkType: hard
+
 "metro-transform-plugins@npm:0.80.10":
   version: 0.80.10
   resolution: "metro-transform-plugins@npm:0.80.10"
@@ -24208,6 +24401,20 @@ __metadata:
     flow-enums-runtime: ^0.0.6
     nullthrows: ^1.1.1
   checksum: 1fa00c50179d4c8877ab531ee558e3467cdfd9c457a733c46d5be6aa2cb1f693ac541e86f5424ae264641a95a34dceecc29918c112217c690ea26a4abfcf2e1c
+  languageName: node
+  linkType: hard
+
+"metro-transform-plugins@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-transform-plugins@npm:0.84.3"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.29.1
+    "@babel/template": ^7.28.6
+    "@babel/traverse": ^7.29.0
+    flow-enums-runtime: ^0.0.6
+    nullthrows: ^1.1.1
+  checksum: 6be40500c2e2fccf78b6991b5643ea3656ab4b10edbb6d54fd3af9252569c4b2e622ebf43005460bfaff1ab01400d5782f774662f157648af041b40551068cca
   languageName: node
   linkType: hard
 
@@ -24355,6 +24562,27 @@ __metadata:
     metro-transform-plugins: 0.83.5
     nullthrows: ^1.1.1
   checksum: 66fac804f74ee5b16c158704e27c1e264e41133c359a43fc5fd3de34a4d90ae4b3402a0c9972825f730dfb9c38e3fb0bcf586f27e51a897ea43bf647ffef0d64
+  languageName: node
+  linkType: hard
+
+"metro-transform-worker@npm:0.84.3":
+  version: 0.84.3
+  resolution: "metro-transform-worker@npm:0.84.3"
+  dependencies:
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.29.1
+    "@babel/parser": ^7.29.0
+    "@babel/types": ^7.29.0
+    flow-enums-runtime: ^0.0.6
+    metro: 0.84.3
+    metro-babel-transformer: 0.84.3
+    metro-cache: 0.84.3
+    metro-cache-key: 0.84.3
+    metro-minify-terser: 0.84.3
+    metro-source-map: 0.84.3
+    metro-transform-plugins: 0.84.3
+    nullthrows: ^1.1.1
+  checksum: 84540d63637995e0a937763bbf91e6b9c7c97cd30497568f53dfb0462726ec40859c6a169196c84b226552677ee4c16b3b27908c40f10e3184193db4f6096952
   languageName: node
   linkType: hard
 
@@ -24710,6 +24938,56 @@ __metadata:
   bin:
     metro: src/cli.js
   checksum: ca4eca050d1d486b5acfc632671a8d1c4b9e92ec2a84ecbec5b7eba68599edf5d0fa8030963e7165b4e8e68f72415c836aeb7864b37dba07c7e205b41d169884
+  languageName: node
+  linkType: hard
+
+"metro@npm:0.84.3, metro@npm:^0.84.0":
+  version: 0.84.3
+  resolution: "metro@npm:0.84.3"
+  dependencies:
+    "@babel/code-frame": ^7.29.0
+    "@babel/core": ^7.25.2
+    "@babel/generator": ^7.29.1
+    "@babel/parser": ^7.29.0
+    "@babel/template": ^7.28.6
+    "@babel/traverse": ^7.29.0
+    "@babel/types": ^7.29.0
+    accepts: ^2.0.0
+    chalk: ^4.0.0
+    ci-info: ^2.0.0
+    connect: ^3.6.5
+    debug: ^4.4.0
+    error-stack-parser: ^2.0.6
+    flow-enums-runtime: ^0.0.6
+    graceful-fs: ^4.2.4
+    hermes-parser: 0.35.0
+    image-size: ^1.0.2
+    invariant: ^2.2.4
+    jest-worker: ^29.7.0
+    jsc-safe-url: ^0.2.2
+    lodash.throttle: ^4.1.1
+    metro-babel-transformer: 0.84.3
+    metro-cache: 0.84.3
+    metro-cache-key: 0.84.3
+    metro-config: 0.84.3
+    metro-core: 0.84.3
+    metro-file-map: 0.84.3
+    metro-resolver: 0.84.3
+    metro-runtime: 0.84.3
+    metro-source-map: 0.84.3
+    metro-symbolicate: 0.84.3
+    metro-transform-plugins: 0.84.3
+    metro-transform-worker: 0.84.3
+    mime-types: ^3.0.1
+    nullthrows: ^1.1.1
+    serialize-error: ^2.1.0
+    source-map: ^0.5.6
+    throat: ^5.0.0
+    ws: ^7.5.10
+    yargs: ^17.6.2
+  bin:
+    metro: src/cli.js
+  checksum: b9df01df33ea022b36ca9381c7d0c480463e32aab8cc56d4afbe927344fdf7d3953b0a8cdfbbcfc70d6a5835a88663e107d0db6d20147bee627b98a67b75bac0
   languageName: node
   linkType: hard
 
@@ -25879,6 +26157,15 @@ __metadata:
   dependencies:
     flow-enums-runtime: ^0.0.6
   checksum: 7a3ed43344d3d10c76060218fc35c652d12e20c0e520cf4bdb3c86c2817f0622b78a3d8c81fd52a05c29d7d2113b65514ee721e61adb352dd547d14a74b6015a
+  languageName: node
+  linkType: hard
+
+"ob1@npm:0.84.3":
+  version: 0.84.3
+  resolution: "ob1@npm:0.84.3"
+  dependencies:
+    flow-enums-runtime: ^0.0.6
+  checksum: 7620743b1e94e6c873dbf77338d04c262b5827a69d17bc3625722d58dd129d82125168223843dd459394aebfcd16858e7ad9595e0809c441a3aad15e46dc749c
   languageName: node
   linkType: hard
 
@@ -28392,32 +28679,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native@npm:0.84.1":
-  version: 0.84.1
-  resolution: "react-native@npm:0.84.1"
+"react-native@npm:0.85.1":
+  version: 0.85.1
+  resolution: "react-native@npm:0.85.1"
   dependencies:
-    "@jest/create-cache-key-function": ^29.7.0
-    "@react-native/assets-registry": 0.84.1
-    "@react-native/codegen": 0.84.1
-    "@react-native/community-cli-plugin": 0.84.1
-    "@react-native/gradle-plugin": 0.84.1
-    "@react-native/js-polyfills": 0.84.1
-    "@react-native/normalize-colors": 0.84.1
-    "@react-native/virtualized-lists": 0.84.1
+    "@react-native/assets-registry": 0.85.1
+    "@react-native/codegen": 0.85.1
+    "@react-native/community-cli-plugin": 0.85.1
+    "@react-native/gradle-plugin": 0.85.1
+    "@react-native/js-polyfills": 0.85.1
+    "@react-native/normalize-colors": 0.85.1
+    "@react-native/virtualized-lists": 0.85.1
     abort-controller: ^3.0.0
     anser: ^1.4.9
     ansi-regex: ^5.0.0
-    babel-jest: ^29.7.0
-    babel-plugin-syntax-hermes-parser: 0.32.0
+    babel-plugin-syntax-hermes-parser: 0.33.3
     base64-js: ^1.5.1
     commander: ^12.0.0
     flow-enums-runtime: ^0.0.6
-    hermes-compiler: 250829098.0.9
+    hermes-compiler: 250829098.0.10
     invariant: ^2.2.4
-    jest-environment-node: ^29.7.0
     memoize-one: ^5.0.0
-    metro-runtime: ^0.83.3
-    metro-source-map: ^0.83.3
+    metro-runtime: ^0.84.0
+    metro-source-map: ^0.84.0
     nullthrows: ^1.1.1
     pretty-format: ^29.7.0
     promise: ^8.3.0
@@ -28432,14 +28716,17 @@ __metadata:
     ws: ^7.5.10
     yargs: ^17.6.2
   peerDependencies:
+    "@react-native/jest-preset": 0.85.1
     "@types/react": ^19.1.1
     react: ^19.2.3
   peerDependenciesMeta:
+    "@react-native/jest-preset":
+      optional: true
     "@types/react":
       optional: true
   bin:
     react-native: cli.js
-  checksum: 0364b29ac2f0d29f4a6d0b612c87d0e2378b1cd86275c1260c3a49156515fe6f2458c0bd222689242827bca5d6f5ad5012f610d805dadc6191feb21cafed348e
+  checksum: b9ec9307361c334f40494f7ff434cfce14c53f8bcb4caa7481064ff40b216a109c7f24a4afc0973b825832b4ec484cdb664c467f0edc6734275fb7f274afbc43
   languageName: node
   linkType: hard
 
@@ -29950,10 +30237,11 @@ __metadata:
     "@react-native-community/cli-platform-android": 20.1.0
     "@react-native-community/cli-platform-ios": 20.1.0
     "@react-native-vector-icons/ionicons": ^12.3.0
-    "@react-native/babel-preset": 0.84.1
-    "@react-native/metro-config": 0.84.1
-    "@react-native/new-app-screen": 0.84.1
-    "@react-native/typescript-config": 0.84.1
+    "@react-native/babel-preset": 0.85.1
+    "@react-native/jest-preset": 0.85.1
+    "@react-native/metro-config": 0.85.1
+    "@react-native/new-app-screen": 0.85.1
+    "@react-native/typescript-config": 0.85.1
     "@react-navigation/bottom-tabs": ^7.4.5
     "@react-navigation/native": ^7.1.17
     "@react-navigation/native-stack": ^7.3.24
@@ -29976,7 +30264,7 @@ __metadata:
     jest: ^29.6.3
     patch-package: ^8.0.0
     react: 19.2.3
-    react-native: 0.84.1
+    react-native: 0.85.1
     react-native-build-config: ^0.3.2
     react-native-gesture-handler: ^2.28.0
     react-native-image-picker: ^8.2.1
@@ -29992,7 +30280,7 @@ __metadata:
     sentry-react-native-samples-utils: "workspace:^"
     setimmediate: ^1.0.5
     ts-jest: ^29.3.1
-    typescript: 5.0.4
+    typescript: 5.8.3
   languageName: unknown
   linkType: soft
 
@@ -32046,6 +32334,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.8.3, typescript@npm:^5.1.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: cb1d081c889a288b962d3c8ae18d337ad6ee88a8e81ae0103fa1fecbe923737f3ba1dbdb3e6d8b776c72bc73bfa6d8d850c0306eed1a51377d2fccdfd75d92c4
+  languageName: node
+  linkType: hard
+
 "typescript@npm:>=3 < 6":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -32063,16 +32361,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 46c842e2cd4797b88b66ef06c9c41dd21da48b95787072ccf39d5f2aa3124361bc4c966aa1c7f709fae0509614d76751455b5231b12dbb72eb97a31369e1ff92
-  languageName: node
-  linkType: hard
-
-"typescript@npm:^5.1.3":
-  version: 5.8.3
-  resolution: "typescript@npm:5.8.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: cb1d081c889a288b962d3c8ae18d337ad6ee88a8e81ae0103fa1fecbe923737f3ba1dbdb3e6d8b776c72bc73bfa6d8d850c0306eed1a51377d2fccdfd75d92c4
   languageName: node
   linkType: hard
 
@@ -32116,7 +32404,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@5.8.3#~builtin<compat/typescript>, typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=29ae49"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -28301,9 +28301,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-svg@npm:^15.12.1":
-  version: 15.13.0
-  resolution: "react-native-svg@npm:15.13.0"
+"react-native-svg@npm:^15.15.4, react-native-svg@npm:^15.3.0":
+  version: 15.15.4
+  resolution: "react-native-svg@npm:15.15.4"
   dependencies:
     css-select: ^5.1.0
     css-tree: ^1.1.3
@@ -28311,21 +28311,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: c20a95029630a1ff6d79caa9d01e9e3ad988afaa6787f306b1057369b8ce4ac1f2f0b3cf3367bac7e529e5f2ed03ce85236542ecfcf29f5827ab77dfd0921bb2
-  languageName: node
-  linkType: hard
-
-"react-native-svg@npm:^15.3.0":
-  version: 15.6.0
-  resolution: "react-native-svg@npm:15.6.0"
-  dependencies:
-    css-select: "npm:^5.1.0"
-    css-tree: "npm:^1.1.3"
-    warn-once: "npm:0.1.1"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 31c70317b7ca4c74d2b1db28af7ae127920c004c606ed4bd37f1e191a9433f6ce9929eabd105ed8768a1327ad26675ef0eaa06a97ca736ced8bfc6410b0d7480
+  checksum: 6438a3e05e6da7891d9170a3e4bb4c75efa48270b2af926eb0dbf0c8f64bea659c28e008f1ceafefd157213344b54fb6b007fbce6817feed7fb9f550f015189e
   languageName: node
   linkType: hard
 
@@ -30272,7 +30258,7 @@ __metadata:
     react-native-reanimated: 4.3.0
     react-native-safe-area-context: ^5.5.2
     react-native-screens: ^4.13.1
-    react-native-svg: ^15.12.1
+    react-native-svg: ^15.15.4
     react-native-webview: ^13.15.0
     react-native-worklets: 0.8.1
     react-redux: ^9.2.0


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-react-native/issues/5993

## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

Bumps the React Native sample app to React Native 0.85.1.

Changes:
- `react-native` 0.84.1 → 0.85.1
- `@react-native/babel-preset`, `@react-native/metro-config`, `@react-native/typescript-config`, `@react-native/new-app-screen` 0.84.1 → 0.85.1
- Added `@react-native/jest-preset` 0.85.1 (moved out of `react-native` core in 0.85)
- Jest preset updated from `react-native` to `@react-native/jest-preset`
- Kotlin 2.0.21 → 2.1.20
- Gradle 9.0.0 → 9.3.1
- TypeScript 5.0.4 → 5.8.3 (required by new `@react-native/typescript-config`)
- `react-native-svg` 15.13.0 → 15.15.4 (RN 0.85 changed `ImageResponseObserver` to `shared_ptr`)

## :bulb: Motivation and Context

Keep the sample app up to date with the latest React Native release.

Similar to #5941.

## :green_heart: How did you test it?

- `yarn build` passes
- `yarn test` passes
- `yarn lint` passes
- `yarn circularDepCheck` passes
- iOS sample app builds locally (arm64 simulator)
- Android sample app builds locally (Gradle 9.3.1, JDK 17)
- CI will validate native builds with the `ready-to-merge` label

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps