### PR TITLE
fix(ci): Install both tarballs in validate job to satisfy cross-dep

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -210,11 +210,18 @@ jobs:
       - name: Install tarball into fresh project
         run: |
           set -e
-          TARBALL=$(find "$PWD/artifacts" -name 'sentry-react-native-*.tgz' -print -quit)
+          CORE_TARBALL=$(find "$PWD/artifacts" -name 'sentry-react-native-*.tgz' -print -quit)
+          EXPO_TARBALL=$(find "$PWD/artifacts" -name 'sentry-expo-upload-sourcemaps-*.tgz' -print -quit)
+          [ -n "$CORE_TARBALL" ] || { echo "::error::core tarball not found"; exit 1; }
+          [ -n "$EXPO_TARBALL" ] || { echo "::error::expo-upload-sourcemaps tarball not found"; exit 1; }
           mkdir -p /tmp/install-test
           cd /tmp/install-test
           npm init -y >/dev/null
-          npm install --no-save "$TARBALL"
+          # Install both local tarballs together so the @sentry/expo-upload-sourcemaps
+          # cross-dep is satisfied locally. On a release branch the bumped version
+          # is not on the npm registry yet (workspace:* resolves to the version
+          # we are about to publish), and a registry fetch would fail with ETARGET.
+          npm install --no-save "$EXPO_TARBALL" "$CORE_TARBALL"
           # workspace:* spec must have been resolved by yarn pack (#6037 regression)
           if grep -q 'workspace:' node_modules/@sentry/react-native/package.json; then
             echo "::error::published package.json still contains unresolved workspace: spec"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Follow-up to #6049. The `job_validate_tarball` install step ran `npm install <core tarball>` only. Core's published `package.json` declares `@sentry/expo-upload-sourcemaps` at a concrete version (yarn pack resolves `workspace:*` at pack time). On a release branch the bumped version isn't on the npm registry yet, so npm falls back to fetching it and fails with `ETARGET`.

Install both tarballs together so the sister dep is satisfied from local.

Reproduced and fixed:
- Failed run on `release/8.9.2`: https://github.com/getsentry/sentry-react-native/actions/runs/24987090493/job/73163953459 — "No matching version found for @sentry/expo-upload-sourcemaps@8.9.2"
- Verified locally with a fake `8.9.99` version (not on registry): `npm install --no-save <expo>.tgz <core>.tgz` resolves the cross-dep from the local sister tarball.

## :bulb: Motivation and Context
Unblocks the 8.9.2 release. The validate job's mode/file checks already pass on the failing run — only the install step was broken, and only by my own validation design (not the underlying tarball fix from #6049).

## :green_heart: How did you test it?
- Locally bumped both packages to `8.9.99` (not on npm), built tarballs with the new `build-tarball.sh`, and ran `npm install --no-save <expo>.tgz <core>.tgz` in a fresh dir. Install completes; `node_modules/@sentry/expo-upload-sourcemaps/package.json` shows version `8.9.99` (resolved from local tarball, not registry).
- All four bin links resolve and `sentry-xcode.sh` is executable post-install.

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
After merge: delete the failed `release/8.9.2` branch (`git push origin --delete release/8.9.2`) and re-dispatch the Release workflow. The new `release/8.9.2` will be created off the now-fixed `release/8.9.1` and the validate job will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)