### PR TITLE
fix(android): Report missing properties file or keys when flavorAware is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixes
 
 - Check `captureReplay` return value in iOS bridge to avoid linking error events to uncaptured replays ([#6008](https://github.com/getsentry/sentry-react-native/pull/6008))
+- Report the expected properties file path and any missing keys when using `flavorAware` on Android, instead of failing with an opaque `Illegal null value provided in this collection` error ([#2839](https://github.com/getsentry/sentry-react-native/issues/2839))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ### Fixes
 
 - Check `captureReplay` return value in iOS bridge to avoid linking error events to uncaptured replays ([#6008](https://github.com/getsentry/sentry-react-native/pull/6008))
-- Report the expected properties file path and any missing keys when using `flavorAware` on Android, instead of failing with an opaque `Illegal null value provided in this collection` error ([#2839](https://github.com/getsentry/sentry-react-native/issues/2839))
+- Report the expected properties file path and any missing keys when using `flavorAware` on Android, instead of failing with an opaque `Illegal null value provided in this collection` error ([#6031](https://github.com/getsentry/sentry-react-native/pull/6031))
 
 ### Dependencies
 

--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -208,7 +208,29 @@ plugins.withId('com.android.application') {
                                 try {
                                     sentryProps.load(new FileInputStream(propertiesFile))
                                 } catch (FileNotFoundException e) {
+                                    if (config.flavorAware) {
+                                        throw new GradleException(
+                                            "Sentry: expected properties file not found for variant '${variant}': ${propertiesFile}. " +
+                                            "Create it, or disable 'flavorAware' in project.ext.sentryCli.")
+                                    }
                                     project.logger.info("file not found '$propertiesFile' for '$variant'")
+                                }
+
+                                def sentryUrl = sentryProps.get("defaults.url")
+                                def sentryAuthToken = sentryProps.get("auth.token") ?: System.getenv("SENTRY_AUTH_TOKEN")
+                                def sentryOrg = sentryProps.get("defaults.org")
+                                def sentryProject = sentryProps.get("defaults.project")
+
+                                if (config.flavorAware) {
+                                    def missing = []
+                                    if (!sentryAuthToken) missing << "auth.token (or SENTRY_AUTH_TOKEN env var)"
+                                    if (!sentryOrg) missing << "defaults.org"
+                                    if (!sentryProject) missing << "defaults.project"
+                                    if (!missing.isEmpty()) {
+                                        throw new GradleException(
+                                            "Sentry: missing required properties in '${propertiesFile}' for variant '${variant}':\n" +
+                                            "  - " + missing.join("\n  - "))
+                                    }
                                 }
 
                                 def cliPackage = resolveSentryCliPackagePath(reactRoot)
@@ -228,18 +250,22 @@ plugins.withId('com.android.application') {
                                 args.addAll(!config.logLevel ? [] : [
                                     "--log-level", config.logLevel      // control verbosity of the output
                                 ])
-                                args.addAll(!config.flavorAware ? [] : [
-                                    "--url", sentryProps.get("defaults.url"),
-                                    "--auth-token", sentryProps.get("auth.token") ?: System.getenv("SENTRY_AUTH_TOKEN")
-                                ])
+                                if (config.flavorAware) {
+                                    if (sentryUrl) {
+                                        args.addAll(["--url", sentryUrl])
+                                    }
+                                    args.addAll(["--auth-token", sentryAuthToken])
+                                }
                                 args.addAll(["react-native", "gradle",
                                     "--bundle", bundleOutput,           // The path to a bundle that should be uploaded.
                                     "--sourcemap", sourcemapOutput      // The path to a sourcemap that should be uploaded.
                                 ])
-                                args.addAll(!config.flavorAware ? [] : [
-                                    "--org", sentryProps.get("defaults.org"),
-                                    "--project", sentryProps.get("defaults.project")
-                                ])
+                                if (config.flavorAware) {
+                                    args.addAll([
+                                        "--org", sentryOrg,
+                                        "--project", sentryProject
+                                    ])
+                                }
 
                                 args.addAll(extraArgs)
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

When `flavorAware` is set in `project.ext.sentryCli` and the per-variant properties file is missing, or required keys are absent, `sentry.gradle` previously swallowed the `FileNotFoundException` (logging at `info`) and passed `null` values to sentry-cli. Gradle then failed with an opaque:

```
Illegal null value provided in this collection: [..., --url, null, --auth-token, null, ..., --org, null, --project, null]
```

This PR makes the error actionable:

- Throws a `GradleException` naming the expected `sentry-${variant}.properties` path when the file is missing (flavor-aware only).
- Collects missing required keys (`auth.token` / `SENTRY_AUTH_TOKEN`, `defaults.org`, `defaults.project`) and throws a single error listing them all alongside the file path.
- Only appends `--url` when `defaults.url` is set, so sentry-cli falls back to its default instead of being handed `null`.
- Non-flavor-aware path (the `SENTRY_PROPERTIES` env flow) is unchanged.


## :bulb: Motivation and Context

Users hitting this flow today (see #2837 as an example of the cryptic surface error) have no indication of which file was expected or which key was missing. This change surfaces both directly.

Fixes #2839.


## :green_heart: How did you test it?

**Parse check** — `./gradlew :app:help` on `samples/react-native/android` with the updated `sentry.gradle` symlinked via the yarn workspace: builds the task graph without errors.

**Validation harness** — built a standalone Gradle project that copies the exact validation block (same message strings, same control flow) and drives 8 scenarios. All pass:

| # | Scenario | Expectation | Result |
|---|----------|-------------|--------|
| A | `flavorAware=true`, properties file missing | `GradleException` naming the expected path and `flavorAware` | PASS |
| B | `flavorAware=true`, file present, only `defaults.org` missing | `GradleException` reporting only that key, with file path | PASS |
| C | `flavorAware=true`, file fully populated | Args contain `--url`, `--auth-token`, `--org`, `--project` with no nulls | PASS |
| D | `flavorAware=true`, `auth.token` absent but `SENTRY_AUTH_TOKEN` set | Succeeds; `--auth-token` uses env value | PASS |
| E | `flavorAware=true`, all three required keys missing | Single `GradleException` listing all three keys | PASS |
| F | `flavorAware=true`, `defaults.url` empty string | `--url` flag omitted; required args still present | PASS |
| G | `flavorAware=false`, properties file missing | No exception (existing silent behavior preserved) | PASS |
| H | `flavorAware=false`, file present | No flavor-specific args added | PASS |

**Not run locally**: a full `:app:bundleRelease` against real Sentry infrastructure. The change is isolated to the `doLast` block inside the `_SentryUpload_` task, and the scenarios above cover every branch touched. No Gradle/Groovy test harness exists in this repo to check these in automatically.


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)