### PR TITLE
ci: Add Danger check to warn about auth token handling changes

### DIFF
--- a/scripts/check-additional-danger.js
+++ b/scripts/check-additional-danger.js
@@ -11,4 +11,5 @@ module.exports = async function ({ fail, warn, message, markdown, danger }) {
   await safeRun('./check-github-label', { fail, warn, message, markdown, danger });
   await safeRun('./check-replay-stubs', { fail, warn, message, markdown, danger });
   await safeRun('./check-android-sdk-mismatch', { fail, warn, message, markdown, danger });
+  await safeRun('./check-auth-token-changes', { fail, warn, message, markdown, danger });
 };

--- a/scripts/check-auth-token-changes.js
+++ b/scripts/check-auth-token-changes.js
@@ -1,0 +1,47 @@
+const AUTH_TOKEN_PATTERN = /\b(SENTRY_AUTH_TOKEN|auth[._]token)\b|[Aa]uth[Tt]oken/;
+
+const EXCLUDED_PATHS = [
+  /^\.github\//,
+  /^CHANGELOG\.md$/,
+];
+
+module.exports = async function ({ fail, warn, __, ___, danger }) {
+  const allChangedFiles = [
+    ...danger.git.modified_files,
+    ...danger.git.created_files,
+  ].filter(file => !EXCLUDED_PATHS.some(pattern => pattern.test(file)));
+
+  const flaggedFiles = [];
+
+  for (const file of allChangedFiles) {
+    try {
+      const diff = await danger.git.structuredDiffForFile(file);
+      if (!diff) {
+        continue;
+      }
+
+      const hasAuthTokenChange = diff.chunks.some(chunk =>
+        chunk.changes.some(change =>
+          change.add && AUTH_TOKEN_PATTERN.test(change.content)
+        )
+      );
+
+      if (hasAuthTokenChange) {
+        flaggedFiles.push(file);
+      }
+    } catch (_error) {
+      // Skip files where diff fails (e.g. binary files)
+    }
+  }
+
+  if (flaggedFiles.length > 0) {
+    const fileList = flaggedFiles.map(file => `- \`${file}\``).join("\n");
+    warn(
+      `### ⚠️ Auth token handling changes detected\n\n` +
+      `This PR modifies code related to Sentry auth token handling. ` +
+      `Please ensure no auth tokens are accidentally exposed or mishandled. ` +
+      `See [GHSA-68c2-4mpx-qh95](https://github.com/getsentry/sentry-react-native/security/advisories/GHSA-68c2-4mpx-qh95) for context.\n\n` +
+      `Files with auth token changes:\n${fileList}`
+    );
+  }
+};


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

Adds a Danger check that warns PR reviewers when changes touch code related to Sentry auth token handling (`authToken`, `SENTRY_AUTH_TOKEN`, `auth.token`, `auth_token`).

When matched, the check posts a warning comment listing the affected files, linking to the prior security advisory for context.

- Scans only **added lines** in the diff (not removals)
- Excludes `.github/` files (which legitimately reference `SENTRY_AUTH_TOKEN` as a secret) and `CHANGELOG.md`
- Uses `danger.git.structuredDiffForFile()` — consistent with the org-wide Danger setup

## :bulb: Motivation and Context

Prevents future incidents like [GHSA-68c2-4mpx-qh95](https://github.com/getsentry/sentry-react-native/security/advisories/GHSA-68c2-4mpx-qh95) by surfacing auth token changes for extra review.

Closes https://github.com/getsentry/sentry-react-native/issues/3683

## :green_heart: How did you test it?

- Verified regex matches expected patterns (`authToken`, `getAuthToken`, `sentryAuthToken`, `SENTRY_AUTH_TOKEN`, `auth.token`, `auth_token`)
- Verified regex rejects false positives (`authenticate`, `authorization`, `reauthorize`, `tokenize`)
- Verified module loads and exports correctly
- YAML/JS syntax validation

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps