### PR TITLE
fix(android): Handle boolean values in JSON options converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Extract text content from children of touched components as a label fallback for touch breadcrumbs ([#6106](https://github.com/getsentry/sentry-react-native/pull/6106))
 
+### Fixes
+
+- Fix boolean options from `sentry.options.json` being ignored on Android when using `RNSentrySDK.init` ([#6130](https://github.com/getsentry/sentry-react-native/pull/6130))
+
 ### Dependencies
 
 - Bump JavaScript SDK from v10.51.0 to v10.52.0 ([#6108](https://github.com/getsentry/sentry-react-native/pull/6108))

--- a/packages/core/RNSentryAndroidTester/app/src/androidTest/java/io/sentry/react/RNSentryJsonConverterTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/androidTest/java/io/sentry/react/RNSentryJsonConverterTest.kt
@@ -22,6 +22,8 @@ class RNSentryJsonConverterTest {
                 put("doubleKey", 12.3)
                 put("intKey", 123)
                 put("stringKey", "test")
+                put("boolTrueKey", true)
+                put("boolFalseKey", false)
                 put("nullKey", JSONObject.NULL)
             }
 
@@ -32,6 +34,8 @@ class RNSentryJsonConverterTest {
         assertEquals(12.3, result.getDouble("doubleKey"), 0.0)
         assertEquals(123, result.getInt("intKey"))
         assertEquals("test", result.getString("stringKey"))
+        assertEquals(true, result.getBoolean("boolTrueKey"))
+        assertEquals(false, result.getBoolean("boolFalseKey"))
         assertNull(result.getString("nullKey"))
     }
 
@@ -62,6 +66,8 @@ class RNSentryJsonConverterTest {
                 put(1)
                 put(2.5)
                 put("string")
+                put(true)
+                put(false)
                 put(JSONObject.NULL)
             }
 
@@ -70,7 +76,9 @@ class RNSentryJsonConverterTest {
         assertEquals(1, result.getInt(0))
         assertEquals(2.5, result.getDouble(1), 0.0)
         assertEquals("string", result.getString(2))
-        assertNull(result.getString(3))
+        assertEquals(true, result.getBoolean(3))
+        assertEquals(false, result.getBoolean(4))
+        assertNull(result.getString(5))
     }
 
     @Test

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryJsonConverter.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryJsonConverter.java
@@ -31,7 +31,9 @@ final class RNSentryJsonConverter {
       while (iterator.hasNext()) {
         String key = iterator.next();
         Object value = jsonObject.get(key);
-        if (value instanceof Float || value instanceof Double) {
+        if (value instanceof Boolean) {
+          writableMap.putBoolean(key, jsonObject.getBoolean(key));
+        } else if (value instanceof Float || value instanceof Double) {
           writableMap.putDouble(key, jsonObject.getDouble(key));
         } else if (value instanceof Number) {
           writableMap.putInt(key, jsonObject.getInt(key));
@@ -57,7 +59,9 @@ final class RNSentryJsonConverter {
     WritableArray writableArray = new JavaOnlyArray();
     for (int i = 0; i < jsonArray.length(); i++) {
       Object value = jsonArray.get(i);
-      if (value instanceof Float || value instanceof Double) {
+      if (value instanceof Boolean) {
+        writableArray.pushBoolean(jsonArray.getBoolean(i));
+      } else if (value instanceof Float || value instanceof Double) {
         writableArray.pushDouble(jsonArray.getDouble(i));
       } else if (value instanceof Number) {
         writableArray.pushInt(jsonArray.getInt(i));


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

`RNSentryJsonConverter.convertToWritable()` did not handle `Boolean` values when converting `sentry.options.json` to a React Native `ReadableMap`. Boolean values were silently dropped because the `instanceof` chain only checked for `Float`, `Double`, `Number`, `String`, `JSONObject`, `JSONArray`, and `null`.

This caused all boolean options to fall back to their defaults when using the `RNSentrySDK.init()` native-first initialization path.

## :bulb: Motivation and Context

Fixes #6122

When users set `maskAllText: false` (or other boolean replay options) in `sentry.options.json` and initialize via `RNSentrySDK.init()`, the `false` value was dropped. The SDK then treated the missing key as `true` (mask everything), making it impossible to disable text masking through the JSON config.

This affects **all boolean options** read from `sentry.options.json`, not just replay masking — including `debug`, `attachScreenshot`, `attachViewHierarchy`, `enableCaptureFailedRequests`, `spotlight`, etc. However, the impact is limited because most boolean options default to sensible values when missing, and the JS-side `Sentry.init()` options (which go through the React Native bridge, not the JSON converter) were never affected.

## :green_heart: How did you test it?

- Added boolean assertions to existing `RNSentryJsonConverterTest` for both map and array conversions
- Manually verified on Android emulator (API 36, Fabric/New Architecture enabled): replay screenshots showed unmasked text after the fix, confirming `maskAllText: false` is now properly applied

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps