### PR TITLE
fix(android): Mask auth token in sentry.gradle upload-task log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 - Stop the Hermes sampling profiler on React instance teardown to prevent `pthread_kill` SIGABRT when the JS thread is torn down with profiling active ([#6035](https://github.com/getsentry/sentry-react-native/pull/6035))
+- Mask the Sentry auth token in the `sentry.gradle` upload-task lifecycle log
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Fixes
 
 - Stop the Hermes sampling profiler on React instance teardown to prevent `pthread_kill` SIGABRT when the JS thread is torn down with profiling active ([#6035](https://github.com/getsentry/sentry-react-native/pull/6035))
-- Mask the Sentry auth token in the `sentry.gradle` upload-task lifecycle log
+- Mask the Sentry auth token in the `sentry.gradle` upload-task lifecycle log ([#6057](https://github.com/getsentry/sentry-react-native/pull/6057))
 
 ### Dependencies
 

--- a/packages/core/sentry.gradle
+++ b/packages/core/sentry.gradle
@@ -269,7 +269,9 @@ plugins.withId('com.android.application') {
 
                                 args.addAll(extraArgs)
 
-                                project.logger.lifecycle("Sentry-CLI arguments: ${args}")
+                                // Mask sentryAuthToken in the logged args; do not pass loggedArgs to the CLI.
+                                def loggedArgs = sentryAuthToken ? args.collect { it == sentryAuthToken ? "***" : it } : args
+                                project.logger.lifecycle("Sentry-CLI arguments: ${loggedArgs}")
                                 def osCompatibility = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c', 'node'] : []
                                 if (!System.getenv('SENTRY_DOTENV_PATH') && file("$reactRoot/.env.sentry-build-plugin").exists()) {
                                     environment('SENTRY_DOTENV_PATH', "$reactRoot/.env.sentry-build-plugin")


### PR DESCRIPTION
## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Description

The `sentry-react-native` upload task in `sentry.gradle` was logging its full sentry-cli argument list at the Gradle lifecycle log level (default verbosity). When `flavorAware` is enabled, those args include the auth token. Replace the token's value with `***` in the logged copy; the actual command-line invocation is unchanged.

The masking is value-based via `args.collect { it == sentryAuthToken ? "***" : it }`, so the token is redacted wherever it appears in the args list. A short comment notes that `loggedArgs` must not be passed to the CLI.

## Motivation and Context

Internal security review.

## How did you test it?

- Manually reviewed the diff and the surrounding flag layout (`--url`, `--bundle`, `--sourcemap`, `--org`, `--project`, `--release`, `--dist`, `extraArgs`) — only `--auth-token` carries a secret.
- The repo has no Gradle/Groovy unit-test harness, so no automated test added. Verifiable by running a flavor-aware release build with a real token and grepping the build log: only `***` appears next to `--auth-token`.

## Checklist

- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes


## Next steps

None.