### PR TITLE
fix(core): Restore broken release process after @sentry/react-native 8.9.0

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,4 +9,5 @@ targets:
       npm:@sentry/react-native:
         includeNames: /^sentry-react-native-\d.*\.tgz$/
       npm:@sentry/expo-upload-sourcemaps:
+        name: '@sentry/expo-upload-sourcemaps'
         includeNames: /^sentry-expo-upload-sourcemaps-\d.*\.tgz$/

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -166,6 +166,7 @@ jobs:
           name: ${{ github.sha }}
           path: |
             ${{ github.workspace }}/packages/core/*.tgz
+            ${{ github.workspace }}/packages/expo-upload-sourcemaps/*.tgz
 
   job_type_check:
     name: Type Check Typescript 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Fixes
 
-- Re-release `8.9.0` as `8.9.1` after the original `8.9.0` tarball shipped with an unresolved `workspace:*` spec for `@sentry/expo-upload-sourcemaps`, which prevented installation. `8.9.0` has been deprecated on npm; install `8.9.1` or newer.
+- Fixes`@sentry/expo-upload-sourcemaps` publishing issue ([#6037](https://github.com/getsentry/sentry-react-native/pull/6037))
 - Fix iOS UI profiling options being silently ignored ([#6012](https://github.com/getsentry/sentry-react-native/pull/6012))
 - Fix `_experiments.enableUnhandledCPPExceptionsV2` being silently ignored on iOS ([#6014](https://github.com/getsentry/sentry-react-native/pull/6014))
 - Check `captureReplay` return value in iOS bridge to avoid linking error events to uncaptured replays ([#6008](https://github.com/getsentry/sentry-react-native/pull/6008))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixes
 
+- Re-release `8.9.0` as `8.9.1` after the original `8.9.0` tarball shipped with an unresolved `workspace:*` spec for `@sentry/expo-upload-sourcemaps`, which prevented installation. `8.9.0` has been deprecated on npm; install `8.9.1` or newer.
 - Fix iOS UI profiling options being silently ignored ([#6012](https://github.com/getsentry/sentry-react-native/pull/6012))
 - Fix `_experiments.enableUnhandledCPPExceptionsV2` being silently ignored on iOS ([#6014](https://github.com/getsentry/sentry-react-native/pull/6014))
 - Check `captureReplay` return value in iOS bridge to avoid linking error events to uncaptured replays ([#6008](https://github.com/getsentry/sentry-react-native/pull/6008))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Fixes
 
-- Fixes`@sentry/expo-upload-sourcemaps` publishing issue ([#6037](https://github.com/getsentry/sentry-react-native/pull/6037))
+- Fix `@sentry/expo-upload-sourcemaps` publishing issue ([#6037](https://github.com/getsentry/sentry-react-native/pull/6037))
 - Fix iOS UI profiling options being silently ignored ([#6012](https://github.com/getsentry/sentry-react-native/pull/6012))
 - Fix `_experiments.enableUnhandledCPPExceptionsV2` being silently ignored on iOS ([#6014](https://github.com/getsentry/sentry-react-native/pull/6014))
 - Check `captureReplay` return value in iOS bridge to avoid linking error events to uncaptured replays ([#6008](https://github.com/getsentry/sentry-react-native/pull/6008))

--- a/packages/core/scripts/build-tarball.sh
+++ b/packages/core/scripts/build-tarball.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
+set -e
 
-rm -f $(dirname "$0")/../*.tgz
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PKG_DIR="$SCRIPT_DIR/.."
 
-cp $(dirname "$0")/../../../README.md $(dirname "$0")/../README.md
+cd "$PKG_DIR"
 
-npm pack
+rm -f sentry-react-native-*.tgz
+
+cp ../../README.md README.md
+
+# Use `yarn pack` instead of `npm pack` so `workspace:*` dependency specs are
+# rewritten to concrete versions in the published tarball. npm pack leaves
+# the spec as `workspace:*`, which consumers cannot resolve.
+VERSION=$(node -p "require('./package.json').version")
+yarn pack --out "sentry-react-native-${VERSION}.tgz"

--- a/packages/expo-upload-sourcemaps/scripts/build-tarball.sh
+++ b/packages/expo-upload-sourcemaps/scripts/build-tarball.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
+set -e
 
-rm -f $(dirname "$0")/../sentry-expo-upload-sourcemaps-*.tgz
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PKG_DIR="$SCRIPT_DIR/.."
 
-npm pack
+cd "$PKG_DIR"
+
+rm -f sentry-expo-upload-sourcemaps-*.tgz
+
+# Use `yarn pack` instead of `npm pack` for consistency with packages/core.
+VERSION=$(node -p "require('./package.json').version")
+yarn pack --out "sentry-expo-upload-sourcemaps-${VERSION}.tgz"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

`@sentry/react-native@8.9.0` shipped to npm with an unresolved `workspace:*` spec for `@sentry/expo-upload-sourcemaps` in its published tarball, so `npm install @sentry/react-native@8.9.0` fails with a dependency-resolution error. `8.9.0` has been deprecated on npm; this PR restores the release pipeline so the re-release (`8.9.1`) produces an installable tarball.

Three underlying issues addressed:

### 1. `npm pack` doesn't rewrite `workspace:*`

`packages/core/scripts/build-tarball.sh` used `npm pack`, which passes yarn's `workspace:` protocol through verbatim. Switch to `yarn pack`, which substitutes `workspace:*` with the concrete version at pack time. Same change applied to `packages/expo-upload-sourcemaps/scripts/build-tarball.sh` for consistency.

Verified locally: `yarn pack` produces a tarball whose `package.json` contains `"@sentry/expo-upload-sourcemaps": "8.8.0"` (concrete), where previously `npm pack` produced `"workspace:*"`.

### 2. CI only archived `packages/core/*.tgz`

`.github/workflows/buildandtest.yml` uploaded build artifacts from `packages/core/` only, so the new package's tarball never reached craft. Extending the `actions/upload-artifact` path to include `packages/expo-upload-sourcemaps/*.tgz` ensures both tarballs are available for the npm + registry targets.

### 3. `.craft.yml` registry entry missed the required `name` field

Craft errored on the registry target with:

```
[error] "name" is required for new package "npm:@sentry/expo-upload-sourcemaps". Add `name` to the registry target config in your .craft.yml.
```

`name` is mandatory for packages that are not yet present in `sentry-release-registry`. Existing packages (like `@sentry/react-native`) skip this requirement. Added the field for the new entry.


## :bulb: Motivation and Context

Fixes the broken 8.9.0 release. Original failure: https://github.com/getsentry/publish/actions/runs/24834580937/job/72691372884

`@sentry/react-native@8.9.0` has been deprecated on npm with a message pointing users at `8.9.1`:

```bash
npm deprecate @sentry/react-native@8.9.0 "8.9.0 has a broken workspace-protocol dependency and cannot be installed; use 8.9.1"
```


## :green_heart: How did you test it?

End-to-end install simulation in a fresh directory — the exact failure mode that broke 8.9.0:

```
mkdir /tmp/rn-hotfix-dryrun && cd /tmp/rn-hotfix-dryrun
npm init -y
yarn build:tarball (in this repo, from root)
npm install ./packages/expo-upload-sourcemaps/sentry-expo-upload-sourcemaps-8.8.0.tgz \
            ./packages/core/sentry-react-native-8.8.0.tgz
```

Result: 248 packages added, no `workspace:*` resolution errors, both `@sentry/react-native` and `@sentry/expo-upload-sourcemaps` present in `node_modules/@sentry/`, bin symlink `node_modules/.bin/sentry-expo-upload-sourcemaps` exists and invokes the CLI through the shim path.

Additional local verification:

- `bash -n` syntax check passes on both `build-tarball.sh` scripts
- `yarn build:tarball` end-to-end from repo root produces both expected tarballs
- Inspected core's packed `package.json` — concrete `8.8.0` version, no `workspace:*`
- Both tarballs include `README.md` and `LICENSE.md`


## :pencil: Checklist
- [x] I added tests to verify changes — dry-run install simulation documented in "How did you test it?"; this is a packaging/release-infra fix with no runtime code change
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps

Merge, tag and release `8.9.1`. Verify post-release that:

- `curl -s https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/latest` returns a real version.
- `npm install @sentry/react-native@8.9.1` in a fresh project completes without `workspace:*` errors.
- sentry-release-registry picks up both packages.