### PR TITLE
Locally vendor `sentry_formatHexAddress*` helpers

### DIFF
--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -47,8 +47,7 @@ Pod::Spec.new do |s|
   s.compiler_flags = other_cflags
 
   s.pod_target_xcconfig = {
-    'DEFINES_MODULE' => 'YES',
-    'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/Sentry/Sources/Sentry" "${PODS_ROOT}/Sentry/Sources/Sentry/include"'
+    'DEFINES_MODULE' => 'YES'
   }
 
   s.dependency 'Sentry', '9.12.1'

--- a/packages/core/ios/RNSentry+fetchNativeStack.m
+++ b/packages/core/ios/RNSentry+fetchNativeStack.m
@@ -1,7 +1,7 @@
 #import "RNSentry.h"
 #import "RNSentryBreadcrumb.h"
+#import "RNSentryHexFormatter.h"
 #import "RNSentryId.h"
-#import "SentryFormatter.h"
 #import <Sentry/PrivateSentrySDKOnly.h>
 @import Sentry;
 
@@ -25,12 +25,12 @@
         SentryBinaryImageInfo *_Nullable image = [[[SentryDependencyContainer sharedInstance]
             binaryImageCache] imageByAddress:[addr unsignedLongLongValue]];
         if (image != nil) {
-            NSString *imageAddr = sentry_formatHexAddressUInt64([image address]);
+            NSString *imageAddr = rnsentry_formatHexAddressUInt64([image address]);
             [imagesAddrToRetrieveDebugMetaImages addObject:imageAddr];
 
             NSDictionary<NSString *, id> *_Nonnull nativeFrame = @{
                 @"platform" : @"cocoa",
-                @"instruction_addr" : sentry_formatHexAddress(addr),
+                @"instruction_addr" : rnsentry_formatHexAddress(addr),
                 @"package" : [image name],
                 @"image_addr" : imageAddr,
                 @"in_app" : [NSNumber numberWithBool:[appPackageName isEqualToString:[image name]]],
@@ -45,7 +45,7 @@
                     NSMutableDictionary<NSString *, id> *_Nonnull symbolicated
                         = nativeFrame.mutableCopy;
                     symbolicated[@"symbol_addr"]
-                        = sentry_formatHexAddressUInt64((uintptr_t)symbolsBuffer.dli_saddr);
+                        = rnsentry_formatHexAddressUInt64((uintptr_t)symbolsBuffer.dli_saddr);
                     symbolicated[@"function"] = [NSString stringWithCString:symbolsBuffer.dli_sname
                                                                    encoding:NSUTF8StringEncoding];
 
@@ -57,7 +57,7 @@
         } else {
             [serializedFrames addObject:@{
                 @"platform" : @"cocoa",
-                @"instruction_addr" : sentry_formatHexAddress(addr),
+                @"instruction_addr" : rnsentry_formatHexAddress(addr),
             }];
         }
     }

--- a/packages/core/ios/RNSentryHexFormatter.h
+++ b/packages/core/ios/RNSentryHexFormatter.h
@@ -1,0 +1,40 @@
+#import <Foundation/Foundation.h>
+
+// 2 for the "0x" prefix, plus 16 for the hex value, plus 1 for the null terminator.
+#define RN_SENTRY_HEX_ADDRESS_LENGTH 19
+
+/**
+ * Formats a 64-bit unsigned integer as a zero-padded hex address string
+ * (e.g. @c 0x000000010f1a2b3c).
+ *
+ * Inlined here so we don't need to reach into sentry-cocoa's private
+ * @c SentryFormatter.h via @c HEADER_SEARCH_PATHS. Keep behavior identical
+ * to @c sentry_snprintfHexAddress in sentry-cocoa.
+ */
+static inline NSString *
+rnsentry_snprintfHexAddress(uint64_t value)
+{
+    char buffer[RN_SENTRY_HEX_ADDRESS_LENGTH];
+    snprintf(buffer, RN_SENTRY_HEX_ADDRESS_LENGTH, "0x%016llx", value);
+    return [NSString stringWithCString:buffer encoding:NSASCIIStringEncoding];
+}
+
+/**
+ * Formats an @c NSNumber address as a zero-padded hex string.
+ * Drop-in replacement for sentry-cocoa's @c sentry_formatHexAddress.
+ */
+static inline NSString *
+rnsentry_formatHexAddress(NSNumber *value)
+{
+    return rnsentry_snprintfHexAddress([value unsignedLongLongValue]);
+}
+
+/**
+ * Formats a @c uint64_t address as a zero-padded hex string.
+ * Drop-in replacement for sentry-cocoa's @c sentry_formatHexAddressUInt64.
+ */
+static inline NSString *
+rnsentry_formatHexAddressUInt64(uint64_t value)
+{
+    return rnsentry_snprintfHexAddress(value);
+}

--- a/packages/core/ios/RNSentryHexFormatter.h
+++ b/packages/core/ios/RNSentryHexFormatter.h
@@ -1,38 +1,30 @@
 #import <Foundation/Foundation.h>
 
-// 2 for the "0x" prefix, plus 16 for the hex value, plus 1 for the null terminator.
+// 2 for the 0x prefix, plus 16 for the hex value, plus 1 for the null terminator
 #define RN_SENTRY_HEX_ADDRESS_LENGTH 19
 
-/**
- * Formats a 64-bit unsigned integer as a zero-padded hex address string
- * (e.g. @c 0x000000010f1a2b3c).
- *
- * Inlined here so we don't need to reach into sentry-cocoa's private
- * @c SentryFormatter.h via @c HEADER_SEARCH_PATHS. Keep behavior identical
- * to @c sentry_snprintfHexAddress in sentry-cocoa.
- */
 static inline NSString *
 rnsentry_snprintfHexAddress(uint64_t value)
 {
     char buffer[RN_SENTRY_HEX_ADDRESS_LENGTH];
     snprintf(buffer, RN_SENTRY_HEX_ADDRESS_LENGTH, "0x%016llx", value);
-    return [NSString stringWithCString:buffer encoding:NSASCIIStringEncoding];
+    NSString *nsString = [NSString stringWithCString:buffer encoding:NSASCIIStringEncoding];
+    return nsString;
 }
 
-/**
- * Formats an @c NSNumber address as a zero-padded hex string.
- * Drop-in replacement for sentry-cocoa's @c sentry_formatHexAddress.
- */
 static inline NSString *
 rnsentry_formatHexAddress(NSNumber *value)
 {
+    /*
+     * We observed a 41% speedup by using snprintf vs +[NSString stringWithFormat:]. In a trial
+     * using a profile, we observed the +[NSString stringWithFormat:] using 282ms of CPU time, vs
+     * 164ms of CPU time for snprintf. There is also an assumed space improvement due to not needing
+     * to allocate as many instances of NSString, like for the format string literal, instead only
+     * using stack-bound C strings.
+     */
     return rnsentry_snprintfHexAddress([value unsignedLongLongValue]);
 }
 
-/**
- * Formats a @c uint64_t address as a zero-padded hex string.
- * Drop-in replacement for sentry-cocoa's @c sentry_formatHexAddressUInt64.
- */
 static inline NSString *
 rnsentry_formatHexAddressUInt64(uint64_t value)
 {


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
We need to vendor `sentry_formatHexAddress*` helpers to get rid of SentryFormatter.h dependency and removing  `${PODS_ROOT}/Sentry/Sources/Sentry...` paths from `HEADER_SEARCH_PATHS`. That's a prerequisite for consuming sentry-cocoa as an `xcframework` or via SPM `binaryTarget`.

What's in SentryFormatter.h is basically a copy-paste from https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Sentry/include/SentryFormatter.h


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog
