### PR TITLE
ci: Restore changelog-preview workflow with hardened craft 2.26.2

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -15,4 +15,3 @@ permissions:
 jobs:
   changelog-preview:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@3dc647fee3586e57c7c31eb900fdec7cbb44f23f # v2.26.2
-    secrets: inherit

--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,0 +1,18 @@
+name: Changelog Preview
+on:
+  pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - edited
+    - labeled
+    - unlabeled
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  changelog-preview:
+    uses: getsentry/craft/.github/workflows/changelog-preview.yml@3dc647fee3586e57c7c31eb900fdec7cbb44f23f # v2.26.2
+    secrets: inherit


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Re-adds `.github/workflows/changelog-preview.yml`, removed in #6030, using the hardened reusable workflow from `getsentry/craft@v2.26.2` (#6050).

Differences from the previously deleted file:
- Pinned to craft `3dc647fee3586e57c7c31eb900fdec7cbb44f23f` (v2.26.2) instead of v2.25.4.
- `permissions.contents: write` → `contents: read`. Upstream's reusable workflow only reads git metadata + `.craft.yml`; write was unnecessary and unsafe under `pull_request_target`.
- Drop `statuses: write` (only needed in non-comment / status-check mode; we use the default comment mode).
- Add `unlabeled` to the trigger types per upstream's recommended caller template.

## :bulb: Motivation and Context
The original workflow combined `pull_request_target` + `contents: write` + `secrets: inherit` while pinning to a craft version (v2.25.4) that predated the upstream hardening series (2.25.5 onward). PR #6030 removed it. Now that #6050 has landed bumping the release workflow to craft 2.26.2, we can safely restore the changelog preview using the redesigned upstream reusable workflow, which:
- downloads the craft binary from releases (does not run any PR code),
- reads only git metadata and `.craft.yml`,
- checks out with `persist-credentials: false`.

Refs:
- #6030 (removal)
- #6050 (craft bump to 2.26.2)
- Upstream caller template documented in `getsentry/craft/.github/workflows/changelog-preview.yml`

## :green_heart: How did you test it?
Workflow file only — will be exercised by GitHub once this PR is opened (the workflow runs on `pull_request_target`, so the version on the base branch is what executes; full validation will come once merged).

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps