### PR TITLE
feat(ai): Re-export AI SDK manual instrumentation helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - Warn Expo users at Metro startup when prebuilt native projects are missing Sentry configuration ([#5984](https://github.com/getsentry/sentry-react-native/pull/5984))
+- Re-export AI SDK manual instrumentation helpers (`instrumentOpenAiClient`, `instrumentAnthropicAiClient`, `instrumentGoogleGenAIClient`, `createLangChainCallbackHandler`, `instrumentLangGraph`, `instrumentStateGraphCompile`) for use in React Native apps ([#5297](https://github.com/getsentry/sentry-react-native/issues/5297))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Expose screenshot masking options (`screenshot.maskAllText`, `screenshot.maskAllImages`, `screenshot.maskedViewClasses`, `screenshot.unmaskedViewClasses`) for error screenshots ([#6007](https://github.com/getsentry/sentry-react-native/pull/6007))
 - Warn Expo users at Metro startup when prebuilt native projects are missing Sentry configuration ([#5984](https://github.com/getsentry/sentry-react-native/pull/5984))
-- Re-export AI SDK manual instrumentation helpers (`instrumentOpenAiClient`, `instrumentAnthropicAiClient`, `instrumentGoogleGenAIClient`, `createLangChainCallbackHandler`, `instrumentLangGraph`, `instrumentStateGraphCompile`) for use in React Native apps ([#5297](https://github.com/getsentry/sentry-react-native/issues/5297))
+- Re-export AI SDK manual instrumentation helpers (`instrumentOpenAiClient`, `instrumentAnthropicAiClient`, `instrumentGoogleGenAIClient`, `createLangChainCallbackHandler`, `instrumentLangGraph`, `instrumentStateGraphCompile`) for use in React Native apps ([#6028](https://github.com/getsentry/sentry-react-native/pull/6028))
 - Add `Sentry.GlobalErrorBoundary` component (and `withGlobalErrorBoundary` HOC) that renders a fallback UI for fatal non-rendering JS errors routed through `ErrorUtils` in addition to the render-phase errors caught by `Sentry.ErrorBoundary`. Opt-in flags `includeNonFatalGlobalErrors` and `includeUnhandledRejections` extend the fallback to non-fatal errors and unhandled promise rejections respectively. ([#6023](https://github.com/getsentry/sentry-react-native/pull/6023))
 
 ### Fixes

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -67,7 +67,6 @@ export type {
   GoogleGenAIClient,
   GoogleGenAIChat,
   GoogleGenAIOptions,
-  GoogleGenAIIstrumentedMethod,
   LangChainOptions,
   LangChainIntegration,
   LangGraphOptions,

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -48,6 +48,31 @@ export {
   addEventProcessor,
   lastEventId,
   consoleSandbox,
+  instrumentOpenAiClient,
+  instrumentAnthropicAiClient,
+  instrumentGoogleGenAIClient,
+  createLangChainCallbackHandler,
+  instrumentLangGraph,
+  instrumentStateGraphCompile,
+} from '@sentry/core';
+
+export type {
+  OpenAiClient,
+  OpenAiOptions,
+  InstrumentedMethod,
+  AnthropicAiClient,
+  AnthropicAiOptions,
+  AnthropicAiInstrumentedMethod,
+  AnthropicAiResponse,
+  GoogleGenAIClient,
+  GoogleGenAIChat,
+  GoogleGenAIOptions,
+  GoogleGenAIIstrumentedMethod,
+  LangChainOptions,
+  LangChainIntegration,
+  LangGraphOptions,
+  LangGraphIntegration,
+  CompiledGraph,
 } from '@sentry/core';
 
 export {

--- a/packages/core/test/aiExports.test.ts
+++ b/packages/core/test/aiExports.test.ts
@@ -1,0 +1,14 @@
+import * as Sentry from '../src/js';
+
+describe('AI SDK manual instrumentation re-exports', () => {
+  test.each([
+    'instrumentOpenAiClient',
+    'instrumentAnthropicAiClient',
+    'instrumentGoogleGenAIClient',
+    'createLangChainCallbackHandler',
+    'instrumentLangGraph',
+    'instrumentStateGraphCompile',
+  ])('re-exports %s from @sentry/core', name => {
+    expect(typeof (Sentry as Record<string, unknown>)[name]).toBe('function');
+  });
+});


### PR DESCRIPTION
## Description

Re-exports the AI SDK manual instrumentation helpers from `@sentry/core` so React Native apps can import them directly from `@sentry/react-native`.

## Why

The automatic (OpenTelemetry-based) integrations for the OpenAI / Anthropic / Google GenAI / LangChain / LangGraph SDKs only work in Node.js runtimes. React Native apps have to use the manual client wrappers. Previously, reaching those helpers required importing from `@sentry/core`, which is awkward and undocumented for RN users. This change mirrors what `@sentry/browser` already does and unblocks documentation for the RN AI SDK.

Refs #5297.