### PR TITLE
test(ios): Add unit tests for RNSentryIsPathUnderAllowedRoots

### DIFF
--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		332D33472CDBDBB600547D76 /* RNSentryReplayOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 332D33462CDBDBB600547D76 /* RNSentryReplayOptionsTests.swift */; };
 		3339C4812D6625570088EB3A /* RNSentryUserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3339C4802D6625570088EB3A /* RNSentryUserTests.m */; };
+		B4DEB41739F14AA38202D4D4 /* RNSentryUriValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E3742693F7643C2ADE1BDF2 /* RNSentryUriValidationTests.m */; };
 		336084392C32E382008CC412 /* RNSentryReplayBreadcrumbConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 336084382C32E382008CC412 /* RNSentryReplayBreadcrumbConverterTests.swift */; };
 		3380C6C42CE25ECA0018B9B6 /* RNSentryReplayPostInitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3380C6C32CE25ECA0018B9B6 /* RNSentryReplayPostInitTests.swift */; };
 		33AFDFED2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33AFDFEC2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m */; };
@@ -30,6 +31,7 @@
 		332D334A2CDCC8EB00547D76 /* RNSentryCocoaTesterTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNSentryCocoaTesterTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		3339C47F2D6625260088EB3A /* RNSentry+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RNSentry+Test.h"; sourceTree = "<group>"; };
 		3339C4802D6625570088EB3A /* RNSentryUserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentryUserTests.m; sourceTree = "<group>"; };
+		3E3742693F7643C2ADE1BDF2 /* RNSentryUriValidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentryUriValidationTests.m; sourceTree = "<group>"; };
 		336084382C32E382008CC412 /* RNSentryReplayBreadcrumbConverterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RNSentryReplayBreadcrumbConverterTests.swift; sourceTree = "<group>"; };
 		3360843A2C32E3A8008CC412 /* RNSentryReplayBreadcrumbConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RNSentryReplayBreadcrumbConverter.h; path = ../ios/RNSentryReplayBreadcrumbConverter.h; sourceTree = "<group>"; };
 		3360843C2C340C76008CC412 /* RNSentryBreadcrumbTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNSentryBreadcrumbTests.swift; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 				336084382C32E382008CC412 /* RNSentryReplayBreadcrumbConverterTests.swift */,
 				33F58ACF2977037D008F60EA /* RNSentryTests.m */,
 				3339C4802D6625570088EB3A /* RNSentryUserTests.m */,
+				3E3742693F7643C2ADE1BDF2 /* RNSentryUriValidationTests.m */,
 				33AFDFEC2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m */,
 				33AFDFF02B8D15E500AAB120 /* RNSentryDependencyContainerTests.m */,
 				3360843C2C340C76008CC412 /* RNSentryBreadcrumbTests.swift */,
@@ -266,6 +269,7 @@
 				33DEDFED2D8DC825006066E4 /* RNSentryOnDrawReporter+Test.mm in Sources */,
 				33F58AD02977037D008F60EA /* RNSentryTests.m in Sources */,
 				3339C4812D6625570088EB3A /* RNSentryUserTests.m in Sources */,
+				B4DEB41739F14AA38202D4D4 /* RNSentryUriValidationTests.m in Sources */,
 				33DEDFF02D9185EB006066E4 /* RNSentryTimeToDisplayTests.swift in Sources */,
 				3380C6C42CE25ECA0018B9B6 /* RNSentryReplayPostInitTests.swift in Sources */,
 				33AFDFED2B8D14B300AAB120 /* RNSentryFramesTrackerListenerTests.m in Sources */,

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentry+Test.h
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentry+Test.h
@@ -7,4 +7,8 @@
 
 + (BOOL)captureReplayWithReturnValue;
 
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
++ (BOOL)isPathUnderAllowedRootsForTesting:(NSString *)path;
+#endif
+
 @end

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryUriValidationTests.m
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryUriValidationTests.m
@@ -1,0 +1,99 @@
+#import "RNSentry+Test.h"
+#import <XCTest/XCTest.h>
+
+#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+
+@interface RNSentryUriValidationTests : XCTestCase
+
+@property (nonatomic, strong) NSURL *symlinkURL;
+
+@end
+
+@implementation RNSentryUriValidationTests
+
+- (void)tearDown
+{
+    if (self.symlinkURL) {
+        [[NSFileManager defaultManager] removeItemAtURL:self.symlinkURL error:nil];
+        self.symlinkURL = nil;
+    }
+    [super tearDown];
+}
+
+- (void)testEmptyPathReturnsFalse
+{
+    XCTAssertFalse([RNSentry isPathUnderAllowedRootsForTesting:@""]);
+}
+
+- (void)testPathWithDotDotComponentReturnsFalse
+{
+    NSString *path = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:@"../Library/Cookies/Cookies.binarycookies"];
+    XCTAssertFalse([RNSentry isPathUnderAllowedRootsForTesting:path]);
+}
+
+- (void)testPathUnderTmpReturnsTrue
+{
+    NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:@"image.jpg"];
+    XCTAssertTrue([RNSentry isPathUnderAllowedRootsForTesting:path]);
+}
+
+- (void)testPathUnderCachesDirReturnsTrue
+{
+    NSString *cachesDir
+        = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+    NSString *path = [cachesDir stringByAppendingPathComponent:@"thumbnail.png"];
+    XCTAssertTrue([RNSentry isPathUnderAllowedRootsForTesting:path]);
+}
+
+- (void)testPathUnderDocumentsDirReturnsTrue
+{
+    NSString *docsDir
+        = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES)
+              .firstObject;
+    NSString *path = [docsDir stringByAppendingPathComponent:@"attachment.jpg"];
+    XCTAssertTrue([RNSentry isPathUnderAllowedRootsForTesting:path]);
+}
+
+- (void)testPathUnderLibraryReturnsFalse
+{
+    NSString *libraryDir
+        = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)
+              .firstObject;
+    NSString *path = [libraryDir stringByAppendingPathComponent:@"Cookies/Cookies.binarycookies"];
+    XCTAssertFalse([RNSentry isPathUnderAllowedRootsForTesting:path]);
+}
+
+- (void)testAbsolutePathOutsideSandboxReturnsFalse
+{
+    XCTAssertFalse([RNSentry isPathUnderAllowedRootsForTesting:@"/etc/passwd"]);
+}
+
+- (void)testPathUnderLibraryApplicationSupportReturnsFalse
+{
+    NSString *libraryDir
+        = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES)
+              .firstObject;
+    NSString *path = [libraryDir stringByAppendingPathComponent:@"Application Support/app.sqlite"];
+    XCTAssertFalse([RNSentry isPathUnderAllowedRootsForTesting:path]);
+}
+
+- (void)testSymlinkInTmpPointingOutsideSandboxReturnsFalse
+{
+    NSString *symlinkPath =
+        [NSTemporaryDirectory() stringByAppendingPathComponent:@"sentry_test_symlink_passwd"];
+    self.symlinkURL = [NSURL fileURLWithPath:symlinkPath];
+
+    NSError *error = nil;
+    [[NSFileManager defaultManager] removeItemAtPath:symlinkPath error:nil];
+    BOOL created = [[NSFileManager defaultManager] createSymbolicLinkAtPath:symlinkPath
+                                                        withDestinationPath:@"/etc/passwd"
+                                                                      error:&error];
+    XCTAssertTrue(created, @"Symlink creation failed: %@", error);
+
+    XCTAssertFalse([RNSentry isPathUnderAllowedRootsForTesting:symlinkPath]);
+}
+
+@end
+
+#endif

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -901,6 +901,11 @@ RNSentryIsPathUnderAllowedRoots(NSString *path)
     }
     return NO;
 }
+
++ (BOOL)isPathUnderAllowedRootsForTesting:(NSString *)path
+{
+    return RNSentryIsPathUnderAllowedRoots(path);
+}
 #endif
 
 RCT_EXPORT_METHOD(getDataFromUri : (NSString *_Nonnull)uri resolve : (


### PR DESCRIPTION
## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Description

Follow-up to #6045 (closes #6062).

Adds iOS XCTest coverage for the `RNSentryIsPathUnderAllowedRoots` path-validation function introduced in #6045, bringing iOS to parity with the Android `RNSentryUriValidationTest` (17 cases).

**What's added:**

- `+isPathUnderAllowedRootsForTesting:` class-method wrapper on `RNSentry`, declared in `RNSentry+Test.h` — exposes the file-scope `static` C function to the test target without making it part of the public API. Same pattern as `+captureReplayWithReturnValue`.
- `RNSentryUriValidationTests.m` — 9 cases wired into `RNSentryCocoaTester.xcodeproj`:
  - empty path → NO
  - path with `..` component → NO
  - path under `NSTemporaryDirectory()` → YES
  - path under caches dir → YES
  - path under documents dir → YES
  - path under `Library/Cookies` → NO
  - absolute path outside sandbox (`/etc/passwd`) → NO
  - path under `Library/Application Support` → NO
  - symlink inside tmp pointing to `/etc/passwd` → NO (real symlink created via `NSFileManager`, cleaned up in `tearDown`)

## Motivation and Context

The path-validation logic handles `..` traversal prevention and symlink resolution — edge cases that should be tested. Flagged during review of #6045.

## How did you test it?

- `yarn build`, `yarn test` (1343 + 259 + 1), `yarn lint:lerna`, `yarn circularDepCheck` — all clean.
- `clang-format --Werror` passes on all three modified iOS files.
- iOS tests run via `native-tests.yml` CI (`xcodebuild test` on the `RNSentryCocoaTester` scheme).

## Checklist

- [x] I reviewed the code myself
- [x] I added tests to verify the changes
- [x] No new linter warnings