### PR TITLE
chore: Back-merge release/8.9.1 into main

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -168,6 +168,80 @@ jobs:
             ${{ github.workspace }}/packages/core/*.tgz
             ${{ github.workspace }}/packages/expo-upload-sourcemaps/*.tgz
 
+  job_validate_tarball:
+    name: Validate tarball
+    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    needs: [job_build, diff_check]
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 18
+      - name: Download tarball artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ github.sha }}
+          path: artifacts
+      - name: Verify executable bits in tarball
+        run: |
+          set -e
+          TARBALL=$(find artifacts -name 'sentry-react-native-*.tgz' -print -quit)
+          [ -n "$TARBALL" ] || { echo "::error::tarball not found in artifacts/"; exit 1; }
+          echo "Tarball: $TARBALL"
+          FAILED=0
+          for entry in package/scripts/sentry-xcode.sh \
+                       package/scripts/sentry-xcode-debug-files.sh \
+                       package/scripts/collect-modules.sh \
+                       package/scripts/eas-build-hook.js \
+                       package/scripts/expo-upload-sourcemaps.js; do
+            mode=$(tar -tvf "$TARBALL" "$entry" 2>/dev/null | awk 'NR==1{print $1}')
+            if [ -z "$mode" ]; then
+              echo "::error::$entry missing from tarball"
+              FAILED=1
+            elif [ "$mode" != "-rwxr-xr-x" ]; then
+              echo "::error::$entry has mode $mode, expected -rwxr-xr-x"
+              FAILED=1
+            else
+              echo "OK: $entry ($mode)"
+            fi
+          done
+          exit $FAILED
+      - name: Install tarball into fresh project
+        run: |
+          set -e
+          TARBALL=$(find "$PWD/artifacts" -name 'sentry-react-native-*.tgz' -print -quit)
+          mkdir -p /tmp/install-test
+          cd /tmp/install-test
+          npm init -y >/dev/null
+          npm install --no-save "$TARBALL"
+          # workspace:* spec must have been resolved by yarn pack (#6037 regression)
+          if grep -q 'workspace:' node_modules/@sentry/react-native/package.json; then
+            echo "::error::published package.json still contains unresolved workspace: spec"
+            grep workspace: node_modules/@sentry/react-native/package.json
+            exit 1
+          fi
+          # bin entries must be linked into node_modules/.bin and executable
+          for bin in sentry-eas-build-on-complete \
+                     sentry-eas-build-on-error \
+                     sentry-eas-build-on-success \
+                     sentry-expo-upload-sourcemaps; do
+            if [ ! -x "node_modules/.bin/$bin" ]; then
+              echo "::error::node_modules/.bin/$bin missing or not executable"
+              ls -la node_modules/.bin/ | grep -i sentry || true
+              exit 1
+            fi
+            echo "OK: node_modules/.bin/$bin"
+          done
+          # sentry-xcode.sh is invoked directly by the iOS build phase, so it
+          # must remain executable after install (#6047)
+          if [ ! -x node_modules/@sentry/react-native/scripts/sentry-xcode.sh ]; then
+            echo "::error::scripts/sentry-xcode.sh is not executable after install"
+            ls -la node_modules/@sentry/react-native/scripts/sentry-xcode.sh
+            exit 1
+          fi
+          echo "OK: scripts/sentry-xcode.sh executable"
+
   job_type_check:
     name: Type Check Typescript 3.8
     runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -210,11 +210,18 @@ jobs:
       - name: Install tarball into fresh project
         run: |
           set -e
-          TARBALL=$(find "$PWD/artifacts" -name 'sentry-react-native-*.tgz' -print -quit)
+          CORE_TARBALL=$(find "$PWD/artifacts" -name 'sentry-react-native-*.tgz' -print -quit)
+          EXPO_TARBALL=$(find "$PWD/artifacts" -name 'sentry-expo-upload-sourcemaps-*.tgz' -print -quit)
+          [ -n "$CORE_TARBALL" ] || { echo "::error::core tarball not found"; exit 1; }
+          [ -n "$EXPO_TARBALL" ] || { echo "::error::expo-upload-sourcemaps tarball not found"; exit 1; }
           mkdir -p /tmp/install-test
           cd /tmp/install-test
           npm init -y >/dev/null
-          npm install --no-save "$TARBALL"
+          # Install both local tarballs together so the @sentry/expo-upload-sourcemaps
+          # cross-dep is satisfied locally. On a release branch the bumped version
+          # is not on the npm registry yet (workspace:* resolves to the version
+          # we are about to publish), and a registry fetch would fail with ETARGET.
+          npm install --no-save "$EXPO_TARBALL" "$CORE_TARBALL"
           # workspace:* spec must have been resolved by yarn pack (#6037 regression)
           if grep -q 'workspace:' node_modules/@sentry/react-native/package.json; then
             echo "::error::published package.json still contains unresolved workspace: spec"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Restore executable bit on shell scripts in the published tarball, fixing `Permission denied` on iOS build ([#6049](https://github.com/getsentry/sentry-react-native/pull/6049))
+- Restore EAS build hook bin scripts (`sentry-eas-build-on-{success,error,complete}`) missing from the published tarball ([#6049](https://github.com/getsentry/sentry-react-native/pull/6049))
+
 ## 8.9.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
-## Unreleased
+## 8.9.2
 
 ### Fixes
 

--- a/SDK-VERSIONS.md
+++ b/SDK-VERSIONS.md
@@ -12,6 +12,7 @@ To manually update the table with the current version, run `./scripts/update-sdk
 
 | React Native SDK | Android SDK | Cocoa SDK | JavaScript SDK |
 | ---------------- | ----------- | --------- | -------------- |
+| [8.9.2](https://github.com/getsentry/sentry-react-native/releases/tag/8.9.2) | [8.40.0](https://github.com/getsentry/sentry-java/releases/tag/8.40.0) | [9.11.0](https://github.com/getsentry/sentry-cocoa/releases/tag/9.11.0) | [10.49.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.49.0) |
 | [8.9.1](https://github.com/getsentry/sentry-react-native/releases/tag/8.9.1) | [8.40.0](https://github.com/getsentry/sentry-java/releases/tag/8.40.0) | [9.11.0](https://github.com/getsentry/sentry-cocoa/releases/tag/9.11.0) | [10.49.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.49.0) |
 | [8.8.0](https://github.com/getsentry/sentry-react-native/releases/tag/8.8.0) | [8.38.0](https://github.com/getsentry/sentry-java/releases/tag/8.38.0) | [9.10.0](https://github.com/getsentry/sentry-cocoa/releases/tag/9.10.0) | [10.48.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.48.0) |
 | [8.7.0](https://github.com/getsentry/sentry-react-native/releases/tag/8.7.0) | [8.37.1](https://github.com/getsentry/sentry-java/releases/tag/8.37.1) | [9.8.0](https://github.com/getsentry/sentry-cocoa/releases/tag/9.8.0) | [10.47.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.47.0) |

--- a/dev-packages/e2e-tests/package.json
+++ b/dev-packages/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-react-native-e2e-tests",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "private": true,
   "description": "Sentry React Native End to End Tests Library",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-typescript": "^7.18.6",
     "@sentry/core": "10.49.0",
-    "@sentry/react-native": "8.9.1",
+    "@sentry/react-native": "8.9.2",
     "@types/node": "^20.9.3",
     "@types/react": "^18.2.64",
     "appium": "3.2.2",

--- a/dev-packages/type-check/package.json
+++ b/dev-packages/type-check/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sentry-react-native-type-check",
   "private": true,
-  "version": "8.9.1",
+  "version": "8.9.2",
   "scripts": {
     "type-check": "./run-type-check.sh"
   }

--- a/dev-packages/utils/package.json
+++ b/dev-packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-react-native-samples-utils",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "description": "Internal Samples Utils",
   "main": "index.js",
   "license": "MIT",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "packages": [
     "packages/*",
     "dev-packages/*",

--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -27,6 +27,7 @@
 !scripts/sentry-xcode-debug-files.sh
 !scripts/sentry_utils.rb
 !scripts/expo-upload-sourcemaps.js
+!scripts/eas-build-hook.js
 
 # Metro
 !/metro.js

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
@@ -2,7 +2,7 @@ package io.sentry.react;
 
 class RNSentryVersion {
   static final String REACT_NATIVE_SDK_PACKAGE_NAME = "npm:@sentry/react-native";
-  static final String REACT_NATIVE_SDK_PACKAGE_VERSION = "8.9.1";
+  static final String REACT_NATIVE_SDK_PACKAGE_VERSION = "8.9.2";
   static final String NATIVE_SDK_NAME = "sentry.native.android.react-native";
   static final String ANDROID_SDK_NAME = "sentry.java.android.react-native";
   static final String REACT_NATIVE_SDK_NAME = "sentry.javascript.react-native";

--- a/packages/core/ios/RNSentryVersion.m
+++ b/packages/core/ios/RNSentryVersion.m
@@ -3,4 +3,4 @@
 NSString *const NATIVE_SDK_NAME = @"sentry.cocoa.react-native";
 NSString *const REACT_NATIVE_SDK_NAME = @"sentry.javascript.react-native";
 NSString *const REACT_NATIVE_SDK_PACKAGE_NAME = @"npm:@sentry/react-native";
-NSString *const REACT_NATIVE_SDK_PACKAGE_VERSION = @"8.9.1";
+NSString *const REACT_NATIVE_SDK_PACKAGE_VERSION = @"8.9.2";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@sentry/react-native",
   "homepage": "https://github.com/getsentry/sentry-react-native",
   "repository": "https://github.com/getsentry/sentry-react-native",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "description": "Official Sentry SDK for react-native",
   "typings": "dist/js/index.d.ts",
   "types": "dist/js/index.d.ts",

--- a/packages/core/scripts/build-tarball.sh
+++ b/packages/core/scripts/build-tarball.sh
@@ -14,4 +14,16 @@ cp ../../README.md README.md
 # rewritten to concrete versions in the published tarball. npm pack leaves
 # the spec as `workspace:*`, which consumers cannot resolve.
 VERSION=$(node -p "require('./package.json').version")
-yarn pack --out "sentry-react-native-${VERSION}.tgz"
+TARBALL="sentry-react-native-${VERSION}.tgz"
+yarn pack --out "$TARBALL"
+
+# yarn pack stores non-bin files with mode 0644, which breaks the Xcode build
+# phase that invokes scripts/sentry-xcode.sh directly (Permission denied).
+# Re-pack with +x on shell scripts and bin entrypoints.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+tar -xzf "$TARBALL" -C "$TMP_DIR"
+chmod 0755 "$TMP_DIR"/package/scripts/*.sh \
+           "$TMP_DIR"/package/scripts/eas-build-hook.js \
+           "$TMP_DIR"/package/scripts/expo-upload-sourcemaps.js
+tar -czf "$TARBALL" -C "$TMP_DIR" package

--- a/packages/core/src/js/version.ts
+++ b/packages/core/src/js/version.ts
@@ -1,3 +1,3 @@
 export const SDK_PACKAGE_NAME = 'npm:@sentry/react-native';
 export const SDK_NAME = 'sentry.javascript.react-native';
-export const SDK_VERSION = '8.9.1';
+export const SDK_VERSION = '8.9.2';

--- a/packages/expo-upload-sourcemaps/package.json
+++ b/packages/expo-upload-sourcemaps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/expo-upload-sourcemaps",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "description": "CLI to upload bundles and source maps from Expo builds to Sentry.",
   "homepage": "https://github.com/getsentry/sentry-react-native/tree/main/packages/expo-upload-sourcemaps",
   "repository": {

--- a/performance-tests/TestAppPlain/package.json
+++ b/performance-tests/TestAppPlain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TestAppPlain",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/performance-tests/TestAppSentry/package.json
+++ b/performance-tests/TestAppSentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TestAppSentry",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@react-native/new-app-screen": "0.80.2",
-    "@sentry/react-native": "8.9.1",
+    "@sentry/react-native": "8.9.2",
     "react": "19.1.0",
     "react-native": "0.80.2"
   },

--- a/samples/expo/app.json
+++ b/samples/expo/app.json
@@ -4,7 +4,7 @@
     "slug": "sentry-react-native-expo-sample",
     "jsEngine": "hermes",
     "scheme": "sentry-expo-sample",
-    "version": "8.9.1",
+    "version": "8.9.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -19,7 +19,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "io.sentry.expo.sample",
-      "buildNumber": "82"
+      "buildNumber": "83"
     },
     "android": {
       "adaptiveIcon": {
@@ -27,7 +27,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "io.sentry.expo.sample",
-      "versionCode": 82
+      "versionCode": 83
     },
     "web": {
       "bundler": "metro",

--- a/samples/expo/package.json
+++ b/samples/expo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-react-native-expo-sample",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@sentry/core": "10.49.0",
-    "@sentry/react-native": "8.9.1",
+    "@sentry/react-native": "8.9.2",
     "@types/react": "~19.2.10",
     "expo": "^55.0.0",
     "expo-constants": "~55.0.7",

--- a/samples/react-native-macos/package.json
+++ b/samples/react-native-macos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-react-native-macos-sample",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "private": true,
   "scripts": {
     "start": "react-native start --experimental-debugger",
@@ -18,7 +18,7 @@
     "@react-navigation/stack": "^6.3.20",
     "@sentry/core": "10.49.0",
     "@sentry/react": "10.49.0",
-    "@sentry/react-native": "8.9.1",
+    "@sentry/react-native": "8.9.2",
     "delay": "^6.0.0",
     "react": "18.2.0",
     "react-native": "0.73.9",

--- a/samples/react-native/android/app/build.gradle
+++ b/samples/react-native/android/app/build.gradle
@@ -130,8 +130,8 @@ android {
         applicationId "io.sentry.reactnative.sample"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 84
-        versionName "8.9.1"
+        versionCode 85
+        versionName "8.9.2"
         buildConfigField "boolean", "SENTRY_DISABLE_NATIVE_START", System.getenv('SENTRY_DISABLE_NATIVE_START') ?: String.valueOf(sentryDisableNativeStart)
 
         testBuildType System.getProperty('testBuildType', 'debug')

--- a/samples/react-native/ios/sentryreactnativesample/Info.plist
+++ b/samples/react-native/ios/sentryreactnativesample/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>8.9.1</string>
+	<string>8.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>89</string>
+	<string>90</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>

--- a/samples/react-native/ios/sentryreactnativesampleTests/Info.plist
+++ b/samples/react-native/ios/sentryreactnativesampleTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>8.9.1</string>
+	<string>8.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>89</string>
+	<string>90</string>
 </dict>
 </plist>

--- a/samples/react-native/package.json
+++ b/samples/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-react-native-sample",
-  "version": "8.9.1",
+  "version": "8.9.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -49,7 +49,7 @@
     "@reduxjs/toolkit": "^2.8.2",
     "@sentry/core": "10.49.0",
     "@sentry/react": "10.49.0",
-    "@sentry/react-native": "8.9.1",
+    "@sentry/react-native": "8.9.2",
     "@shopify/flash-list": "^2.0.2",
     "delay": "^6.0.0",
     "react": "19.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11225,7 +11225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/react-native@8.9.1, @sentry/react-native@workspace:packages/core":
+"@sentry/react-native@8.9.2, @sentry/react-native@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@sentry/react-native@workspace:packages/core"
   dependencies:
@@ -12528,7 +12528,7 @@ __metadata:
     "@react-native/metro-config": 0.80.2
     "@react-native/new-app-screen": 0.80.2
     "@react-native/typescript-config": 0.80.2
-    "@sentry/react-native": 8.9.1
+    "@sentry/react-native": 8.9.2
     "@types/jest": ^29.5.13
     "@types/react": ^19.1.0
     "@types/react-test-renderer": ^19.1.0
@@ -30140,7 +30140,7 @@ __metadata:
     "@babel/preset-env": ^7.25.3
     "@babel/preset-typescript": ^7.18.6
     "@sentry/core": 10.49.0
-    "@sentry/react-native": 8.9.1
+    "@sentry/react-native": 8.9.2
     "@types/node": ^20.9.3
     "@types/react": ^18.2.64
     appium: 3.2.2
@@ -30170,7 +30170,7 @@ __metadata:
     "@babel/preset-env": ^7.26.0
     "@sentry/babel-plugin-component-annotate": 5.2.0
     "@sentry/core": 10.49.0
-    "@sentry/react-native": 8.9.1
+    "@sentry/react-native": 8.9.2
     "@types/node": 20.10.4
     "@types/react": ~19.2.10
     expo: ^55.0.0
@@ -30209,7 +30209,7 @@ __metadata:
     "@react-navigation/stack": ^6.3.20
     "@sentry/core": 10.49.0
     "@sentry/react": 10.49.0
-    "@sentry/react-native": 8.9.1
+    "@sentry/react-native": 8.9.2
     "@types/react": ^18.2.65
     "@types/react-native-vector-icons": ^6.4.18
     babel-plugin-module-resolver: ^5.0.0
@@ -30255,7 +30255,7 @@ __metadata:
     "@sentry/babel-plugin-component-annotate": 5.2.0
     "@sentry/core": 10.49.0
     "@sentry/react": 10.49.0
-    "@sentry/react-native": 8.9.1
+    "@sentry/react-native": 8.9.2
     "@shopify/flash-list": ^2.0.2
     "@testing-library/react-native": ^13.2.2
     "@types/jest": ^29.5.14


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [x] Other (back-merge)


## :scroll: Description
Back-merges `release/8.9.1` (which now contains the 8.9.2 release) into `main`. Brings the following onto main:

- `fix(core)`: Restore tarball script permissions and missing EAS build hook (#6049)
- `fix(ci)`: Install both tarballs in validate job to satisfy cross-dep (#6052)
- `release: 8.9.2` version bumps (lerna, package.json files, native version files, sample app pins)
- The `## 8.9.2` CHANGELOG block

## :bulb: Motivation and Context
8.9.2 was released from `release/8.9.1` (since this was a hotfix on top of the 8.9.1 tag). Main needs the fix code, the new validate-tarball CI job, and the version bump so downstream releases continue from 8.9.2.

## :green_heart: How did you test it?
- Ran `git merge --no-ff origin/release/8.9.1` and resolved 6 file conflicts:
  - `CHANGELOG.md`: kept main's `## Unreleased` block (8.10-bound entries) and inserted `## 8.9.2` between it and `## 8.9.1`.
  - `dev-packages/e2e-tests/package.json`, `samples/expo/package.json`, `samples/react-native-macos/package.json`, `samples/react-native/package.json`: took `@sentry/react-native: 8.9.2` from release branch, kept `@sentry/core` / `@sentry/react` at `10.50.0` from main (those are 8.10-bound bumps that should not regress to 10.49.0).
  - `yarn.lock`: regenerated with `yarn install --mode=update-lockfile` after package.json conflicts were resolved.
- Verified post-merge state: `packages/core/package.json` is at `8.9.2`, the validate-tarball CI job is present, `.npmignore` includes `!scripts/eas-build-hook.js`, `build-tarball.sh` has the `chmod` step.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
After merge, `release/8.9.1` can be deleted (or kept around if further 8.9.x patches are anticipated). The next regular release will continue from main at `8.9.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)