### PR TITLE
chore: Update warning regarding iOS crash in sentry-cocoa 9.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ## 8.11.0
 
 > [!WARNING]
-> ⚠️ **Known Issue (iOS):** Apps using `sentry-react-native` **8.11.0+** may crash when using `AVAssetDownloadURLSession` due to an issue in the [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa/) SDK. Until a fix is released, pin `sentry-react-native` to **8.9.2** (`sentry-cocoa` `9.11.0`). Follow [#7886](https://github.com/getsentry/sentry-cocoa/issues/7886) for updates.
+> ⚠️ **Known Issue (iOS):** Apps using `sentry-react-native` **8.11.0+** may crash when using `AVAssetDownloadURLSession` due to an issue in the [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa/) SDK. **Please use [8.11.1](https://github.com/getsentry/sentry-react-native/releases/tag/8.11.1)**.
 
 ### Features
 
@@ -47,7 +47,7 @@
 ## 8.10.0
 
 > [!WARNING]
-> ⚠️ **Known Issue (iOS):** Apps using `sentry-react-native` **8.11.0+** may crash when using `AVAssetDownloadURLSession` due to an issue in the [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa/) SDK. Until a fix is released, pin `sentry-react-native` to **8.9.2** (`sentry-cocoa` `9.11.0`). Follow [#7886](https://github.com/getsentry/sentry-cocoa/issues/7886) for updates.
+> ⚠️ **Known Issue (iOS):** Apps using `sentry-react-native` **8.11.0+** may crash when using `AVAssetDownloadURLSession` due to an issue in the [`sentry-cocoa`](https://github.com/getsentry/sentry-cocoa/) SDK. **Please use [8.11.1](https://github.com/getsentry/sentry-react-native/releases/tag/8.11.1)**.
 
 ### Features
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Update [warning regarding iOS crash in sentry-cocoa 9.12.0](https://github.com/getsentry/sentry-react-native/pull/6123) after releasing a fix with https://github.com/getsentry/sentry-react-native/releases/tag/8.11.1

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [ ] No breaking changes

## :crystal_ball: Next steps
