### PR TITLE
test(profiling): pin Android RNSentryStart wiring of _experiments.profilingOptions

### DIFF
--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryProfilingOptionsTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryProfilingOptionsTest.kt
@@ -1,0 +1,230 @@
+package io.sentry.react
+
+import com.facebook.react.bridge.JavaOnlyMap
+import io.sentry.ILogger
+import io.sentry.ProfileLifecycle
+import io.sentry.SentryLevel
+import io.sentry.android.core.SentryAndroidOptions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+/**
+ * Pins the wiring of `_experiments.profilingOptions` from the JS bridge into
+ * `SentryAndroidOptions` via `RNSentryStart.configureAndroidProfiling`.
+ *
+ * The Android side is correctly wired today (unlike the iOS bug fixed in #6012). These tests
+ * ensure that a future refactor moving `configureAndroidProfiling` out of the live init path
+ * — the same shape of regression as the iOS one — fails loudly.
+ */
+@RunWith(JUnit4::class)
+class RNSentryProfilingOptionsTest {
+    private lateinit var logger: ILogger
+
+    @Before
+    fun setUp() {
+        logger = mock(ILogger::class.java)
+    }
+
+    @Test
+    fun `profilingOptions wires sessionSampleRate, trace lifecycle, and startOnAppStart`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of(
+                        "profileSessionSampleRate",
+                        1.0,
+                        "lifecycle",
+                        "trace",
+                        "startOnAppStart",
+                        true,
+                    ),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertEquals(1.0, options.profileSessionSampleRate!!, 0.0)
+        assertEquals(ProfileLifecycle.TRACE, options.profileLifecycle)
+        assertTrue(options.isStartProfilerOnAppStart)
+    }
+
+    @Test
+    fun `profilingOptions lifecycle manual maps to ProfileLifecycle MANUAL`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of("lifecycle", "manual"),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertEquals(ProfileLifecycle.MANUAL, options.profileLifecycle)
+    }
+
+    @Test
+    fun `profilingOptions lifecycle is case-insensitive`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of("lifecycle", "TRACE"),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertEquals(ProfileLifecycle.TRACE, options.profileLifecycle)
+    }
+
+    @Test
+    fun `profilingOptions startOnAppStart false is honored`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of("startOnAppStart", false),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertFalse(options.isStartProfilerOnAppStart)
+    }
+
+    @Test
+    fun `no _experiments key leaves profiling defaults untouched`() {
+        val rnOptions = JavaOnlyMap()
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertNull(options.profileSessionSampleRate)
+        assertEquals(ProfileLifecycle.MANUAL, options.profileLifecycle)
+        assertFalse(options.isStartProfilerOnAppStart)
+    }
+
+    @Test
+    fun `_experiments without profilingOptions leaves profiling defaults untouched`() {
+        val rnOptions = JavaOnlyMap.of("_experiments", JavaOnlyMap())
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertNull(options.profileSessionSampleRate)
+        assertEquals(ProfileLifecycle.MANUAL, options.profileLifecycle)
+        assertFalse(options.isStartProfilerOnAppStart)
+    }
+
+    @Test
+    fun `empty profilingOptions leaves profiling defaults untouched`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of("profilingOptions", JavaOnlyMap()),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertNull(options.profileSessionSampleRate)
+        assertEquals(ProfileLifecycle.MANUAL, options.profileLifecycle)
+        assertFalse(options.isStartProfilerOnAppStart)
+    }
+
+    @Test
+    fun `non-number profileSessionSampleRate logs a warning and is ignored`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of("profileSessionSampleRate", "not-a-number"),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertNull(options.profileSessionSampleRate)
+        verify(logger, times(1)).log(eq(SentryLevel.WARNING), anyString())
+    }
+
+    @Test
+    fun `non-string lifecycle logs a warning and is ignored`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of("lifecycle", 1),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertEquals(ProfileLifecycle.MANUAL, options.profileLifecycle)
+        verify(logger, times(1)).log(eq(SentryLevel.WARNING), anyString())
+    }
+
+    @Test
+    fun `non-boolean startOnAppStart logs a warning and is ignored`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of("startOnAppStart", "yes"),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertFalse(options.isStartProfilerOnAppStart)
+        verify(logger, times(1)).log(eq(SentryLevel.WARNING), anyString())
+    }
+
+    @Test
+    fun `unknown lifecycle string is silently ignored without warning`() {
+        val rnOptions =
+            JavaOnlyMap.of(
+                "_experiments",
+                JavaOnlyMap.of(
+                    "profilingOptions",
+                    JavaOnlyMap.of("lifecycle", "not-a-real-mode"),
+                ),
+            )
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        // Implementation only logs a warning for type mismatches, not unknown string values.
+        // Lifecycle stays at the default.
+        assertEquals(ProfileLifecycle.MANUAL, options.profileLifecycle)
+        verify(logger, never()).log(eq(SentryLevel.WARNING), anyString())
+    }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Refactoring


