### PR TITLE
chore(deps): bump @xmldom/xmldom to 0.8.13/0.9.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "See: https://github.com/appium/appium-chromedriver/pull/424"
   ],
   "resolutions": {
-    "appium-chromedriver@npm:8.2.19/@xmldom/xmldom": "0.8.12",
+    "appium-chromedriver@npm:8.2.19/@xmldom/xmldom": "0.8.13",
     "@istanbuljs/load-nyc-config@npm:1.1.0/js-yaml": "^3.14.2",
     "@yarnpkg/parsers@npm:3.0.0-rc.46/js-yaml": "^3.14.2",
     "cosmiconfig@npm:5.2.1/js-yaml": "^3.14.2",
@@ -122,13 +122,13 @@
     "minimatch@npm:5.1.9/brace-expansion": "^2.0.3",
     "minimatch@npm:8.0.7/brace-expansion": "^2.0.3",
     "minimatch@npm:9.0.9/brace-expansion": "^2.0.3",
-    "@expo/plist@npm:0.1.3/@xmldom/xmldom": "^0.8.12",
-    "@expo/plist@npm:0.3.4/@xmldom/xmldom": "^0.8.12",
-    "@expo/plist@npm:0.5.2/@xmldom/xmldom": "^0.8.12",
-    "plist@npm:3.1.0/@xmldom/xmldom": "^0.8.12",
+    "@expo/plist@npm:0.1.3/@xmldom/xmldom": "^0.8.13",
+    "@expo/plist@npm:0.3.4/@xmldom/xmldom": "^0.8.13",
+    "@expo/plist@npm:0.5.2/@xmldom/xmldom": "^0.8.13",
+    "plist@npm:3.1.0/@xmldom/xmldom": "^0.8.13",
     "@appium/support@npm:7.0.6/yauzl": "^3.2.1",
-    "appium-ios-remotexpc@npm:0.36.0/@xmldom/xmldom": "^0.9.9",
-    "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.9"
+    "appium-ios-remotexpc@npm:0.36.0/@xmldom/xmldom": "^0.9.10",
+    "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.10"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12429,17 +12429,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:0.8.12, @xmldom/xmldom@npm:^0.8.12":
-  version: 0.8.12
-  resolution: "@xmldom/xmldom@npm:0.8.12"
-  checksum: 609bbcd6f31fa24023f5cc836e804d49c60e3df83ca73f744da9caff7fed516221dcf2f23de44e5289d715951781ec35fa90adf57008c3eae944a7550c39e325
+"@xmldom/xmldom@npm:0.8.13, @xmldom/xmldom@npm:^0.8.13":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: b5568a3dee6306c4c6256c94f27d74f904d7cc923607f0dcaa37998e370361ce37a6e99aa55e8e725f07079e619a6f8b3a7de218e76b522ba2b1aca3ada5265c
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.9.9":
-  version: 0.9.9
-  resolution: "@xmldom/xmldom@npm:0.9.9"
-  checksum: 73bd69379f70b29cdef742eb834c299ef13268e9ce42ea6384a78ade1083c3e0c71c764019d3c8d860a76147c6c84b4cba5e6e5b2123ed2cd806d8621c4c9559
+"@xmldom/xmldom@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 420f3ba52316163384ce626cda087d06b0eb5888d393b00bbc5f56489bbaccc8633e9b078942ee05facda93fbf813b209a5deb5044f89a6e04373305a0e573c0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates scoped resolutions to patch @xmldom/xmldom XML injection and DoS vulnerabilities:
- 0.8.x consumers: 0.8.12 → 0.8.13
- 0.9.x consumers: 0.9.9 → 0.9.10

Dev-only dependencies.

https://github.com/getsentry/sentry-react-native/security/dependabot/501
https://github.com/getsentry/sentry-react-native/security/dependabot/502
https://github.com/getsentry/sentry-react-native/security/dependabot/503
https://github.com/getsentry/sentry-react-native/security/dependabot/504
https://github.com/getsentry/sentry-react-native/security/dependabot/506
https://github.com/getsentry/sentry-react-native/security/dependabot/507
https://github.com/getsentry/sentry-react-native/security/dependabot/508
https://github.com/getsentry/sentry-react-native/security/dependabot/509