### PR TITLE
ci: Add workflow to notify issues when fix is released

### DIFF
--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -1,0 +1,38 @@
+name: "Automation: Notify issues for release"
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version to notify issues for
+        required: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  release-comment-issues:
+    runs-on: ubuntu-latest
+    name: "Notify issues"
+    steps:
+      - name: Get version
+        id: get_version
+        env:
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "version=${INPUTS_VERSION:-$RELEASE_TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on linked issues that are mentioned in release
+        if: |
+          steps.get_version.outputs.version != ''
+          && !contains(steps.get_version.outputs.version, '-beta.')
+          && !contains(steps.get_version.outputs.version, '-alpha.')
+          && !contains(steps.get_version.outputs.version, '-rc.')
+        uses: getsentry/release-comment-issues-gh-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Adds a GitHub Actions workflow that automatically comments on closed issues when the release containing their fix is published.

When a release is published, the [`release-comment-issues-gh-action`](https://github.com/getsentry/release-comment-issues-gh-action) parses PR links from the release notes, looks up which issues each PR closes (via GitHub closing keywords like `Fixes #123`), and posts a comment on those issues notifying users that the fix has been released.

Pre-release versions (alpha, beta, rc) are skipped. The workflow can also be triggered manually via `workflow_dispatch`.

Already used in [sentry-javascript](https://github.com/getsentry/sentry-javascript/blob/develop/.github/workflows/release-comment-issues.yml) and being added to [sentry-dart](https://github.com/getsentry/sentry-dart/pull/3685).


## :bulb: Motivation and Context

Improves the experience for issue reporters — they get notified when a fix ships without anyone having to manually go back and comment.


## :green_heart: How did you test it?

Verified the release notes format matches the action's expected PR link pattern (`[#1234](https://github.com/getsentry/sentry-react-native/pull/1234)`). Can be further tested via `workflow_dispatch` after merge.


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps