### PR TITLE
ci: Integrate Warden for AI-powered PR code review

### DIFF
--- a/agents.toml
+++ b/agents.toml
@@ -3,3 +3,7 @@ agents = ["claude", "cursor"]
 
 [trust]
 github_orgs = ["getsentry"]
+
+[[skills]]
+name = "warden"
+source = "getsentry/warden"

--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,37 @@
+version = 1
+
+[defaults]
+failOn = "high"
+reportOn = "medium"
+
+[[skills]]
+name = "code-review"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "find-bugs"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "security-review"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "gha-security-review"
+remote = "getsentry/skills"
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
## 📢 Type of change

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring

## 📜 Description

Adds `warden.toml` at the repo root to enable [Warden](<https://warden.sentry.dev/>) AI-powered PR reviews. The org-wide workflow in `getsentry/.github` already runs Warden on all repos — this config file activates it for `sentry-react-native`.

**Skills enabled:**

* `code-review` — AI code review
* `find-bugs` — bug detection
* `security-review` — security analysis
* `gha-security-review` — GitHub Actions security review

Also adds the `warden` skill to `agents.toml` for local agent usage.

## 💡 Motivation and Context

Per the [SDK Review and CI standards](<https://develop.sentry.dev/sdk/getting-started/standards/review-ci/>), SDK repositories should have Warden configured in CI.

Closes [RN-585](https://linear.app/getsentry/issue/RN-585/integrate-warden-for-ai-powered-pr-code-review)

## 💚 How did you test it?

Warden ran successfully on this PR via the org-wide workflow. All 4 skills completed with zero findings

## :pencil: Checklist

- [ ] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] All tests passing
- [X] No breaking changes

## 🔮 Next steps

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)