### PR TITLE
chore: Add warning regarding iOS crash in sentry-cocoa 9.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 ## 8.11.0
 
+> [!WARNING]
+> ⚠️ **Known Issue (iOS):** Apps using `sentry-react-native` **8.11.0+** may crash when using `AVAssetDownloadURLSession` due to an issue in the [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa/) SDK. Until a fix is released, pin `sentry-react-native` to **8.9.2** (`sentry-cocoa` `9.11.0`). Follow [#7886](https://github.com/getsentry/sentry-cocoa/issues/7886) for updates.
+
 ### Features
 
 - Use `accessibilityLabel`, `aria-label`, and `testID` as fallback labels for touch breadcrumbs when `sentry-label` is not set ([#6103](https://github.com/getsentry/sentry-react-native/pull/6103))
@@ -35,6 +38,9 @@
   - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.12.0...9.12.1)
 
 ## 8.10.0
+
+> [!WARNING]
+> ⚠️ **Known Issue (iOS):** Apps using `sentry-react-native` **8.11.0+** may crash when using `AVAssetDownloadURLSession` due to an issue in the [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa/) SDK. Until a fix is released, pin `sentry-react-native` to **8.9.2** (`sentry-cocoa` `9.11.0`). Follow [#7886](https://github.com/getsentry/sentry-cocoa/issues/7886) for updates.
 
 ### Features
 


### PR DESCRIPTION
## Summary
- Adds a visible warning to the 8.11.0 and 8.10.0 changelog entries about the known `AVAssetDownloadURLSession` crash on iOS

#skip-changelog