### PR TITLE
fix(core): Restore tarball script permissions and missing EAS build hook

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -168,6 +168,80 @@ jobs:
             ${{ github.workspace }}/packages/core/*.tgz
             ${{ github.workspace }}/packages/expo-upload-sourcemaps/*.tgz
 
+  job_validate_tarball:
+    name: Validate tarball
+    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    needs: [job_build, diff_check]
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 18
+      - name: Download tarball artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ github.sha }}
+          path: artifacts
+      - name: Verify executable bits in tarball
+        run: |
+          set -e
+          TARBALL=$(find artifacts -name 'sentry-react-native-*.tgz' -print -quit)
+          [ -n "$TARBALL" ] || { echo "::error::tarball not found in artifacts/"; exit 1; }
+          echo "Tarball: $TARBALL"
+          FAILED=0
+          for entry in package/scripts/sentry-xcode.sh \
+                       package/scripts/sentry-xcode-debug-files.sh \
+                       package/scripts/collect-modules.sh \
+                       package/scripts/eas-build-hook.js \
+                       package/scripts/expo-upload-sourcemaps.js; do
+            mode=$(tar -tvf "$TARBALL" "$entry" 2>/dev/null | awk 'NR==1{print $1}')
+            if [ -z "$mode" ]; then
+              echo "::error::$entry missing from tarball"
+              FAILED=1
+            elif [ "$mode" != "-rwxr-xr-x" ]; then
+              echo "::error::$entry has mode $mode, expected -rwxr-xr-x"
+              FAILED=1
+            else
+              echo "OK: $entry ($mode)"
+            fi
+          done
+          exit $FAILED
+      - name: Install tarball into fresh project
+        run: |
+          set -e
+          TARBALL=$(find "$PWD/artifacts" -name 'sentry-react-native-*.tgz' -print -quit)
+          mkdir -p /tmp/install-test
+          cd /tmp/install-test
+          npm init -y >/dev/null
+          npm install --no-save "$TARBALL"
+          # workspace:* spec must have been resolved by yarn pack (#6037 regression)
+          if grep -q 'workspace:' node_modules/@sentry/react-native/package.json; then
+            echo "::error::published package.json still contains unresolved workspace: spec"
+            grep workspace: node_modules/@sentry/react-native/package.json
+            exit 1
+          fi
+          # bin entries must be linked into node_modules/.bin and executable
+          for bin in sentry-eas-build-on-complete \
+                     sentry-eas-build-on-error \
+                     sentry-eas-build-on-success \
+                     sentry-expo-upload-sourcemaps; do
+            if [ ! -x "node_modules/.bin/$bin" ]; then
+              echo "::error::node_modules/.bin/$bin missing or not executable"
+              ls -la node_modules/.bin/ | grep -i sentry || true
+              exit 1
+            fi
+            echo "OK: node_modules/.bin/$bin"
+          done
+          # sentry-xcode.sh is invoked directly by the iOS build phase, so it
+          # must remain executable after install (#6047)
+          if [ ! -x node_modules/@sentry/react-native/scripts/sentry-xcode.sh ]; then
+            echo "::error::scripts/sentry-xcode.sh is not executable after install"
+            ls -la node_modules/@sentry/react-native/scripts/sentry-xcode.sh
+            exit 1
+          fi
+          echo "OK: scripts/sentry-xcode.sh executable"
+
   job_type_check:
     name: Type Check Typescript 3.8
     runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Restore executable bit on shell scripts in the published tarball, fixing `Permission denied` on iOS build ([#6049](https://github.com/getsentry/sentry-react-native/pull/6049))
+- Restore EAS build hook bin scripts (`sentry-eas-build-on-{success,error,complete}`) missing from the published tarball ([#6049](https://github.com/getsentry/sentry-react-native/pull/6049))
+
 ## 8.9.1
 
 ### Features

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -27,6 +27,7 @@
 !scripts/sentry-xcode-debug-files.sh
 !scripts/sentry_utils.rb
 !scripts/expo-upload-sourcemaps.js
+!scripts/eas-build-hook.js
 
 # Metro
 !/metro.js

--- a/packages/core/scripts/build-tarball.sh
+++ b/packages/core/scripts/build-tarball.sh
@@ -14,4 +14,16 @@ cp ../../README.md README.md
 # rewritten to concrete versions in the published tarball. npm pack leaves
 # the spec as `workspace:*`, which consumers cannot resolve.
 VERSION=$(node -p "require('./package.json').version")
-yarn pack --out "sentry-react-native-${VERSION}.tgz"
+TARBALL="sentry-react-native-${VERSION}.tgz"
+yarn pack --out "$TARBALL"
+
+# yarn pack stores non-bin files with mode 0644, which breaks the Xcode build
+# phase that invokes scripts/sentry-xcode.sh directly (Permission denied).
+# Re-pack with +x on shell scripts and bin entrypoints.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+tar -xzf "$TARBALL" -C "$TMP_DIR"
+chmod 0755 "$TMP_DIR"/package/scripts/*.sh \
+           "$TMP_DIR"/package/scripts/eas-build-hook.js \
+           "$TMP_DIR"/package/scripts/expo-upload-sourcemaps.js
+tar -czf "$TARBALL" -C "$TMP_DIR" package


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
8.9.1 shipped two regressions caused by switching `packages/core/scripts/build-tarball.sh` from `npm pack` to `yarn pack` in #6037:

1. **Executable bit stripped on shell scripts.** `yarn pack` stores files with mode `0644`. `scripts/sentry-xcode.sh`, invoked directly by Xcode's build phase, fails with `Permission denied` (#6047).
2. **`scripts/eas-build-hook.js` missing from the tarball.** `yarn pack` does not auto-include files referenced from the `bin` field; `npm pack` did. The file has never been in the `.npmignore` allowlist, so the three `sentry-eas-build-on-{success,error,complete}` bin commands silently stopped working in 8.9.1 ([#6048 follow-up](https://github.com/getsentry/sentry-react-native/issues/6048#issuecomment-4324441279)).

Changes:
- `packages/core/scripts/build-tarball.sh` — after `yarn pack`, extract → `chmod 0755` on `scripts/*.sh` and the two bin `.js` entries → re-pack.
- `packages/core/.npmignore` — allow `scripts/eas-build-hook.js`.
- `.github/workflows/buildandtest.yml` — new `job_validate_tarball` job that installs the produced tarball into a fresh project and asserts script modes, bin links, post-install executability of `sentry-xcode.sh`, and that `workspace:*` specs were resolved.

Note: this PR fixes only the bin-scripts follow-up of #6048. The primary bug in that issue (config plugin not applied during EAS cloud prebuild) is unrelated and stays open.

## :bulb: Motivation and Context
8.9.1 reached npm with a broken tarball: iOS builds break with `Permission denied`, and the EAS build-hook bin commands no longer resolve. Both ship the same week and share the same root cause. Users currently downgrade to 8.8.0 as a workaround.

Fixes #6047. Fixes the bin-scripts portion of #6048.

## :green_heart: How did you test it?
Locally:
- Built the tarball with the new `build-tarball.sh` and inspected with `tar -tvf`: all `*.sh` files and both bin `*.js` entries are `0755`; `eas-build-hook.js` is present.
- Installed the tarball into a fresh `npm init -y` project: all four `sentry-eas-build-*` / `sentry-expo-upload-sourcemaps` bin links resolve and are executable; `scripts/sentry-xcode.sh` is `-rwxr-xr-x` post-install; `package.json` no longer contains `workspace:` strings.
- The new CI job runs the same checks against the artifact built in `job_build`.

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Changelog entry will be added once this PR has a number to reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)