### PR TITLE
fix(android): Use safeExtGet for compileSdkVersion in expo-handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- Fix Android build failure in `expo-handler` when Android SDK 31 is not installed by using `safeExtGet` for `compileSdkVersion` and `minSdkVersion` ([#6061](https://github.com/getsentry/sentry-react-native/pull/6061))
 - Stop the Hermes sampling profiler on React instance teardown to prevent `pthread_kill` SIGABRT when the JS thread is torn down with profiling active ([#6035](https://github.com/getsentry/sentry-react-native/pull/6035))
 - Mask the Sentry auth token in the `sentry.gradle` upload-task lifecycle log ([#6057](https://github.com/getsentry/sentry-react-native/pull/6057))
 - Discard invalid navigation/interaction transactions via an event processor instead of mutating the internal `_sampled` flag, removing misleading "dropped due to sampling" debug logs ([#6051](https://github.com/getsentry/sentry-react-native/pull/6051))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixes
 
-- Fix Android build failure in `expo-handler` when Android SDK 31 is not installed by using `safeExtGet` for `compileSdkVersion` and `minSdkVersion` ([#6061](https://github.com/getsentry/sentry-react-native/pull/6061))
+- Android build failure in `expo-handler` when Android SDK 31 is not installed by using `safeExtGet` for `compileSdkVersion` and `minSdkVersion` ([#6061](https://github.com/getsentry/sentry-react-native/pull/6061))
 - Stop the Hermes sampling profiler on React instance teardown to prevent `pthread_kill` SIGABRT when the JS thread is torn down with profiling active ([#6035](https://github.com/getsentry/sentry-react-native/pull/6035))
 - Mask the Sentry auth token in the `sentry.gradle` upload-task lifecycle log ([#6057](https://github.com/getsentry/sentry-react-native/pull/6057))
 - Discard invalid navigation/interaction transactions via an event processor instead of mutating the internal `_sampled` flag, removing misleading "dropped due to sampling" debug logs ([#6051](https://github.com/getsentry/sentry-react-native/pull/6051))

--- a/packages/core/android/expo-handler/build.gradle
+++ b/packages/core/android/expo-handler/build.gradle
@@ -1,11 +1,15 @@
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion safeExtGet('compileSdkVersion', 31)
     namespace = "io.sentry.react.expo"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion safeExtGet('minSdkVersion', 21)
     }
 
     compileOptions {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
Add `safeExtGet` helper to `expo-handler/build.gradle` and use it for `compileSdkVersion` and `minSdkVersion` instead of hardcoded values, matching the pattern already used in the main `build.gradle`.

## :bulb: Motivation and Context
When a user only has a newer Android SDK installed (e.g. SDK 36) and not SDK 31, the build fails with:

```
Failed to find target with hash string 'android-31' in: /Users/<user>/Library/Android/sdk
```

This happens because `expo-handler/build.gradle` hardcodes `compileSdkVersion 31`, while the main `build.gradle` already uses `safeExtGet('compileSdkVersion', 31)` to inherit the value from the root project. The fix brings `expo-handler` in line with the same pattern.

Fixes #6054

## :green_heart: How did you test it?

Code review — the change is a mechanical port of the existing `safeExtGet` pattern from `packages/core/android/build.gradle` into `packages/core/android/expo-handler/build.gradle`.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps