### PR TITLE
fix(core): Fix sourcemap upload when withSentry is used programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixes
 
+- Fix sourcemap upload script failing when `withSentry` is used programmatically in `app.config.ts` ([#6006](https://github.com/getsentry/sentry-react-native/pull/6006))
 - Retry native module resolution to prevent silent event drops in production Hermes builds ([#5981](https://github.com/getsentry/sentry-react-native/pull/5981))
 - Lazy-load Metro internal modules to prevent Expo 55 import errors ([#5958](https://github.com/getsentry/sentry-react-native/pull/5958))
 - Fix app start transaction profile offset by using the actual profiling start timestamp instead of the adjusted app start time ([#5962](https://github.com/getsentry/sentry-react-native/issues/5962))

--- a/packages/core/plugin/src/withSentry.ts
+++ b/packages/core/plugin/src/withSentry.ts
@@ -22,6 +22,29 @@ interface PluginProps {
   experimental_android?: SentryAndroidGradlePluginOptions;
 }
 
+/**
+ * Store build-time properties in config._internal so they're discoverable
+ * by the sourcemap upload script via `expo config --json`, even when
+ * withSentry is used programmatically in app.config.ts.
+ *
+ * We use _internal instead of extra because _internal is stripped from the
+ * public config (app manifest) and not shipped in the production app, while
+ * extra would leak org/project metadata into the app binary.
+ */
+function storeBuildPropertiesInConfig(config: ExpoConfig, props: PluginProps | void): void {
+  if (props?.organization || props?.project) {
+    // ExpoConfig types don't include _internal, but it's a standard Expo field
+    // used by config plugins infrastructure (e.g. pluginHistory).
+    const configWithInternal = config as ExpoConfig & { _internal?: Record<string, unknown> };
+    configWithInternal._internal = configWithInternal._internal || {};
+    configWithInternal._internal.sentryBuildProperties = {
+      organization: props?.organization,
+      project: props?.project,
+      url: props?.url || 'https://sentry.io/',
+    };
+  }
+}
+
 const withSentryPlugin: ConfigPlugin<PluginProps | void> = (config, props) => {
   const sentryProperties = getSentryProperties(props);
 
@@ -29,6 +52,8 @@ const withSentryPlugin: ConfigPlugin<PluginProps | void> = (config, props) => {
     // If not removed, the plugin config with the authToken will be written to the application package
     delete props.authToken;
   }
+
+  storeBuildPropertiesInConfig(config, props);
 
   let cfg = config;
   const pluginOptions = props?.options ? { ...props.options } : {};

--- a/packages/core/scripts/expo-upload-sourcemaps.js
+++ b/packages/core/scripts/expo-upload-sourcemaps.js
@@ -21,11 +21,7 @@ function getSentryPluginPropertiesFromExpoConfig() {
       throw result.error || new Error(`expo config exited with status ${result.status}`);
     }
     const config = JSON.parse(result.stdout);
-    const plugins = config.plugins;
-    if (!plugins) {
-      return null;
-    }
-
+    const plugins = config.plugins || [];
     const sentryPlugin = plugins.find(plugin => {
       if (!Array.isArray(plugin) || plugin.length < 2) {
         return false;

--- a/packages/core/scripts/expo-upload-sourcemaps.js
+++ b/packages/core/scripts/expo-upload-sourcemaps.js
@@ -34,15 +34,65 @@ function getSentryPluginPropertiesFromExpoConfig() {
       return pluginName === '@sentry/react-native/expo';
     });
 
-    if (!sentryPlugin) {
-      return null;
+    if (sentryPlugin) {
+      const [, pluginConfig] = sentryPlugin;
+      return pluginConfig;
     }
-    const [, pluginConfig] = sentryPlugin;
-    return pluginConfig;
+
+    // When withSentry is used programmatically in app.config.ts, the plugin
+    // doesn't appear in the plugins array. Check config._internal where the
+    // plugin stashes build-time properties as a fallback.
+    if (config._internal?.sentryBuildProperties) {
+      return config._internal.sentryBuildProperties;
+    }
+
+    return null;
   } catch (error) {
     console.error('Error fetching expo config:', error);
     return null;
   }
+}
+
+function getSentryPropertiesFromFile() {
+  const candidates = [
+    path.join(projectRoot, 'android', 'sentry.properties'),
+    path.join(projectRoot, 'ios', 'sentry.properties'),
+  ];
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) {
+      continue;
+    }
+    try {
+      const content = fs.readFileSync(candidate, 'utf8');
+      const props = {};
+      for (const line of content.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) {
+          continue;
+        }
+        const eqIndex = trimmed.indexOf('=');
+        if (eqIndex === -1) {
+          continue;
+        }
+        const key = trimmed.substring(0, eqIndex).trim();
+        const value = trimmed.substring(eqIndex + 1).trim();
+        if (key === 'defaults.org') {
+          props.organization = value;
+        } else if (key === 'defaults.project') {
+          props.project = value;
+        } else if (key === 'defaults.url') {
+          props.url = value;
+        }
+      }
+      if (props.organization || props.project) {
+        console.log(`Found sentry properties in ${candidate}`);
+        return props;
+      }
+    } catch (_e) {
+      // continue to next candidate
+    }
+  }
+  return null;
 }
 
 function readAndPrintJSONFile(filePath) {
@@ -144,9 +194,16 @@ const sentryCliBin = getEnvVar(SENTRY_CLI_EXECUTABLE) || require.resolve('@sentr
 
 if (!sentryOrg || !sentryProject || !sentryUrl) {
   console.log('🐕 Fetching from expo config...');
-  const pluginConfig = getSentryPluginPropertiesFromExpoConfig();
+  let pluginConfig = getSentryPluginPropertiesFromExpoConfig();
   if (!pluginConfig) {
-    console.error("Could not fetch '@sentry/react-native' plugin properties from expo config.");
+    console.log('Could not fetch from expo config, trying sentry.properties files...');
+    pluginConfig = getSentryPropertiesFromFile();
+  }
+  if (!pluginConfig) {
+    console.error(
+      "Could not resolve Sentry configuration. Set SENTRY_ORG, SENTRY_PROJECT, and SENTRY_URL environment variables, " +
+      "or ensure '@sentry/react-native/expo' is in your plugins array in app.json/app.config.ts."
+    );
     process.exit(1);
   }
 

--- a/packages/core/test/scripts/expo-upload-sourcemaps.test.ts
+++ b/packages/core/test/scripts/expo-upload-sourcemaps.test.ts
@@ -294,6 +294,223 @@ process.exit(exitCode);
     });
   });
 
+  describe('sentry.properties fallback', () => {
+    let mockNpxScript: string;
+    let mockBinDir: string;
+
+    beforeEach(() => {
+      // Create a mock npx that makes `expo config --json` fail fast
+      // so the script falls through to the sentry.properties fallback
+      mockBinDir = path.join(tempDir, 'mock-bin');
+      fs.mkdirSync(mockBinDir, { recursive: true });
+      mockNpxScript = path.join(mockBinDir, 'npx');
+      fs.writeFileSync(mockNpxScript, '#!/usr/bin/env node\nprocess.exit(1);\n');
+      fs.chmodSync(mockNpxScript, '755');
+    });
+
+    const createSentryProperties = (dir: string, content: string) => {
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, 'sentry.properties'), content);
+    };
+
+    const runScriptWithCwd = (
+      cwd: string,
+      env: Record<string, string | undefined> = {},
+    ): { stdout: string; stderr: string; exitCode: number } => {
+      const defaultEnv = {
+        SENTRY_AUTH_TOKEN: 'test-token',
+        SENTRY_CLI_EXECUTABLE: mockSentryCliScript,
+        // Put mock npx first in PATH so expo config fails fast
+        PATH: `${mockBinDir}:${process.env.PATH}`,
+      };
+
+      const result = spawnSync(process.execPath, [EXPO_UPLOAD_SCRIPT, outputDir], {
+        cwd,
+        env: { ...process.env, ...defaultEnv, ...env },
+        encoding: 'utf8',
+        timeout: 10000,
+      });
+
+      return {
+        stdout: result.stdout || '',
+        stderr: result.stderr || '',
+        exitCode: result.status || 0,
+      };
+    };
+
+    it('reads config from android/sentry.properties when expo config is not available', () => {
+      createAssets(['bundle.js', 'bundle.js.map']);
+      createSentryProperties(
+        path.join(tempDir, 'android'),
+        'defaults.url=https://sentry.io/\ndefaults.org=props-org\ndefaults.project=props-project\n',
+      );
+
+      const result = runScriptWithCwd(tempDir, {
+        SENTRY_ORG: undefined,
+        SENTRY_PROJECT: undefined,
+        SENTRY_URL: undefined,
+        MOCK_CLI_EXIT_CODE: '0',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Found sentry properties in');
+      expect(result.stdout).toContain('android');
+    });
+
+    it('reads config from ios/sentry.properties when android is not available', () => {
+      createAssets(['bundle.js', 'bundle.js.map']);
+      createSentryProperties(
+        path.join(tempDir, 'ios'),
+        'defaults.url=https://sentry.io/\ndefaults.org=ios-org\ndefaults.project=ios-project\n',
+      );
+
+      const result = runScriptWithCwd(tempDir, {
+        SENTRY_ORG: undefined,
+        SENTRY_PROJECT: undefined,
+        SENTRY_URL: undefined,
+        MOCK_CLI_EXIT_CODE: '0',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Found sentry properties in');
+      expect(result.stdout).toContain('ios');
+    });
+
+    it('skips comment lines and empty lines in sentry.properties', () => {
+      createAssets(['bundle.js', 'bundle.js.map']);
+      createSentryProperties(
+        path.join(tempDir, 'android'),
+        '# This is a comment\ndefaults.url=https://sentry.io/\n\ndefaults.org=comment-org\n# Another comment\ndefaults.project=comment-project\n',
+      );
+
+      const result = runScriptWithCwd(tempDir, {
+        SENTRY_ORG: undefined,
+        SENTRY_PROJECT: undefined,
+        SENTRY_URL: undefined,
+        MOCK_CLI_EXIT_CODE: '0',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Found sentry properties in');
+    });
+
+    it('fails with helpful message when no config source is available', () => {
+      createAssets(['bundle.js', 'bundle.js.map']);
+
+      const result = runScriptWithCwd(tempDir, {
+        SENTRY_ORG: undefined,
+        SENTRY_PROJECT: undefined,
+        SENTRY_URL: undefined,
+      });
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('SENTRY_ORG');
+      expect(output).toContain('SENTRY_PROJECT');
+    });
+  });
+
+  describe('config._internal.sentryBuildProperties fallback (withSentry programmatic usage)', () => {
+    const runScriptWithMockExpoConfig = (
+      expoConfig: Record<string, unknown>,
+      env: Record<string, string | undefined> = {},
+    ): { stdout: string; stderr: string; exitCode: number } => {
+      // Create a mock npx that outputs the given expo config as JSON
+      const mockBinDir = path.join(tempDir, 'mock-bin-expo');
+      fs.mkdirSync(mockBinDir, { recursive: true });
+      const mockNpxScript = path.join(mockBinDir, 'npx');
+      // The mock npx script outputs the config JSON when called with 'expo config --json'
+      fs.writeFileSync(
+        mockNpxScript,
+        `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args.includes('expo') && args.includes('config') && args.includes('--json')) {
+  process.stdout.write(${JSON.stringify(JSON.stringify(expoConfig))});
+  process.exit(0);
+}
+process.exit(1);
+`,
+      );
+      fs.chmodSync(mockNpxScript, '755');
+
+      const defaultEnv = {
+        SENTRY_AUTH_TOKEN: 'test-token',
+        SENTRY_CLI_EXECUTABLE: mockSentryCliScript,
+        PATH: `${mockBinDir}:${process.env.PATH}`,
+      };
+
+      const result = spawnSync(process.execPath, [EXPO_UPLOAD_SCRIPT, outputDir], {
+        cwd: tempDir,
+        env: { ...process.env, ...defaultEnv, ...env },
+        encoding: 'utf8',
+        timeout: 10000,
+      });
+
+      return {
+        stdout: result.stdout || '',
+        stderr: result.stderr || '',
+        exitCode: result.status || 0,
+      };
+    };
+
+    it('reads config from _internal.sentryBuildProperties when plugin is not in plugins array', () => {
+      createAssets(['bundle.js', 'bundle.js.map']);
+
+      const result = runScriptWithMockExpoConfig(
+        {
+          plugins: [['some-other-plugin', {}]],
+          _internal: {
+            sentryBuildProperties: {
+              organization: 'internal-org',
+              project: 'internal-project',
+              url: 'https://sentry.io/',
+            },
+          },
+        },
+        {
+          SENTRY_ORG: undefined,
+          SENTRY_PROJECT: undefined,
+          SENTRY_URL: undefined,
+          MOCK_CLI_EXIT_CODE: '0',
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Uploaded bundles and sourcemaps to Sentry successfully');
+    });
+
+    it('prefers plugins array over _internal.sentryBuildProperties', () => {
+      createAssets(['bundle.js', 'bundle.js.map']);
+
+      const result = runScriptWithMockExpoConfig(
+        {
+          plugins: [
+            [
+              '@sentry/react-native/expo',
+              { organization: 'plugin-org', project: 'plugin-project', url: 'https://sentry.io/' },
+            ],
+          ],
+          _internal: {
+            sentryBuildProperties: {
+              organization: 'internal-org',
+              project: 'internal-project',
+              url: 'https://sentry.io/',
+            },
+          },
+        },
+        {
+          SENTRY_ORG: undefined,
+          SENTRY_PROJECT: undefined,
+          SENTRY_URL: undefined,
+          MOCK_CLI_EXIT_CODE: '0',
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('SENTRY_ORG resolved to plugin-org');
+    });
+  });
+
   describe('sourcemap processing', () => {
     it('converts debugId to debug_id in sourcemaps', () => {
       createAssets(['bundle.js', 'bundle.js.map']);

--- a/packages/core/test/scripts/expo-upload-sourcemaps.test.ts
+++ b/packages/core/test/scripts/expo-upload-sourcemaps.test.ts
@@ -509,6 +509,31 @@ process.exit(1);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('SENTRY_ORG resolved to plugin-org');
     });
+
+    it('reads _internal.sentryBuildProperties even when plugins array is missing', () => {
+      createAssets(['bundle.js', 'bundle.js.map']);
+
+      const result = runScriptWithMockExpoConfig(
+        {
+          _internal: {
+            sentryBuildProperties: {
+              organization: 'no-plugins-org',
+              project: 'no-plugins-project',
+              url: 'https://sentry.io/',
+            },
+          },
+        },
+        {
+          SENTRY_ORG: undefined,
+          SENTRY_PROJECT: undefined,
+          SENTRY_URL: undefined,
+          MOCK_CLI_EXIT_CODE: '0',
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Uploaded bundles and sourcemaps to Sentry successfully');
+    });
   });
 
   describe('sourcemap processing', () => {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

When `withSentry` is used programmatically in `app.config.ts`, the Expo sourcemap upload script (`sentry-expo-upload-sourcemaps`) fails because it discovers Sentry config by looking for `@sentry/react-native/expo` in the `plugins` array of `expo config --json`. Programmatically-applied plugins don't appear in this array.

This PR fixes the issue by:

1. **Stashing build-time properties in `config._internal`** — The `withSentry` plugin now stores `organization`, `project`, and `url` in `config._internal.sentryBuildProperties` during config resolution. This field is included in `expo config --json` output but is stripped from the public app manifest (`isPublicConfig: true` deletes `_internal`), so no metadata leaks into production builds.

2. **Reading `_internal.sentryBuildProperties` in the upload script** — When the plugin isn't found in the `plugins` array, the script now checks `config._internal.sentryBuildProperties` from the same `expo config --json` response.

3. **Fallback to `sentry.properties` files** — As additional defense-in-depth, the script also tries reading `android/sentry.properties` or `ios/sentry.properties` (created during `expo prebuild`).

4. **Improved error message** — When no config source is found, the error now mentions the `SENTRY_ORG`/`SENTRY_PROJECT`/`SENTRY_URL` environment variable workaround.

### Resolution chain (in order of priority)
1. Environment variables (`SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_URL`)
2. Declarative plugin in `config.plugins` array
3. `config._internal.sentryBuildProperties` (new — fixes the reported issue)
4. `sentry.properties` files from prebuild (new — defense-in-depth)
5. Error with actionable guidance

## :bulb: Motivation and Context

Follow up to https://github.com/getsentry/sentry-react-native/issues/5303#issuecomment-4239823688

Users following the `withSentry` documentation for `app.config.ts` hit this error when uploading sourcemaps for EAS Update:
```
Could not fetch '@sentry/react-native' plugin properties from expo config.
```

The root cause is that `createRunOncePlugin` (used by `withSentry`) applies config modifications through Expo's mod system but doesn't add the plugin to `config.plugins`. The `expo config --json` output therefore lacks the plugin entry, and the upload script can't find it.

## :green_heart: How did you test it?

- Added 6 new tests covering `_internal.sentryBuildProperties` fallback, `sentry.properties` fallback, priority ordering, and error messaging
- End-to-end verified locally: created a minimal `app.config.js` using programmatic `withSentry`, confirmed `expo config --json` includes `_internal.sentryBuildProperties` while `plugins` array does not contain the sentry plugin
- Verified `_internal` is stripped from the public config (app manifest) by Expo's `getConfig({ isPublicConfig: true })`, so no metadata ships in the production app
- All 196 existing SDK tests pass
- Lint passes

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps