### PR TITLE
chore(deps): bump uuid to ^13.0.1 to fix buffer bounds check vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,9 @@
     "@appium/support@npm:7.0.6/yauzl": "^3.2.1",
     "appium-ios-remotexpc@npm:0.36.0/@xmldom/xmldom": "^0.9.10",
     "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.10",
-    "postcss": "^8.5.10"
+    "postcss": "^8.5.10",
+    "@appium/support@npm:7.0.6/uuid": "^13.0.1",
+    "node-simctl@npm:8.1.6/uuid": "^13.0.1"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32552,21 +32552,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:13.0.0, uuid@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 7510ee1ab371be5339ef26ff8cabc2f4a2c60640ff880652968f758072f53bd4f4af1c8b0e671a8c9bb29ef926a24dec3ef0e3861d78183b39291a85743a9f96
-  languageName: node
-  linkType: hard
-
 "uuid@npm:^10.0.0":
   version: 10.0.0
   resolution: "uuid@npm:10.0.0"
   bin:
     uuid: dist/bin/uuid
   checksum: 4b81611ade2885d2313ddd8dc865d93d8dccc13ddf901745edca8f86d99bc46d7a330d678e7532e7ebf93ce616679fb19b2e3568873ac0c14c999032acb25869
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^13.0.1":
+  version: 13.0.2
+  resolution: "uuid@npm:13.0.2"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: b8ca7da03b5563ad7ee9a9e38f5c6d63709183d5ae5c8f4c638fcf6f7349e7f3f0e4d1699f24f42d9f7b0f2f6e376a11c032750d2fc4a45e2dfab70142c9caf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description

Adds scoped yarn resolutions to bump `uuid` from 13.0.0 to `^13.0.1` for `@appium/support` and `node-simctl`. This fixes the missing buffer bounds check vulnerability in uuid v3/v5/v6 when `buf` is provided.

This is a **dev-only** dependency — only appium (E2E testing) and node-simctl (iOS simulator control) use uuid 13.x. The SDK does not depend on uuid at runtime.

Other uuid consumers (lerna 10.x, xcode 7.x) are not in the vulnerable range (≥13.0.0 <13.0.1) and are left unchanged.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-react-native/security/dependabot/513

## :green_heart: How did you test it?

- `yarn install` ✅
- `yarn build` ✅
- `yarn test` (263 tests passed) ✅
- `yarn lint:lerna` ✅

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps