### PR TITLE
feat(core): Add GlobalErrorBoundary for non-rendering errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Features
 
 - Warn Expo users at Metro startup when prebuilt native projects are missing Sentry configuration ([#5984](https://github.com/getsentry/sentry-react-native/pull/5984))
-- Add `Sentry.GlobalErrorBoundary` component (and `withGlobalErrorBoundary` HOC) that renders a fallback UI for fatal non-rendering JS errors routed through `ErrorUtils` in addition to the render-phase errors caught by `Sentry.ErrorBoundary`. Opt-in flags `includeNonFatalGlobalErrors` and `includeUnhandledRejections` extend the fallback to non-fatal errors and unhandled promise rejections respectively. ([#5930](https://github.com/getsentry/sentry-react-native/issues/5930))
+- Add `Sentry.GlobalErrorBoundary` component (and `withGlobalErrorBoundary` HOC) that renders a fallback UI for fatal non-rendering JS errors routed through `ErrorUtils` in addition to the render-phase errors caught by `Sentry.ErrorBoundary`. Opt-in flags `includeNonFatalGlobalErrors` and `includeUnhandledRejections` extend the fallback to non-fatal errors and unhandled promise rejections respectively. ([#6023](https://github.com/getsentry/sentry-react-native/pull/6023))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - Warn Expo users at Metro startup when prebuilt native projects are missing Sentry configuration ([#5984](https://github.com/getsentry/sentry-react-native/pull/5984))
+- Add `Sentry.GlobalErrorBoundary` component (and `withGlobalErrorBoundary` HOC) that renders a fallback UI for fatal non-rendering JS errors routed through `ErrorUtils` in addition to the render-phase errors caught by `Sentry.ErrorBoundary`. Opt-in flags `includeNonFatalGlobalErrors` and `includeUnhandledRejections` extend the fallback to non-fatal errors and unhandled promise rejections respectively. ([#5930](https://github.com/getsentry/sentry-react-native/issues/5930))
 
 ### Dependencies
 

--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -148,9 +148,11 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
     this._latched = true;
 
     const error = event.error ?? new Error('Unknown global error');
-    // The integration captured the event just before publishing, so the
-    // current lastEventId is ours. Fall back to '' to match the type contract.
-    const eventId = lastEventId() ?? '';
+    // Prefer the eventId threaded through the bus payload — it's the exact id
+    // returned by the capture call that produced this notification. Fall back
+    // to lastEventId() for older publishers that don't include it, then to ''
+    // to satisfy the type contract.
+    const eventId = event.eventId ?? lastEventId() ?? '';
 
     this.setState({ globalError: error, globalEventId: eventId });
     this.props.onError?.(error, '', eventId);

--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -142,7 +142,9 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
     // shouldn't rewrite what the user is looking at. We use an instance flag
     // instead of reading state because multiple publishes can fire in the
     // same batch, before setState has flushed.
-    if (this._latched) return;
+    if (this._latched) {
+      return;
+    }
     this._latched = true;
     this.setState({ globalError: event.error ?? new Error('Unknown global error') });
   };

--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -1,0 +1,177 @@
+import type { ErrorBoundaryProps } from '@sentry/react';
+
+import { ErrorBoundary } from '@sentry/react';
+import * as React from 'react';
+
+import type { GlobalErrorEvent } from './integrations/globalErrorBus';
+
+import { subscribeGlobalError } from './integrations/globalErrorBus';
+
+/**
+ * Props for {@link GlobalErrorBoundary}. Extends the standard `ErrorBoundary`
+ * props from `@sentry/react` with two opt-ins that control which
+ * non-rendering errors trigger the fallback UI.
+ */
+export type GlobalErrorBoundaryProps = ErrorBoundaryProps & {
+  /**
+   * If `true`, the fallback is also rendered for *non-fatal* errors routed
+   * through `ErrorUtils` (React Native's global handler).
+   *
+   * Defaults to `false` — only fatals trigger the fallback, matching the
+   * semantics of the native red-screen.
+   */
+  includeNonFatalGlobalErrors?: boolean;
+
+  /**
+   * If `true`, the fallback is also rendered for unhandled promise rejections.
+   *
+   * Defaults to `false` because many apps prefer to surface rejections as
+   * toasts / inline errors rather than as a full-screen fallback.
+   */
+  includeUnhandledRejections?: boolean;
+};
+
+interface GlobalErrorThrowerProps {
+  error: unknown | null;
+  children?: React.ReactNode | (() => React.ReactNode);
+}
+
+/**
+ * Tiny component that re-throws a global error during render so the
+ * surrounding `ErrorBoundary` catches it through the standard React path.
+ */
+class GlobalErrorThrower extends React.Component<GlobalErrorThrowerProps> {
+  public render(): React.ReactNode {
+    if (this.props.error !== null && this.props.error !== undefined) {
+      // Throwing here routes the error into the surrounding ErrorBoundary's
+      // getDerivedStateFromError / componentDidCatch lifecycle.
+      throw this.props.error;
+    }
+    return typeof this.props.children === 'function' ? this.props.children() : this.props.children;
+  }
+}
+
+interface GlobalErrorBoundaryState {
+  globalError: unknown | null;
+}
+
+/**
+ * An error boundary that also catches **non-rendering** fatal JS errors.
+ *
+ * In addition to the render-phase errors caught by `Sentry.ErrorBoundary`,
+ * this component renders the provided fallback when:
+ *
+ * - A fatal error is reported through React Native's `ErrorUtils` global
+ *   handler (event handlers, timers, native → JS bridge errors, …).
+ * - Optionally, non-fatal global errors (opt-in via
+ *   `includeNonFatalGlobalErrors`).
+ * - Optionally, unhandled promise rejections (opt-in via
+ *   `includeUnhandledRejections`).
+ *
+ * The Sentry error pipeline (capture → flush → mechanism tagging) is
+ * unchanged; this component only surfaces the fallback UI and suppresses
+ * React Native's default fatal handler while the fallback is mounted.
+ *
+ * Intended usage is at the top of the component tree, typically just inside
+ * `Sentry.wrap()`:
+ *
+ * ```tsx
+ * <Sentry.GlobalErrorBoundary
+ *   fallback={({ error, resetError }) => (
+ *     <MyFallback error={error} onRetry={resetError} />
+ *   )}
+ * >
+ *   <App />
+ * </Sentry.GlobalErrorBoundary>
+ * ```
+ */
+export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProps, GlobalErrorBoundaryState> {
+  public state: GlobalErrorBoundaryState = { globalError: null };
+
+  private _unsubscribe?: () => void;
+  private _latched = false;
+
+  public componentDidMount(): void {
+    this._unsubscribe = subscribeGlobalError(this._onGlobalError, {
+      fatal: true,
+      nonFatal: !!this.props.includeNonFatalGlobalErrors,
+      unhandledRejection: !!this.props.includeUnhandledRejections,
+    });
+  }
+
+  public componentWillUnmount(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = undefined;
+  }
+
+  public componentDidUpdate(prevProps: GlobalErrorBoundaryProps): void {
+    // Re-subscribe if the opt-in flags change so the filter stays accurate.
+    if (
+      prevProps.includeNonFatalGlobalErrors !== this.props.includeNonFatalGlobalErrors ||
+      prevProps.includeUnhandledRejections !== this.props.includeUnhandledRejections
+    ) {
+      this._unsubscribe?.();
+      this._unsubscribe = subscribeGlobalError(this._onGlobalError, {
+        fatal: true,
+        nonFatal: !!this.props.includeNonFatalGlobalErrors,
+        unhandledRejection: !!this.props.includeUnhandledRejections,
+      });
+    }
+  }
+
+  public render(): React.ReactNode {
+    const {
+      children,
+      onReset,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      includeNonFatalGlobalErrors: _ignoredA,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      includeUnhandledRejections: _ignoredB,
+      ...forwarded
+    } = this.props;
+
+    return (
+      <ErrorBoundary {...forwarded} onReset={this._onReset(onReset)}>
+        <GlobalErrorThrower error={this.state.globalError}>{children}</GlobalErrorThrower>
+      </ErrorBoundary>
+    );
+  }
+
+  private _onGlobalError = (event: GlobalErrorEvent): void => {
+    // Keep the first error — once the fallback is up, subsequent errors
+    // shouldn't rewrite what the user is looking at. We use an instance flag
+    // instead of reading state because multiple publishes can fire in the
+    // same batch, before setState has flushed.
+    if (this._latched) return;
+    this._latched = true;
+    this.setState({ globalError: event.error ?? new Error('Unknown global error') });
+  };
+
+  private _onReset =
+    (userOnReset: GlobalErrorBoundaryProps['onReset']) =>
+    (error: unknown, componentStack: string, eventId: string): void => {
+      this._latched = false;
+      this.setState({ globalError: null });
+      userOnReset?.(error, componentStack, eventId);
+    };
+}
+
+/**
+ * HOC counterpart to {@link GlobalErrorBoundary}.
+ */
+export function withGlobalErrorBoundary<P extends Record<string, unknown>>(
+  WrappedComponent: React.ComponentType<P>,
+  errorBoundaryOptions: GlobalErrorBoundaryProps,
+): React.FC<P> {
+  const componentDisplayName = WrappedComponent.displayName || WrappedComponent.name || 'unknown';
+
+  const Wrapped: React.FC<P> = props => (
+    <GlobalErrorBoundary {...errorBoundaryOptions}>
+      <WrappedComponent {...props} />
+    </GlobalErrorBoundary>
+  );
+
+  Wrapped.displayName = `globalErrorBoundary(${componentDisplayName})`;
+
+  return Wrapped;
+}

--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import type { ErrorBoundaryProps } from '@sentry/react';
 
+import { lastEventId } from '@sentry/core';
 import { ErrorBoundary } from '@sentry/react';
 import * as React from 'react';
 
@@ -31,28 +32,9 @@ export type GlobalErrorBoundaryProps = ErrorBoundaryProps & {
   includeUnhandledRejections?: boolean;
 };
 
-interface GlobalErrorThrowerProps {
-  error: unknown | null;
-  children?: React.ReactNode | (() => React.ReactNode);
-}
-
-/**
- * Tiny component that re-throws a global error during render so the
- * surrounding `ErrorBoundary` catches it through the standard React path.
- */
-class GlobalErrorThrower extends React.Component<GlobalErrorThrowerProps> {
-  public render(): React.ReactNode {
-    if (this.props.error !== null && this.props.error !== undefined) {
-      // Throwing here routes the error into the surrounding ErrorBoundary's
-      // getDerivedStateFromError / componentDidCatch lifecycle.
-      throw this.props.error;
-    }
-    return typeof this.props.children === 'function' ? this.props.children() : this.props.children;
-  }
-}
-
 interface GlobalErrorBoundaryState {
   globalError: unknown | null;
+  globalEventId: string;
 }
 
 /**
@@ -68,9 +50,9 @@ interface GlobalErrorBoundaryState {
  * - Optionally, unhandled promise rejections (opt-in via
  *   `includeUnhandledRejections`).
  *
- * The Sentry error pipeline (capture → flush → mechanism tagging) is
- * unchanged; this component only surfaces the fallback UI and suppresses
- * React Native's default fatal handler while the fallback is mounted.
+ * The Sentry error pipeline (capture → flush → mechanism tagging) runs in the
+ * integration before this component is notified, so the fallback UI surfaces
+ * an already-captured event and does not generate a duplicate.
  *
  * Intended usage is at the top of the component tree, typically just inside
  * `Sentry.wrap()`:
@@ -86,17 +68,13 @@ interface GlobalErrorBoundaryState {
  * ```
  */
 export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProps, GlobalErrorBoundaryState> {
-  public state: GlobalErrorBoundaryState = { globalError: null };
+  public state: GlobalErrorBoundaryState = { globalError: null, globalEventId: '' };
 
   private _unsubscribe?: () => void;
   private _latched = false;
 
   public componentDidMount(): void {
-    this._unsubscribe = subscribeGlobalError(this._onGlobalError, {
-      fatal: true,
-      nonFatal: !!this.props.includeNonFatalGlobalErrors,
-      unhandledRejection: !!this.props.includeUnhandledRejections,
-    });
+    this._subscribe();
   }
 
   public componentWillUnmount(): void {
@@ -111,18 +89,15 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
       prevProps.includeUnhandledRejections !== this.props.includeUnhandledRejections
     ) {
       this._unsubscribe?.();
-      this._unsubscribe = subscribeGlobalError(this._onGlobalError, {
-        fatal: true,
-        nonFatal: !!this.props.includeNonFatalGlobalErrors,
-        unhandledRejection: !!this.props.includeUnhandledRejections,
-      });
+      this._subscribe();
     }
   }
 
   public render(): React.ReactNode {
+    const { globalError, globalEventId } = this.state;
     const {
       children,
-      onReset,
+      fallback,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       includeNonFatalGlobalErrors: _ignoredA,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -130,11 +105,36 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
       ...forwarded
     } = this.props;
 
+    // Global-error path: render the fallback directly. The error was already
+    // captured by the integration before the bus published it, so we must NOT
+    // route it through @sentry/react's ErrorBoundary — its componentDidCatch
+    // would call captureReactException and produce a duplicate Sentry event.
+    if (globalError !== null && globalError !== undefined) {
+      if (typeof fallback === 'function') {
+        return fallback({
+          error: globalError,
+          componentStack: '',
+          eventId: globalEventId,
+          resetError: this._resetFromFallback,
+        });
+      }
+      return fallback ?? null;
+    }
+
+    // Render-phase path: delegate to the upstream ErrorBoundary untouched.
     return (
-      <ErrorBoundary {...forwarded} onReset={this._onReset(onReset)}>
-        <GlobalErrorThrower error={this.state.globalError}>{children}</GlobalErrorThrower>
+      <ErrorBoundary {...forwarded} fallback={fallback} onReset={this._onRenderBoundaryReset}>
+        {children}
       </ErrorBoundary>
     );
+  }
+
+  private _subscribe(): void {
+    this._unsubscribe = subscribeGlobalError(this._onGlobalError, {
+      fatal: true,
+      nonFatal: !!this.props.includeNonFatalGlobalErrors,
+      unhandledRejection: !!this.props.includeUnhandledRejections,
+    });
   }
 
   private _onGlobalError = (event: GlobalErrorEvent): void => {
@@ -146,16 +146,28 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
       return;
     }
     this._latched = true;
-    this.setState({ globalError: event.error ?? new Error('Unknown global error') });
+
+    const error = event.error ?? new Error('Unknown global error');
+    // The integration captured the event just before publishing, so the
+    // current lastEventId is ours. Fall back to '' to match the type contract.
+    const eventId = lastEventId() ?? '';
+
+    this.setState({ globalError: error, globalEventId: eventId });
+    this.props.onError?.(error, '', eventId);
   };
 
-  private _onReset =
-    (userOnReset: GlobalErrorBoundaryProps['onReset']) =>
-    (error: unknown, componentStack: string, eventId: string): void => {
-      this._latched = false;
-      this.setState({ globalError: null });
-      userOnReset?.(error, componentStack, eventId);
-    };
+  private _resetFromFallback = (): void => {
+    const { globalError, globalEventId } = this.state;
+    this._latched = false;
+    this.setState({ globalError: null, globalEventId: '' });
+    this.props.onReset?.(globalError, '', globalEventId);
+  };
+
+  private _onRenderBoundaryReset = (error: unknown, componentStack: string, eventId: string): void => {
+    // Delegate to the user's onReset for render-phase resets; no internal
+    // state to clear on this path.
+    this.props.onReset?.(error, componentStack, eventId);
+  };
 }
 
 /**

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -75,6 +75,8 @@ export { ReactNativeClient } from './client';
 
 export { init, wrap, nativeCrash, flush, close, withScope, crashedLastRun, appLoaded } from './sdk';
 export { TouchEventBoundary, withTouchEventBoundary } from './touchevents';
+export { GlobalErrorBoundary, withGlobalErrorBoundary } from './GlobalErrorBoundary';
+export type { GlobalErrorBoundaryProps } from './GlobalErrorBoundary';
 
 export {
   reactNativeTracingIntegration,

--- a/packages/core/src/js/integrations/globalErrorBus.ts
+++ b/packages/core/src/js/integrations/globalErrorBus.ts
@@ -9,6 +9,8 @@
  * This module is internal to the SDK.
  */
 
+import { debug } from '@sentry/core';
+
 import { RN_GLOBAL_OBJ } from '../utils/worldwide';
 
 /** Where the error came from. */
@@ -19,6 +21,13 @@ export interface GlobalErrorEvent {
   error: unknown;
   isFatal: boolean;
   kind: GlobalErrorKind;
+  /**
+   * Sentry event id assigned when the integration captured this error.
+   * Threaded through to subscribers so the fallback UI can show the exact
+   * id without racing against unrelated `captureException` calls happening
+   * elsewhere in the app via `lastEventId()`.
+   */
+  eventId?: string;
 }
 
 /** Options describing which kinds of errors a subscriber wants. */
@@ -91,14 +100,24 @@ export function hasInterestedSubscribers(kind: GlobalErrorKind, isFatal: boolean
 }
 
 /**
- * Publish a global error to all interested subscribers.
+ * Publish a global error to all interested subscribers. Each listener runs
+ * isolated in try/catch so a misbehaving subscriber cannot interrupt others
+ * or unwind into the caller (the error handlers integration depends on
+ * publish never throwing so its `handlingFatal` latch is always released).
  */
 export function publishGlobalError(event: GlobalErrorEvent): void {
   for (const { listener, options } of getBus().subscribers) {
-    if (event.kind === 'onerror') {
-      if (event.isFatal ? options.fatal : options.nonFatal) listener(event);
-    } else if (event.kind === 'onunhandledrejection' && options.unhandledRejection) {
+    const interested =
+      event.kind === 'onerror'
+        ? event.isFatal
+          ? options.fatal
+          : options.nonFatal
+        : event.kind === 'onunhandledrejection' && options.unhandledRejection;
+    if (!interested) continue;
+    try {
       listener(event);
+    } catch (e) {
+      debug.error('[GlobalErrorBus] Subscriber threw while handling a global error.', e);
     }
   }
 }

--- a/packages/core/src/js/integrations/globalErrorBus.ts
+++ b/packages/core/src/js/integrations/globalErrorBus.ts
@@ -1,0 +1,109 @@
+/**
+ * Global error bus used by {@link GlobalErrorBoundary} to receive errors that
+ * are captured outside the React render tree (e.g. `ErrorUtils` fatals,
+ * unhandled promise rejections).
+ *
+ * The bus is intentionally tiny and stored on the global object so that it
+ * survives Fast Refresh during development.
+ *
+ * This module is internal to the SDK.
+ */
+
+import { RN_GLOBAL_OBJ } from '../utils/worldwide';
+
+/** Where the error came from. */
+export type GlobalErrorKind = 'onerror' | 'onunhandledrejection';
+
+/** Payload delivered to subscribers. */
+export interface GlobalErrorEvent {
+  error: unknown;
+  isFatal: boolean;
+  kind: GlobalErrorKind;
+}
+
+/** Options describing which kinds of errors a subscriber wants. */
+export interface GlobalErrorSubscriberOptions {
+  /** Receive fatal `ErrorUtils` errors. Defaults to true. */
+  fatal?: boolean;
+  /** Receive non-fatal `ErrorUtils` errors. Defaults to false. */
+  nonFatal?: boolean;
+  /** Receive unhandled promise rejections. Defaults to false. */
+  unhandledRejection?: boolean;
+}
+
+type Listener = (event: GlobalErrorEvent) => void;
+
+interface Subscriber {
+  listener: Listener;
+  options: Required<GlobalErrorSubscriberOptions>;
+}
+
+interface BusState {
+  subscribers: Set<Subscriber>;
+}
+
+interface GlobalWithBus {
+  __SENTRY_RN_GLOBAL_ERROR_BUS__?: BusState;
+}
+
+function getBus(): BusState {
+  const host = RN_GLOBAL_OBJ as unknown as GlobalWithBus;
+  if (!host.__SENTRY_RN_GLOBAL_ERROR_BUS__) {
+    host.__SENTRY_RN_GLOBAL_ERROR_BUS__ = { subscribers: new Set() };
+  }
+  return host.__SENTRY_RN_GLOBAL_ERROR_BUS__;
+}
+
+/**
+ * Subscribe to global errors. Returns an unsubscribe function.
+ */
+export function subscribeGlobalError(listener: Listener, options: GlobalErrorSubscriberOptions = {}): () => void {
+  const subscriber: Subscriber = {
+    listener,
+    options: {
+      fatal: options.fatal ?? true,
+      nonFatal: options.nonFatal ?? false,
+      unhandledRejection: options.unhandledRejection ?? false,
+    },
+  };
+  getBus().subscribers.add(subscriber);
+  return () => {
+    getBus().subscribers.delete(subscriber);
+  };
+}
+
+/**
+ * Returns true if at least one subscriber is interested in the given event.
+ *
+ * Used by the error handlers integration to decide whether to skip invoking
+ * React Native's default error handler (which would otherwise tear down the
+ * JS context and prevent any fallback UI from rendering).
+ */
+export function hasInterestedSubscribers(kind: GlobalErrorKind, isFatal: boolean): boolean {
+  for (const { options } of getBus().subscribers) {
+    if (kind === 'onerror') {
+      if (isFatal ? options.fatal : options.nonFatal) return true;
+    } else if (kind === 'onunhandledrejection' && options.unhandledRejection) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Publish a global error to all interested subscribers.
+ */
+export function publishGlobalError(event: GlobalErrorEvent): void {
+  for (const { listener, options } of getBus().subscribers) {
+    if (event.kind === 'onerror') {
+      if (event.isFatal ? options.fatal : options.nonFatal) listener(event);
+    } else if (event.kind === 'onunhandledrejection' && options.unhandledRejection) {
+      listener(event);
+    }
+  }
+}
+
+/** Test-only: clear all subscribers. */
+export function _resetGlobalErrorBus(): void {
+  getBus().subscribers.clear();
+}

--- a/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
@@ -14,6 +14,7 @@ import type { ReactNativeClientOptions } from '../options';
 import { isHermesEnabled, isWeb } from '../utils/environment';
 import { createSyntheticError, isErrorLike } from '../utils/error';
 import { RN_GLOBAL_OBJ } from '../utils/worldwide';
+import { hasInterestedSubscribers, publishGlobalError } from './globalErrorBus';
 import { checkPromiseAndWarn, polyfillPromise, requireRejectionTracking } from './reactnativeerrorhandlersutils';
 
 const INTEGRATION_NAME = 'ReactNativeErrorHandlers';
@@ -80,6 +81,7 @@ function setupUnhandledRejectionsTracking(patchGlobalPromise: boolean): void {
           syntheticException: isErrorLike(error) ? undefined : createSyntheticError(),
           mechanism: { handled: false, type: 'onunhandledrejection' },
         });
+        publishGlobalError({ error, isFatal: false, kind: 'onunhandledrejection' });
       });
     } else if (patchGlobalPromise) {
       // For JSC and other environments, use the existing approach
@@ -113,6 +115,7 @@ const promiseRejectionTrackingOptions: PromiseRejectionTrackingOptions = {
       syntheticException: isErrorLike(error) ? undefined : createSyntheticError(),
       mechanism: { handled: true, type: 'onunhandledrejection' },
     });
+    publishGlobalError({ error, isFatal: false, kind: 'onunhandledrejection' });
   },
   onHandled: id => {
     if (__DEV__) {
@@ -204,16 +207,29 @@ function setupErrorUtilsGlobalHandler(): void {
 
     client.captureEvent(event, hint);
 
+    // Notify any mounted GlobalErrorBoundary. Subscribers filter internally by
+    // fatal/non-fatal preferences.
+    publishGlobalError({ error, isFatal: !!isFatal, kind: 'onerror' });
+
+    // If a GlobalErrorBoundary is interested in this error, we skip the
+    // default handler so the fallback UI can own the screen. Otherwise the
+    // default handler would unmount React (in release) or show LogBox (in dev)
+    // over our fallback.
+    const fallbackWillRender = hasInterestedSubscribers('onerror', !!isFatal);
+
     if (__DEV__) {
       // If in dev, we call the default handler anyway and hope the error will be sent
-      // Just for a better dev experience
+      // Just for a better dev experience. If a fallback is mounted it will still
+      // render alongside LogBox.
       defaultHandler(error, isFatal);
       return;
     }
 
     void client.flush((client.getOptions() as ReactNativeClientOptions).shutdownTimeout || 2000).then(
       () => {
-        defaultHandler(error, isFatal);
+        if (!fallbackWillRender) {
+          defaultHandler(error, isFatal);
+        }
       },
       (reason: unknown) => {
         debug.error('[ReactNativeErrorHandlers] Error while flushing the event cache after uncaught error.', reason);

--- a/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
@@ -76,12 +76,16 @@ function setupUnhandledRejectionsTracking(patchGlobalPromise: boolean): void {
 
       // Use Sentry's built-in global unhandled rejection handler
       addGlobalUnhandledRejectionInstrumentationHandler((error: unknown) => {
-        captureException(error, {
+        const eventId = captureException(error, {
           originalException: error,
           syntheticException: isErrorLike(error) ? undefined : createSyntheticError(),
           mechanism: { handled: false, type: 'onunhandledrejection' },
         });
-        publishGlobalError({ error, isFatal: false, kind: 'onunhandledrejection' });
+        try {
+          publishGlobalError({ error, isFatal: false, kind: 'onunhandledrejection', eventId });
+        } catch (e) {
+          debug.error('[ReactNativeErrorHandlers] Failed to publish global error.', e);
+        }
       });
     } else if (patchGlobalPromise) {
       // For JSC and other environments, use the existing approach
@@ -109,13 +113,17 @@ const promiseRejectionTrackingOptions: PromiseRejectionTrackingOptions = {
 
     // Marking the rejection as handled to avoid breaking crash rate calculations.
     // See: https://github.com/getsentry/sentry-react-native/issues/4141
-    captureException(error, {
+    const eventId = captureException(error, {
       data: { id },
       originalException: error,
       syntheticException: isErrorLike(error) ? undefined : createSyntheticError(),
       mechanism: { handled: true, type: 'onunhandledrejection' },
     });
-    publishGlobalError({ error, isFatal: false, kind: 'onunhandledrejection' });
+    try {
+      publishGlobalError({ error, isFatal: false, kind: 'onunhandledrejection', eventId });
+    } catch (e) {
+      debug.error('[ReactNativeErrorHandlers] Failed to publish global error.', e);
+    }
   },
   onHandled: id => {
     if (__DEV__) {
@@ -205,11 +213,16 @@ function setupErrorUtilsGlobalHandler(): void {
       });
     }
 
-    client.captureEvent(event, hint);
+    const eventId = client.captureEvent(event, hint);
 
     // Notify any mounted GlobalErrorBoundary. Subscribers filter internally by
-    // fatal/non-fatal preferences.
-    publishGlobalError({ error, isFatal: !!isFatal, kind: 'onerror' });
+    // fatal/non-fatal preferences. Wrapped defensively so a misbehaving
+    // subscriber can't unwind into this handler and leave handlingFatal set.
+    try {
+      publishGlobalError({ error, isFatal: !!isFatal, kind: 'onerror', eventId });
+    } catch (e) {
+      debug.error('[ReactNativeErrorHandlers] Failed to publish global error.', e);
+    }
 
     if (__DEV__) {
       // If in dev, we call the default handler anyway and hope the error will be sent

--- a/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
@@ -229,9 +229,16 @@ function setupErrorUtilsGlobalHandler(): void {
         if (!hasInterestedSubscribers('onerror', !!isFatal)) {
           defaultHandler(error, isFatal);
         }
+        // Release the latch so any subsequent fatal can still be captured.
+        // Before GlobalErrorBoundary existed, the default handler always tore
+        // the app down, so the latch was effectively permanent. Now the app
+        // can survive the first fatal via the fallback UI, and a later fatal
+        // must flow through the full capture + publish pipeline.
+        handlingFatal = false;
       },
       (reason: unknown) => {
         debug.error('[ReactNativeErrorHandlers] Error while flushing the event cache after uncaught error.', reason);
+        handlingFatal = false;
       },
     );
   });

--- a/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
@@ -211,12 +211,6 @@ function setupErrorUtilsGlobalHandler(): void {
     // fatal/non-fatal preferences.
     publishGlobalError({ error, isFatal: !!isFatal, kind: 'onerror' });
 
-    // If a GlobalErrorBoundary is interested in this error, we skip the
-    // default handler so the fallback UI can own the screen. Otherwise the
-    // default handler would unmount React (in release) or show LogBox (in dev)
-    // over our fallback.
-    const fallbackWillRender = hasInterestedSubscribers('onerror', !!isFatal);
-
     if (__DEV__) {
       // If in dev, we call the default handler anyway and hope the error will be sent
       // Just for a better dev experience. If a fallback is mounted it will still
@@ -227,7 +221,12 @@ function setupErrorUtilsGlobalHandler(): void {
 
     void client.flush((client.getOptions() as ReactNativeClientOptions).shutdownTimeout || 2000).then(
       () => {
-        if (!fallbackWillRender) {
+        // Re-check subscribers *after* the flush. The flush can take up to the
+        // configured shutdownTimeout (default 2s); a boundary could mount or
+        // unmount during that window, so the pre-flush answer may be stale.
+        // If a fallback will render, we skip the default handler so it can own
+        // the screen instead of being torn down.
+        if (!hasInterestedSubscribers('onerror', !!isFatal)) {
           defaultHandler(error, isFatal);
         }
       },

--- a/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
+++ b/packages/core/src/js/integrations/reactnativeerrorhandlers.ts
@@ -246,12 +246,18 @@ function setupErrorUtilsGlobalHandler(): void {
         // Before GlobalErrorBoundary existed, the default handler always tore
         // the app down, so the latch was effectively permanent. Now the app
         // can survive the first fatal via the fallback UI, and a later fatal
-        // must flow through the full capture + publish pipeline.
-        handlingFatal = false;
+        // must flow through the full capture + publish pipeline. Guard with
+        // shouldHandleFatal so a concurrent non-fatal's flush can't clear the
+        // latch out from under an in-flight fatal.
+        if (shouldHandleFatal) {
+          handlingFatal = false;
+        }
       },
       (reason: unknown) => {
         debug.error('[ReactNativeErrorHandlers] Error while flushing the event cache after uncaught error.', reason);
-        handlingFatal = false;
+        if (shouldHandleFatal) {
+          handlingFatal = false;
+        }
       },
     );
   });

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -27,18 +27,19 @@ function Ok(): React.ReactElement {
 }
 
 describe('GlobalErrorBoundary', () => {
-  // react-test-renderer / React surfaces a console.error for uncaught exceptions
-  // routed through componentDidCatch. Silence to keep test output clean.
-  let errorSpy: jest.SpyInstance;
-  beforeAll(() => {
-    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-  afterAll(() => {
-    errorSpy.mockRestore();
-  });
-
   beforeEach(() => {
     _resetGlobalErrorBus();
+    // react-test-renderer / React surfaces a console.error for uncaught
+    // exceptions routed through componentDidCatch. Silence per-test so it
+    // survives restoreAllMocks() in afterEach.
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restore every jest.spyOn() created in beforeEach or inside individual
+    // tests (lastEventId, captureReactException, …) so they don't leak into
+    // subsequent tests.
+    jest.restoreAllMocks();
   });
 
   test('renders children when no error occurs', () => {
@@ -209,7 +210,6 @@ describe('GlobalErrorBoundary', () => {
 
     expect(getByTestId('fallback').props.children.join('')).toBe('fallback:global-once');
     expect(captureReactExceptionSpy).not.toHaveBeenCalled();
-    captureReactExceptionSpy.mockRestore();
   });
 
   test('surfaces the published eventId to the fallback for global errors', () => {

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -212,8 +212,11 @@ describe('GlobalErrorBoundary', () => {
     captureReactExceptionSpy.mockRestore();
   });
 
-  test('surfaces lastEventId to the fallback for global errors', () => {
-    jest.spyOn(SentryCore, 'lastEventId').mockReturnValue('evt-abc123');
+  test('surfaces the published eventId to the fallback for global errors', () => {
+    // lastEventId is intentionally set to a *different* id to prove the
+    // boundary prefers the eventId threaded through the bus payload over the
+    // racy global lastEventId().
+    jest.spyOn(SentryCore, 'lastEventId').mockReturnValue('evt-stale');
 
     let capturedEventId = '';
     const { getByTestId } = render(
@@ -228,11 +231,56 @@ describe('GlobalErrorBoundary', () => {
     );
 
     act(() => {
-      publishGlobalError({ error: new Error('with-event'), isFatal: true, kind: 'onerror' });
+      publishGlobalError({
+        error: new Error('with-event'),
+        isFatal: true,
+        kind: 'onerror',
+        eventId: 'evt-from-bus',
+      });
     });
 
     expect(getByTestId('fallback')).not.toBeNull();
-    expect(capturedEventId).toBe('evt-abc123');
+    expect(capturedEventId).toBe('evt-from-bus');
+  });
+
+  test('falls back to lastEventId when the bus payload omits eventId', () => {
+    jest.spyOn(SentryCore, 'lastEventId').mockReturnValue('evt-fallback');
+
+    let capturedEventId = '';
+    render(
+      <GlobalErrorBoundary
+        fallback={({ error, eventId, resetError }) => {
+          capturedEventId = eventId;
+          return <Fallback error={error} resetError={resetError} />;
+        }}
+      >
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('legacy'), isFatal: true, kind: 'onerror' });
+    });
+
+    expect(capturedEventId).toBe('evt-fallback');
+  });
+
+  test('isolates a misbehaving subscriber so other listeners still fire', () => {
+    const good = jest.fn();
+    // First subscriber throws on every call — the bus must not propagate.
+    const unsubBad = require('../src/js/integrations/globalErrorBus').subscribeGlobalError(
+      () => {
+        throw new Error('bad listener');
+      },
+      { fatal: true },
+    );
+    const unsubGood = require('../src/js/integrations/globalErrorBus').subscribeGlobalError(good, { fatal: true });
+
+    expect(() => publishGlobalError({ error: new Error('isolated'), isFatal: true, kind: 'onerror' })).not.toThrow();
+    expect(good).toHaveBeenCalledTimes(1);
+
+    unsubBad();
+    unsubGood();
   });
 
   test('invokes onError for global errors', () => {

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,3 +1,5 @@
+import * as SentryCore from '@sentry/core';
+import * as SentryReact from '@sentry/react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
@@ -186,6 +188,69 @@ describe('GlobalErrorBoundary', () => {
     expect(hasInterestedSubscribers('onerror', true)).toBe(true);
     unmount();
     expect(hasInterestedSubscribers('onerror', true)).toBe(false);
+  });
+
+  test('does not double-capture global errors through the inner ErrorBoundary', () => {
+    // The integration captures the fatal before publishing to the bus; if we
+    // also re-threw through the inner ErrorBoundary, componentDidCatch would
+    // call captureReactException and produce a duplicate Sentry event.
+    const captureReactExceptionSpy = jest.spyOn(SentryReact, 'captureReactException');
+    jest.spyOn(SentryCore, 'lastEventId').mockReturnValue('evt-global');
+
+    const { getByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('global-once'), isFatal: true, kind: 'onerror' });
+    });
+
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:global-once');
+    expect(captureReactExceptionSpy).not.toHaveBeenCalled();
+    captureReactExceptionSpy.mockRestore();
+  });
+
+  test('surfaces lastEventId to the fallback for global errors', () => {
+    jest.spyOn(SentryCore, 'lastEventId').mockReturnValue('evt-abc123');
+
+    let capturedEventId = '';
+    const { getByTestId } = render(
+      <GlobalErrorBoundary
+        fallback={({ error, eventId, resetError }) => {
+          capturedEventId = eventId;
+          return <Fallback error={error} resetError={resetError} />;
+        }}
+      >
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('with-event'), isFatal: true, kind: 'onerror' });
+    });
+
+    expect(getByTestId('fallback')).not.toBeNull();
+    expect(capturedEventId).toBe('evt-abc123');
+  });
+
+  test('invokes onError for global errors', () => {
+    jest.spyOn(SentryCore, 'lastEventId').mockReturnValue('evt-xyz');
+    const onError = jest.fn();
+
+    render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />} onError={onError}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    const err = new Error('cb');
+    act(() => {
+      publishGlobalError({ error: err, isFatal: true, kind: 'onerror' });
+    });
+
+    expect(onError).toHaveBeenCalledWith(err, '', 'evt-xyz');
   });
 
   test('withGlobalErrorBoundary wraps a component', () => {

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,0 +1,224 @@
+import { act, fireEvent, render } from '@testing-library/react-native';
+import * as React from 'react';
+import { Text, View } from 'react-native';
+
+import { GlobalErrorBoundary, withGlobalErrorBoundary } from '../src/js/GlobalErrorBoundary';
+import {
+  _resetGlobalErrorBus,
+  hasInterestedSubscribers,
+  publishGlobalError,
+} from '../src/js/integrations/globalErrorBus';
+
+function Fallback({ error, resetError }: { error: unknown; resetError: () => void }): React.ReactElement {
+  return (
+    <View>
+      <Text testID="fallback">fallback:{(error as Error)?.message ?? 'none'}</Text>
+      <Text testID="reset" onPress={resetError}>
+        reset
+      </Text>
+    </View>
+  );
+}
+
+function Ok(): React.ReactElement {
+  return <Text testID="ok">ok</Text>;
+}
+
+describe('GlobalErrorBoundary', () => {
+  // react-test-renderer / React surfaces a console.error for uncaught exceptions
+  // routed through componentDidCatch. Silence to keep test output clean.
+  let errorSpy: jest.SpyInstance;
+  beforeAll(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterAll(() => {
+    errorSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    _resetGlobalErrorBus();
+  });
+
+  test('renders children when no error occurs', () => {
+    const { queryByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    expect(queryByTestId('ok')).not.toBeNull();
+    expect(queryByTestId('fallback')).toBeNull();
+  });
+
+  test('renders fallback on a render-phase error (delegates to upstream ErrorBoundary)', () => {
+    function Boom(): React.ReactElement {
+      throw new Error('render-boom');
+    }
+
+    const { getByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Boom />
+      </GlobalErrorBoundary>,
+    );
+
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:render-boom');
+  });
+
+  test('renders fallback when a fatal global error is published', () => {
+    const { getByTestId, queryByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('global-boom'), isFatal: true, kind: 'onerror' });
+    });
+
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:global-boom');
+    expect(queryByTestId('ok')).toBeNull();
+  });
+
+  test('ignores non-fatal global errors by default', () => {
+    const { queryByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('soft'), isFatal: false, kind: 'onerror' });
+    });
+
+    expect(queryByTestId('ok')).not.toBeNull();
+    expect(queryByTestId('fallback')).toBeNull();
+  });
+
+  test('renders fallback for non-fatal global errors when opted in', () => {
+    const { getByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />} includeNonFatalGlobalErrors>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('soft'), isFatal: false, kind: 'onerror' });
+    });
+
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:soft');
+  });
+
+  test('ignores unhandled promise rejections by default', () => {
+    const { queryByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('rej'), isFatal: false, kind: 'onunhandledrejection' });
+    });
+
+    expect(queryByTestId('fallback')).toBeNull();
+  });
+
+  test('renders fallback for unhandled rejections when opted in', () => {
+    const { getByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />} includeUnhandledRejections>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('rej'), isFatal: false, kind: 'onunhandledrejection' });
+    });
+
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:rej');
+  });
+
+  test('resetError restores children and clears internal state', () => {
+    const onReset = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />} onReset={onReset}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('first'), isFatal: true, kind: 'onerror' });
+    });
+    expect(queryByTestId('fallback')).not.toBeNull();
+
+    fireEvent.press(getByTestId('reset'));
+
+    expect(queryByTestId('ok')).not.toBeNull();
+    expect(queryByTestId('fallback')).toBeNull();
+    expect(onReset).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      publishGlobalError({ error: new Error('second'), isFatal: true, kind: 'onerror' });
+    });
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:second');
+  });
+
+  test('first global error wins while fallback is mounted', () => {
+    const { getByTestId } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    act(() => {
+      publishGlobalError({ error: new Error('first'), isFatal: true, kind: 'onerror' });
+      publishGlobalError({ error: new Error('second'), isFatal: true, kind: 'onerror' });
+    });
+
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:first');
+  });
+
+  test('unsubscribes on unmount', () => {
+    const { unmount } = render(
+      <GlobalErrorBoundary fallback={props => <Fallback {...props} />}>
+        <Ok />
+      </GlobalErrorBoundary>,
+    );
+
+    expect(hasInterestedSubscribers('onerror', true)).toBe(true);
+    unmount();
+    expect(hasInterestedSubscribers('onerror', true)).toBe(false);
+  });
+
+  test('withGlobalErrorBoundary wraps a component', () => {
+    const Wrapped = withGlobalErrorBoundary(Ok, { fallback: props => <Fallback {...props} /> });
+    const { getByTestId, queryByTestId } = render(<Wrapped />);
+
+    expect(queryByTestId('ok')).not.toBeNull();
+
+    act(() => {
+      publishGlobalError({ error: new Error('hoc-boom'), isFatal: true, kind: 'onerror' });
+    });
+    expect(getByTestId('fallback').props.children.join('')).toBe('fallback:hoc-boom');
+  });
+});
+
+describe('hasInterestedSubscribers', () => {
+  beforeEach(() => _resetGlobalErrorBus());
+
+  test('returns false when no subscribers exist', () => {
+    expect(hasInterestedSubscribers('onerror', true)).toBe(false);
+    expect(hasInterestedSubscribers('onerror', false)).toBe(false);
+    expect(hasInterestedSubscribers('onunhandledrejection', false)).toBe(false);
+  });
+
+  test('respects subscriber opt-ins', () => {
+    render(
+      <GlobalErrorBoundary fallback={() => <Text>fb</Text>} includeUnhandledRejections>
+        <Text>x</Text>
+      </GlobalErrorBoundary>,
+    );
+
+    expect(hasInterestedSubscribers('onerror', true)).toBe(true);
+    expect(hasInterestedSubscribers('onerror', false)).toBe(false);
+    expect(hasInterestedSubscribers('onunhandledrejection', false)).toBe(true);
+  });
+});

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -251,6 +251,32 @@ describe('ReactNativeErrorHandlers', () => {
         expect(defaultHandler).not.toHaveBeenCalled();
       });
 
+      test('releases handlingFatal latch after flush so subsequent fatals are captured', async () => {
+        // With a GlobalErrorBoundary mounted, defaultHandler is skipped and the
+        // app survives the first fatal. The latch that previously relied on the
+        // app crashing must now release so later fatals still flow through.
+        hasSubscribersSpy.mockReturnValue(true);
+        const integration = reactNativeErrorHandlersIntegration();
+        integration.setupOnce!();
+
+        await errorHandlerCallback!(new Error('First fatal'), true);
+        await client.flush();
+        await new Promise(resolve => setImmediate(resolve));
+
+        (captureException as jest.Mock).mockClear();
+        const secondError = new Error('Second fatal');
+        await errorHandlerCallback!(secondError, true);
+        await client.flush();
+
+        expect(client.event).toBeDefined();
+        expect(client.event?.exception?.values?.[0]?.value).toBe('Second fatal');
+        expect(publishSpy).toHaveBeenLastCalledWith({
+          error: secondError,
+          isFatal: true,
+          kind: 'onerror',
+        });
+      });
+
       test('re-evaluates subscribers after flush (boundary unmounts during flush)', async () => {
         // Always returns false — simulates the boundary being gone by the
         // time the flush resolves. The check must happen inside the .then,

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -289,7 +289,14 @@ describe('ReactNativeErrorHandlers', () => {
       const [options] = mockEnable.mock.calls[0];
       const onUnhandledHandler = options.onUnhandled;
 
+      const publishSpy = jest.spyOn(globalErrorBus, 'publishGlobalError').mockImplementation(() => {});
       onUnhandledHandler('test-id', 'Test Error');
+      expect(publishSpy).toHaveBeenCalledWith({
+        error: 'Test Error',
+        isFatal: false,
+        kind: 'onunhandledrejection',
+      });
+      publishSpy.mockRestore();
 
       expect(captureException).toHaveBeenCalledWith(
         'Test Error',
@@ -360,7 +367,14 @@ describe('ReactNativeErrorHandlers', () => {
         const onUnhandledHandler = options.onUnhandled;
 
         const testError = new Error('Hermes Test Error');
+        const publishSpy = jest.spyOn(globalErrorBus, 'publishGlobalError').mockImplementation(() => {});
         onUnhandledHandler('hermes-test-error', testError);
+        expect(publishSpy).toHaveBeenCalledWith({
+          error: testError,
+          isFatal: false,
+          kind: 'onunhandledrejection',
+        });
+        publishSpy.mockRestore();
 
         expect(captureException).toHaveBeenCalledWith(
           testError,
@@ -401,7 +415,14 @@ describe('ReactNativeErrorHandlers', () => {
         const [callback] = (addGlobalUnhandledRejectionInstrumentationHandler as jest.Mock).mock.calls[0];
 
         const mockError = new Error('Web Test Error');
+        const publishSpy = jest.spyOn(globalErrorBus, 'publishGlobalError').mockImplementation(() => {});
         callback(mockError);
+        expect(publishSpy).toHaveBeenCalledWith({
+          error: mockError,
+          isFatal: false,
+          kind: 'onunhandledrejection',
+        });
+        publishSpy.mockRestore();
 
         expect(captureException).toHaveBeenCalledWith(
           mockError,

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -250,6 +250,22 @@ describe('ReactNativeErrorHandlers', () => {
 
         expect(defaultHandler).not.toHaveBeenCalled();
       });
+
+      test('re-evaluates subscribers after flush (boundary unmounts during flush)', async () => {
+        // Always returns false — simulates the boundary being gone by the
+        // time the flush resolves. The check must happen inside the .then,
+        // not before client.flush(), otherwise we'd never call defaultHandler.
+        hasSubscribersSpy.mockReturnValue(false);
+        const integration = reactNativeErrorHandlersIntegration();
+        integration.setupOnce!();
+
+        await errorHandlerCallback!(new Error('Boom'), true);
+        await client.flush();
+        // Drain the .then() microtask attached to the integration's flush promise.
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(defaultHandler).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -226,7 +226,7 @@ describe('ReactNativeErrorHandlers', () => {
         await errorHandlerCallback!(error, true);
         await client.flush();
 
-        expect(publishSpy).toHaveBeenCalledWith({ error, isFatal: true, kind: 'onerror' });
+        expect(publishSpy).toHaveBeenCalledWith(expect.objectContaining({ error, isFatal: true, kind: 'onerror' }));
       });
 
       test('still invokes the default handler when no boundary is subscribed', async () => {
@@ -270,11 +270,9 @@ describe('ReactNativeErrorHandlers', () => {
 
         expect(client.event).toBeDefined();
         expect(client.event?.exception?.values?.[0]?.value).toBe('Second fatal');
-        expect(publishSpy).toHaveBeenLastCalledWith({
-          error: secondError,
-          isFatal: true,
-          kind: 'onerror',
-        });
+        expect(publishSpy).toHaveBeenLastCalledWith(
+          expect.objectContaining({ error: secondError, isFatal: true, kind: 'onerror' }),
+        );
       });
 
       test('re-evaluates subscribers after flush (boundary unmounts during flush)', async () => {

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -485,5 +485,5 @@ describe('ReactNativeErrorHandlers', () => {
 });
 
 function set__DEV__(value: boolean): void {
-  Object.defineProperty(globalThis, '__DEV__', { value, writable: true });
+  Object.defineProperty(globalThis, '__DEV__', { value, writable: true, configurable: true });
 }

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -5,6 +5,7 @@ import type { SeverityLevel } from '@sentry/core';
 
 import { addGlobalUnhandledRejectionInstrumentationHandler, captureException, setCurrentClient } from '@sentry/core';
 
+import * as globalErrorBus from '../../src/js/integrations/globalErrorBus';
 import { reactNativeErrorHandlersIntegration } from '../../src/js/integrations/reactnativeerrorhandlers';
 import {
   checkPromiseAndWarn,
@@ -195,6 +196,60 @@ describe('ReactNativeErrorHandlers', () => {
       await errorHandlerCallback!(error, false);
 
       expect(error.stack).toBe(originalStack);
+    });
+
+    describe('GlobalErrorBoundary integration', () => {
+      let publishSpy: jest.SpyInstance;
+      let hasSubscribersSpy: jest.SpyInstance;
+      let defaultHandler: jest.Mock;
+
+      beforeEach(() => {
+        publishSpy = jest.spyOn(globalErrorBus, 'publishGlobalError').mockImplementation(() => {});
+        hasSubscribersSpy = jest.spyOn(globalErrorBus, 'hasInterestedSubscribers');
+        defaultHandler = jest.fn();
+        (RN_GLOBAL_OBJ.ErrorUtils!.getGlobalHandler as jest.Mock).mockReturnValue(defaultHandler);
+        set__DEV__(false);
+      });
+
+      afterEach(() => {
+        publishSpy.mockRestore();
+        hasSubscribersSpy.mockRestore();
+        set__DEV__(true);
+      });
+
+      test('publishes fatals to the global error bus', async () => {
+        hasSubscribersSpy.mockReturnValue(false);
+        const integration = reactNativeErrorHandlersIntegration();
+        integration.setupOnce!();
+
+        const error = new Error('Boom');
+        await errorHandlerCallback!(error, true);
+        await client.flush();
+
+        expect(publishSpy).toHaveBeenCalledWith({ error, isFatal: true, kind: 'onerror' });
+      });
+
+      test('still invokes the default handler when no boundary is subscribed', async () => {
+        hasSubscribersSpy.mockReturnValue(false);
+        const integration = reactNativeErrorHandlersIntegration();
+        integration.setupOnce!();
+
+        await errorHandlerCallback!(new Error('Boom'), true);
+        await client.flush();
+
+        expect(defaultHandler).toHaveBeenCalledTimes(1);
+      });
+
+      test('skips the default handler on fatals when a boundary is subscribed', async () => {
+        hasSubscribersSpy.mockImplementation((kind, isFatal) => kind === 'onerror' && isFatal === true);
+        const integration = reactNativeErrorHandlersIntegration();
+        integration.setupOnce!();
+
+        await errorHandlerCallback!(new Error('Boom'), true);
+        await client.flush();
+
+        expect(defaultHandler).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -391,3 +446,7 @@ describe('ReactNativeErrorHandlers', () => {
     });
   });
 });
+
+function set__DEV__(value: boolean): void {
+  Object.defineProperty(globalThis, '__DEV__', { value, writable: true });
+}

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -236,6 +236,8 @@ describe('ReactNativeErrorHandlers', () => {
 
         await errorHandlerCallback!(new Error('Boom'), true);
         await client.flush();
+        // Drain the .then() microtask attached to the integration's flush promise.
+        await new Promise(resolve => setImmediate(resolve));
 
         expect(defaultHandler).toHaveBeenCalledTimes(1);
       });
@@ -247,6 +249,7 @@ describe('ReactNativeErrorHandlers', () => {
 
         await errorHandlerCallback!(new Error('Boom'), true);
         await client.flush();
+        await new Promise(resolve => setImmediate(resolve));
 
         expect(defaultHandler).not.toHaveBeenCalled();
       });

--- a/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
+++ b/packages/core/test/integrations/reactnativeerrorhandlers.test.ts
@@ -315,11 +315,9 @@ describe('ReactNativeErrorHandlers', () => {
 
       const publishSpy = jest.spyOn(globalErrorBus, 'publishGlobalError').mockImplementation(() => {});
       onUnhandledHandler('test-id', 'Test Error');
-      expect(publishSpy).toHaveBeenCalledWith({
-        error: 'Test Error',
-        isFatal: false,
-        kind: 'onunhandledrejection',
-      });
+      expect(publishSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Test Error', isFatal: false, kind: 'onunhandledrejection' }),
+      );
       publishSpy.mockRestore();
 
       expect(captureException).toHaveBeenCalledWith(
@@ -393,11 +391,9 @@ describe('ReactNativeErrorHandlers', () => {
         const testError = new Error('Hermes Test Error');
         const publishSpy = jest.spyOn(globalErrorBus, 'publishGlobalError').mockImplementation(() => {});
         onUnhandledHandler('hermes-test-error', testError);
-        expect(publishSpy).toHaveBeenCalledWith({
-          error: testError,
-          isFatal: false,
-          kind: 'onunhandledrejection',
-        });
+        expect(publishSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ error: testError, isFatal: false, kind: 'onunhandledrejection' }),
+        );
         publishSpy.mockRestore();
 
         expect(captureException).toHaveBeenCalledWith(
@@ -441,11 +437,9 @@ describe('ReactNativeErrorHandlers', () => {
         const mockError = new Error('Web Test Error');
         const publishSpy = jest.spyOn(globalErrorBus, 'publishGlobalError').mockImplementation(() => {});
         callback(mockError);
-        expect(publishSpy).toHaveBeenCalledWith({
-          error: mockError,
-          isFatal: false,
-          kind: 'onunhandledrejection',
-        });
+        expect(publishSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ error: mockError, isFatal: false, kind: 'onunhandledrejection' }),
+        );
         publishSpy.mockRestore();
 
         expect(captureException).toHaveBeenCalledWith(

--- a/samples/react-native/src/Screens/ErrorsScreen.tsx
+++ b/samples/react-native/src/Screens/ErrorsScreen.tsx
@@ -318,6 +318,12 @@ const ErrorsScreen = (_props: Props) => {
         />
 
         <Button
+          title="Global Error Boundary demo"
+          onPress={() => {
+            _props.navigation.navigate('GlobalErrorBoundary');
+          }}
+        />
+        <Button
           title="Feedback form"
           onPress={() => {
             _props.navigation.navigate('FeedbackForm');

--- a/samples/react-native/src/Screens/GlobalErrorBoundaryScreen.tsx
+++ b/samples/react-native/src/Screens/GlobalErrorBoundaryScreen.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import {
+  Button as NativeButton,
+  ButtonProps,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import * as Sentry from '@sentry/react-native';
+
+/**
+ * Demonstrates `Sentry.GlobalErrorBoundary` — the boundary that catches
+ * fatal JS errors thrown *outside* the React render phase (event handlers,
+ * timers, unhandled promise rejections) and renders a fallback UI.
+ *
+ * In release builds the fallback replaces React Native's default red-box
+ * handler for fatals. In dev, LogBox still appears — the fallback renders
+ * alongside it so you can see both.
+ */
+const GlobalErrorBoundaryScreen: React.FC = () => {
+  return (
+    <Sentry.GlobalErrorBoundary
+      // Opt in to rejection fallback so the "Unhandled Promise Rejection"
+      // button also swaps the screen for the fallback UI.
+      includeUnhandledRejections
+      fallback={({ error, eventId, resetError }) => (
+        <View style={styles.fallback}>
+          <Text style={styles.fallbackTitle}>Something went wrong.</Text>
+          <Text style={styles.fallbackBody}>
+            {(error as Error)?.message ?? String(error)}
+          </Text>
+          {eventId ? (
+            <Text style={styles.fallbackMeta}>Event: {eventId}</Text>
+          ) : null}
+          <View style={styles.fallbackButton}>
+            <NativeButton title="Reset" onPress={resetError} color="#6C5FC7" />
+          </View>
+        </View>
+      )}
+      onError={(error, _componentStack, eventId) => {
+        // eslint-disable-next-line no-console
+        console.log(
+          '[GlobalErrorBoundary] caught',
+          (error as Error)?.message,
+          'eventId=',
+          eventId,
+        );
+      }}>
+      <Playground />
+    </Sentry.GlobalErrorBoundary>
+  );
+};
+
+const Playground: React.FC = () => {
+  return (
+    <>
+      <StatusBar barStyle="dark-content" />
+      <ScrollView style={styles.main}>
+        <Text style={styles.heading}>Sentry.GlobalErrorBoundary</Text>
+        <Text style={styles.description}>
+          Each button triggers a fatal JS error from a context that a regular
+          React error boundary cannot catch. The fallback above replaces this
+          content until you press Reset.
+        </Text>
+
+        <Button
+          title="Throw from event handler"
+          onPress={() => {
+            throw new Error(
+              'GlobalErrorBoundary: thrown synchronously from onPress',
+            );
+          }}
+        />
+
+        <Button
+          title="Throw from setTimeout"
+          onPress={() => {
+            setTimeout(() => {
+              throw new Error('GlobalErrorBoundary: thrown from setTimeout');
+            }, 0);
+          }}
+        />
+
+        <Button
+          title="Unhandled promise rejection"
+          onPress={() => {
+            // Intentionally not awaited and not caught.
+            void Promise.reject(
+              new Error('GlobalErrorBoundary: unhandled promise rejection'),
+            );
+          }}
+        />
+
+        <View style={styles.footer} />
+      </ScrollView>
+    </>
+  );
+};
+
+const Button: React.FC<ButtonProps> = props => (
+  <>
+    <NativeButton {...props} color="#6C5FC7" />
+    <View style={styles.buttonSpacer} />
+  </>
+);
+
+const styles = StyleSheet.create({
+  main: {
+    padding: 20,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#362D59',
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: 14,
+    color: '#4A4556',
+    marginBottom: 20,
+  },
+  buttonSpacer: {
+    marginBottom: 8,
+  },
+  footer: {
+    marginTop: 32,
+  },
+  fallback: {
+    flex: 1,
+    padding: 24,
+    justifyContent: 'center',
+    backgroundColor: '#FFF5F5',
+  },
+  fallbackTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#6C1A1A',
+    marginBottom: 12,
+  },
+  fallbackBody: {
+    fontSize: 14,
+    color: '#6C1A1A',
+    marginBottom: 12,
+  },
+  fallbackMeta: {
+    fontSize: 12,
+    color: '#8B5A5A',
+    marginBottom: 24,
+  },
+  fallbackButton: {
+    alignSelf: 'flex-start',
+  },
+});
+
+export default GlobalErrorBoundaryScreen;

--- a/samples/react-native/src/tabs/ErrorsTab.tsx
+++ b/samples/react-native/src/tabs/ErrorsTab.tsx
@@ -7,6 +7,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Provider } from 'react-redux';
 
 import ErrorsScreen from '../Screens/ErrorsScreen';
+import GlobalErrorBoundaryScreen from '../Screens/GlobalErrorBoundaryScreen';
 import store from '../store';
 
 const styles = StyleSheet.create({
@@ -26,6 +27,11 @@ export default function getErrorsTab(Navigator: TypedNavigator<any, any>) {
                 name="ErrorsScreen"
                 component={ErrorsScreen}
                 options={{ title: 'Errors' }}
+              />
+              <Navigator.Screen
+                name="GlobalErrorBoundary"
+                component={GlobalErrorBoundaryScreen}
+                options={{ title: 'Global Error Boundary' }}
               />
               <Navigator.Screen
                 name="FeedbackForm"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Adds `Sentry.GlobalErrorBoundary` (and a `withGlobalErrorBoundary` HOC) that renders a fallback UI for fatal JS errors routed through `ErrorUtils` — event handlers, timers, async code, and other errors thrown outside the React render tree — in addition to the render-phase errors caught by the existing `Sentry.ErrorBoundary`.

```tsx
<Sentry.GlobalErrorBoundary
  fallback={({ error, resetError }) => <MyFallback error={error} onRetry={resetError} />}
>
  <App />
</Sentry.GlobalErrorBoundary>
```

Two opt-in props extend coverage:
- `includeNonFatalGlobalErrors` — also trigger the fallback on non-fatal `ErrorUtils` errors.
- `includeUnhandledRejections` — also trigger the fallback on unhandled promise rejections.

Under the hood, a small internal pub/sub bus lets `reactNativeErrorHandlersIntegration` publish errors after capture + flush. When a boundary is subscribed, the integration skips React Native's default fatal handler in release builds so the fallback can own the screen. Dev mode still invokes the default handler so LogBox keeps working.


## :bulb: Motivation and Context

React error boundaries only catch render-phase errors. Customers who want a fallback UI for fatal errors thrown in event handlers, `setTimeout`, promises, or outside the component tree have to override `ErrorUtils.setGlobalHandler` themselves, disable our `onerror` integration, and bridge into React state — which is fragile, bypasses our error pipeline (flush, mechanism tagging, fatal dedup), and risks running the app in a corrupted state.

Closes #5930.


## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

- Update the public docs (`sentry-docs`) with a "Showing a fallback UI for fatal errors" section and a migration note away from hand-rolled `setGlobalHandler`.
