### PR TITLE
ci(danger): Demote Android SDK version mismatch from fail to warn

### DIFF
--- a/scripts/check-android-sdk-mismatch.js
+++ b/scripts/check-android-sdk-mismatch.js
@@ -119,17 +119,20 @@ module.exports = async function ({ fail, warn, __, ___, danger }) {
 
   // Compare versions
   if (sdkVersion !== bundledVersion) {
-    fail(
+    warn(
       createSectionWarning(
         'Android SDK Version Mismatch',
         `| Component | Version |\n` +
           `|-----------|--------|\n` +
           `| \`sentry-android\` in build.gradle | **${sdkVersion}** |\n` +
           `| \`sentry-android\` bundled by gradle plugin ${gradlePluginVersion} | **${bundledVersion}** |\n\n` +
-          `This mismatch will cause crashes on Android with error:\n` +
+          `If a user enables AGP \`autoInstallation\` (default: \`true\`), this mismatch causes:\n` +
           `> \`IllegalStateException: Sentry SDK has detected a mix of versions\`\n\n` +
-          `**Fix:** Update \`packages/core/android/build.gradle\` to use version \`${bundledVersion}\` ` +
-          `or wait for a gradle plugin release that bundles \`${sdkVersion}\`.`,
+          `Our docs instruct React Native users to set \`autoInstallation.enabled = false\`, ` +
+          `so users following the guide are unaffected. Consider either updating ` +
+          `\`packages/core/android/build.gradle\` to \`${bundledVersion}\` or waiting for a ` +
+          `gradle plugin release that bundles \`${sdkVersion}\`.`,
+        '⚠️',
       ),
     );
   } else {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

Downgrade the Danger check in `scripts/check-android-sdk-mismatch.js` from `fail()` to `warn()` when the `sentry-android` version in `packages/core/android/build.gradle` differs from the version bundled by the pinned Sentry Android Gradle Plugin (AGP).

The message is also updated to reflect that the crash is conditional on AGP `autoInstallation` being enabled, and to point reviewers at the docs-based mitigation rather than treating the mismatch as a guaranteed crash.

## :bulb: Motivation and Context

The check was originally added as a hard fail because an `IllegalStateException: Sentry SDK has detected a mix of versions` crash can occur at app startup when AGP's `autoInstallation` (default: `true`) pulls in a different `sentry-android` version than the one shipped by `@sentry/react-native`.

Since then, the docs have been updated to explicitly instruct React Native users to disable `autoInstallation` in their `android/app/build.gradle`:

- getsentry/sentry-docs#17349 — adds warning alerts to the manual setup guide and v7→v8 migration page, plus a dedicated troubleshooting section for the `IllegalStateException`.

Per internal discussion, adding AGP to a React Native app is an explicit opt-in step, and users performing that step are expected to follow the setup guide — which now prominently instructs them to set `autoInstallation.enabled = false`. In that world, a version mismatch between our bundled `sentry-android` and the version AGP would auto-install is no longer a guaranteed crash: it only affects users who both opt into AGP and ignore the documented configuration.

Keeping the check as `fail()` couples RN SDK release cadence to gradle plugin release cadence (we couldn't bump `sentry-android` until a matching AGP release shipped), without providing meaningful additional protection over the docs. Demoting to `warn()` preserves reviewer visibility while unblocking dependency bumps.


## :green_heart: How did you test it?

- Manual review of the updated Danger rule; all other branches in the script already emit `warn()` with a `⚠️` icon, so the mismatch branch is now visually and behaviorally consistent with them.
- The check path is otherwise unchanged — same parsing, same upstream fetch, same comparison; only the severity and message content change.


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps