### PR TITLE
fix(ci): Grant statuses: write to changelog-preview caller

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   changelog-preview:


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
Adds `statuses: write` to the caller's `permissions:` block in `.github/workflows/changelog-preview.yml`.

## :bulb: Motivation and Context
After #6056 landed, every PR is failing workflow validation:

> Invalid workflow file: .github/workflows/changelog-preview.yml#L16
> The workflow is not valid. Error calling workflow 'getsentry/craft/.github/workflows/changelog-preview.yml@3dc647fee3586e57c7c31eb900fdec7cbb44f23f'. The nested job 'preview' is requesting 'statuses: write', but is only allowed 'statuses: none'.

Example: https://github.com/getsentry/sentry-react-native/actions/runs/25053863171

The upstream reusable workflow's `preview` job declares `permissions.statuses: write` unconditionally (its inline comment "# For status check mode" is misleading — the permission is requested even in comment mode). Reusable workflows can only request permissions ≤ caller's, so the caller has to grant it. This matches the pattern already in sentry-cocoa, sentry-dotnet, and sentry-go.

Note: I dropped this permission in #6056 reasoning that we use comment mode and don't need it. That was wrong — the validation happens at job-permissions level regardless of which input we pass.

## :green_heart: How did you test it?
Workflow file only — verified against the upstream `permissions:` block at the pinned SHA. Final validation will come from the next PR opened against `main` after this lands.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
