### PR TITLE
Blocked for now: Enable logging by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 
 ### Breaking Changes
 
-- `enableLogs` defaults to `true` ([#XXXX](https://github.com/getsentry/sentry-react-native/pull/XXXX))
-- `consoleLoggingIntegration` is no longer added by default. To forward `console.*` calls to Sentry logs, add it explicitly: `integrations: [Sentry.consoleLoggingIntegration()]` ([#XXXX](https://github.com/getsentry/sentry-react-native/pull/XXXX))
+- `enableLogs` defaults to `true` ([#6084](https://github.com/getsentry/sentry-react-native/pull/6084))
+- `consoleLoggingIntegration` is no longer added by default. To forward `console.*` calls to Sentry logs, add it explicitly: `integrations: [Sentry.consoleLoggingIntegration()]` ([#6084](https://github.com/getsentry/sentry-react-native/pull/6084))
 
 ## 8.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Breaking Changes
+
+- `enableLogs` defaults to `true` ([#XXXX](https://github.com/getsentry/sentry-react-native/pull/XXXX))
+- `consoleLoggingIntegration` is no longer added by default. To forward `console.*` calls to Sentry logs, add it explicitly: `integrations: [Sentry.consoleLoggingIntegration()]` ([#XXXX](https://github.com/getsentry/sentry-react-native/pull/XXXX))
+
 ## 8.10.0
 
 ### Features

--- a/packages/core/src/js/client.ts
+++ b/packages/core/src/js/client.ts
@@ -70,6 +70,9 @@ export class ReactNativeClient extends Client<ReactNativeClientOptions> {
     options.parentSpanIsAlwaysRootSpan =
       options.parentSpanIsAlwaysRootSpan === undefined ? true : options.parentSpanIsAlwaysRootSpan;
 
+    // Logs are opt-out now: calling `Sentry.logger.*` is the user's opt-in.
+    options.enableLogs = options.enableLogs ?? options._experiments?.enableLogs ?? true;
+
     // enableLogs must be disabled before calling super() to avoid logs being captured.
     // This makes a copy of the user defined value, so we can restore it later for the native usaege.
     const originalEnableLogs = options.enableLogs;

--- a/packages/core/src/js/integrations/default.ts
+++ b/packages/core/src/js/integrations/default.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable eslint(complexity) */
 import type { Integration } from '@sentry/core';
 
-import { browserSessionIntegration, consoleLoggingIntegration } from '@sentry/browser';
+import { browserSessionIntegration } from '@sentry/browser';
 
 import type { ReactNativeClientOptions } from '../options';
 
@@ -92,7 +92,6 @@ export function getDefaultIntegrations(options: ReactNativeClientOptions): Integ
     integrations.push(modulesLoaderIntegration());
     if (options.enableLogs && options.logsOrigin !== 'native') {
       integrations.push(logEnricherIntegration());
-      integrations.push(consoleLoggingIntegration());
     }
     if (options.attachScreenshot) {
       integrations.push(screenshotIntegration());

--- a/packages/core/src/js/options.ts
+++ b/packages/core/src/js/options.ts
@@ -407,6 +407,13 @@ export interface BaseReactNativeOptions {
   propagateTraceparent?: boolean;
 
   /**
+   * Acts as the kill switch for Sentry logs. When set to `false`, no logs are sent to Sentry.
+   *
+   * @default true
+   */
+  enableLogs?: boolean;
+
+  /**
    * Controls which log origin is captured when `enableLogs` is set to true.
    * 'all' will log all origins.
    * 'js' will capture only JavaScript logs.

--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -164,6 +164,8 @@ export function init(passedOptions: ReactNativeOptions): void {
     options.environment = getDefaultEnvironment();
   }
 
+  options.enableLogs = options.enableLogs ?? options._experiments?.enableLogs ?? true;
+
   const defaultIntegrations: false | Integration[] =
     userOptions.defaultIntegrations === undefined ? getDefaultIntegrations(options) : userOptions.defaultIntegrations;
 

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -900,6 +900,32 @@ describe('Tests ReactNativeClient', () => {
       expect(flushLogsSpy).toHaveBeenCalledTimes(1);
       expect(flushLogsSpy).toHaveBeenLastCalledWith(client);
     });
+
+    test('defaults enableLogs to true when not provided', () => {
+      jest.useFakeTimers();
+      const flushLogsSpy = jest.spyOn(SentryCore, '_INTERNAL_flushLogsBuffer').mockImplementation(jest.fn());
+
+      const { client } = createClientWithSpy({});
+
+      expect(client.getOptions().enableLogs).toBe(true);
+
+      client.emit('afterCaptureLog', { message: 'test', attributes: {} } as unknown);
+      jest.advanceTimersByTime(5000);
+
+      expect(flushLogsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('respects user-provided enableLogs: false over the default', () => {
+      const { client } = createClientWithSpy({ enableLogs: false });
+      expect(client.getOptions().enableLogs).toBe(false);
+    });
+
+    test('backfills enableLogs from _experiments.enableLogs when top-level is undefined', () => {
+      const { client } = createClientWithSpy({
+        _experiments: { enableLogs: false },
+      } as Partial<ReactNativeClientOptions>);
+      expect(client.getOptions().enableLogs).toBe(false);
+    });
   });
 });
 

--- a/packages/core/test/integrations/defaultLogs.test.ts
+++ b/packages/core/test/integrations/defaultLogs.test.ts
@@ -37,21 +37,26 @@ describe('getDefaultIntegrations - logging integrations', () => {
     return integrations.map((integration: Integration) => integration.name);
   };
 
-  it('does not add logging integrations when enableLogs is falsy', () => {
+  it('does not add logEnricher when enableLogs is false', () => {
     const names = getIntegrationNames(createOptions({ enableLogs: false }));
 
     expect(names).not.toContain(logEnricherIntegrationName);
     expect(names).not.toContain(consoleLoggingIntegrationName);
   });
 
-  it('adds logging integrations when enableLogs is true and logsOrigin is not native', () => {
+  it('adds logEnricher when enableLogs is true and logsOrigin is not native', () => {
     const names = getIntegrationNames(createOptions({ enableLogs: true }));
 
     expect(names).toContain(logEnricherIntegrationName);
-    expect(names).toContain(consoleLoggingIntegrationName);
   });
 
-  it('does not add logging integrations when logsOrigin is native', () => {
+  it('never adds consoleLoggingIntegration by default — it must be opt-in', () => {
+    const names = getIntegrationNames(createOptions({ enableLogs: true }));
+
+    expect(names).not.toContain(consoleLoggingIntegrationName);
+  });
+
+  it('does not add logEnricher when logsOrigin is native', () => {
     const names = getIntegrationNames(
       createOptions({
         enableLogs: true,
@@ -76,6 +81,7 @@ describe('getDefaultIntegrations - logging integrations', () => {
     );
 
     expect(names.includes(logEnricherIntegrationName)).toBe(shouldInclude);
-    expect(names.includes(consoleLoggingIntegrationName)).toBe(shouldInclude);
+    // consoleLoggingIntegration is always opt-in regardless of logsOrigin
+    expect(names).not.toContain(consoleLoggingIntegrationName);
   });
 });

--- a/packages/core/test/sdk.test.ts
+++ b/packages/core/test/sdk.test.ts
@@ -1296,6 +1296,35 @@ describe('Tests the SDK functionality', () => {
       }),
     );
   });
+
+  describe('enableLogs default', () => {
+    it('defaults enableLogs to true when not provided', () => {
+      init({});
+      expect(usedOptions()?.enableLogs).toBe(true);
+    });
+
+    it('registers logEnricherIntegration in default integrations when enableLogs defaults to true', () => {
+      init({});
+      expectIntegration('LogEnricher');
+    });
+
+    it('does not register consoleLoggingIntegration by default — it must be opt-in', () => {
+      init({});
+      expectNotIntegration('ConsoleLogs');
+    });
+
+    it('respects user-provided enableLogs: false', () => {
+      init({ enableLogs: false });
+      expect(usedOptions()?.enableLogs).toBe(false);
+      expectNotIntegration('LogEnricher');
+    });
+
+    it('backfills enableLogs from _experiments.enableLogs when top-level is undefined', () => {
+      init({ _experiments: { enableLogs: false } });
+      expect(usedOptions()?.enableLogs).toBe(false);
+      expectNotIntegration('LogEnricher');
+    });
+  });
 });
 
 function expectIntegration(name: string): void {


### PR DESCRIPTION
**This PR is finished but blocked because we decided to only include it to the next major.**

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Enables logging by default, fixes https://github.com/getsentry/sentry-react-native/issues/6083


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/getsentry/sentry-react-native/issues/6083

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