## :scroll: Description

Adds a new JUnit test class `RNSentryProfilingOptionsTest` under `packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/` that pins the wiring of `_experiments.profilingOptions` from the JS bridge into `SentryAndroidOptions` via `RNSentryStart.configureAndroidProfiling`.

The 11 tests cover:

- All three fields propagate when set together (`profileSessionSampleRate`, `lifecycle: "trace"`, `startOnAppStart: true` → `options.profileSessionSampleRate == 1.0`, `profileLifecycle == TRACE`, `isStartProfilerOnAppStart == true`).
- `lifecycle: "manual"` → `ProfileLifecycle.MANUAL`.
- `lifecycle: "TRACE"` → case-insensitive match.
- `startOnAppStart: false` is honored.
- Defaults are preserved when `_experiments` is missing, when `_experiments` has no `profilingOptions`, and when `profilingOptions` is empty.
- Type mismatches (string for `profileSessionSampleRate`, number for `lifecycle`, string for `startOnAppStart`) log a `SentryLevel.WARNING` and leave the field unchanged.
- Unknown `lifecycle` strings are silently ignored without a warning, matching the implementation's actual behavior (only type mismatches log).

This piggybacks on the existing `RNSentryAndroidTester` Gradle module and follows the conventions of the neighboring `RNSentryStartTest.kt` (JUnit4 + Mockito + `JavaOnlyMap.of(...)` fixtures + real `SentryAndroidOptions()` instances).

Note on scope: the issue mentioned considering pinning `_experiments.enableUnhandledCPPExceptionsV2` on Android too. That option is `@platform ios` only (see `packages/core/src/js/options.ts:361`) and is not handled on Android by design — there's nothing to pin. Skipped.


## :bulb: Motivation and Context

Closes #6016. The iOS bug fixed in #6012 (`_experiments.profilingOptions` silently ignored since v8.0.0) shipped because no test exercised the live init path's profiling wiring. The Android wiring is correct today, but it has no JUnit coverage either — so a future refactor moving `configureAndroidProfiling` out of `getSentryAndroidOptions` (or introducing a parallel init path the way the iOS one slipped in) would silently regress the same way. These tests close that gap with the same shape of coverage that pins the iOS path.


## :green_heart: How did you test it?

- `./gradlew :app:testDebugUnitTest --tests "io.sentry.react.RNSentryProfilingOptionsTest"` — 11/11 pass.
- `./gradlew :app:testDebugUnitTest` — full Android test suite still green.
- `yarn lint:android`, `yarn lint:kotlin`, `yarn build`, `yarn test`, `yarn circularDepCheck` — all clean.
- Mentally traced regression coverage: deleting any of the three `options.set…` calls inside `configureAndroidProfiling` causes the "all three fields propagate" test to fail. Removing the `configureAndroidProfiling(...)` call site causes all 11 tests to fail.


## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
