### PR TITLE
chore(deps): bump postcss to ^8.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
     "plist@npm:3.1.0/@xmldom/xmldom": "^0.8.13",
     "@appium/support@npm:7.0.6/yauzl": "^3.2.1",
     "appium-ios-remotexpc@npm:0.36.0/@xmldom/xmldom": "^0.9.10",
-    "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.10"
+    "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.10",
+    "postcss": "^8.5.10"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25500,7 +25500,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.23, nanoid@npm:^3.3.7":
+"nanoid@npm:^3.1.23":
   version: 3.3.8
   resolution: "nanoid@npm:3.3.8"
   bin:
@@ -27442,14 +27442,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.1.7, postcss@npm:^8.4.23, postcss@npm:~8.4.32":
-  version: 8.4.41
-  resolution: "postcss@npm:8.4.41"
+"postcss@npm:^8.5.10":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
   dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.0.1"
-    source-map-js: "npm:^1.2.0"
-  checksum: f865894929eb0f7fc2263811cc853c13b1c75103028b3f4f26df777e27b201f1abe21cb4aa4c2e901c80a04f6fb325ee22979688fe55a70e2ea82b0a517d3b6f
+    nanoid: ^3.3.11
+    picocolors: ^1.1.1
+    source-map-js: ^1.2.1
+  checksum: e11818908d9f1693438bd7c6e3af99431552f5c9b3f400ebe76af3f25bd1b1efb26bc4c13533f3dcff45540a66ad4e84c62e06491f88003bbfa4ef35b6175f55
   languageName: node
   linkType: hard
 
@@ -30807,10 +30807,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "source-map-js@npm:1.2.0"
-  checksum: 791a43306d9223792e84293b00458bf102a8946e7188f3db0e4e22d8d530b5f80a4ce468eb5ec0bf585443ad55ebbd630bf379c98db0b1f317fd902500217f97
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 4eb0cd997cdf228bc253bcaff9340afeb706176e64868ecd20efbe6efea931465f43955612346d6b7318789e5265bdc419bc7669c1cebe3db0eb255f57efa76b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Unscoped resolution to bump postcss from 8.4.41 to 8.5.12, fixing XSS via unescaped `</style>` in CSS stringify output.

Dev-only dependency.

https://github.com/getsentry/sentry-react-native/security/dependabot/512