### PR TITLE
feat(core): Enable autoInjectSentryLabel by default in Metro config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - Extract text content from children of touched components as a label fallback for touch breadcrumbs ([#6106](https://github.com/getsentry/sentry-react-native/pull/6106))
+- Auto-inject `sentry-label` from static text content at build time when `annotateReactComponents` is enabled ([#6141](https://github.com/getsentry/sentry-react-native/pull/6141))
 
 ### Dependencies
 

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -213,9 +213,7 @@ export function withSentryBabelTransformer(
 
   if (typeof annotateReactComponents === 'object') {
     setSentryBabelTransformerOptions({
-      annotateReactComponents: {
-        ...annotateReactComponents,
-      },
+      annotateReactComponents,
     });
   }
 

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -33,6 +33,14 @@ export interface SentryMetroConfigOptions {
     | boolean
     | {
         ignoredComponents?: string[];
+        /**
+         * Automatically inject `sentry-label` props from static text content.
+         * When enabled, the Babel plugin extracts text from children of touchable
+         * components and injects it as a `sentry-label` prop at build time.
+         *
+         * @default true when `annotateReactComponents` is enabled
+         */
+        autoInjectSentryLabel?: boolean;
       };
   /**
    * Adds the Sentry replay package for web.
@@ -205,7 +213,9 @@ export function withSentryBabelTransformer(
 
   if (typeof annotateReactComponents === 'object') {
     setSentryBabelTransformerOptions({
-      annotateReactComponents,
+      annotateReactComponents: {
+        ...annotateReactComponents,
+      },
     });
   }
 

--- a/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
+++ b/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
@@ -4,7 +4,12 @@ import * as process from 'process';
 
 import type { BabelTransformer, BabelTransformerArgs } from './vendor/metro/metroBabelTransformer';
 
-export type SentryBabelTransformerOptions = { annotateReactComponents?: { ignoredComponents?: string[] } };
+export type SentryBabelTransformerOptions = {
+  annotateReactComponents?: {
+    ignoredComponents?: string[];
+    autoInjectSentryLabel?: boolean;
+  };
+};
 
 export const SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH = 'SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH';
 export const SENTRY_BABEL_TRANSFORMER_OPTIONS = 'SENTRY_BABEL_TRANSFORMER_OPTIONS';
@@ -111,10 +116,10 @@ function addSentryComponentAnnotatePlugin(
   }
 
   if (!args.filename.includes('node_modules')) {
-    if (options) {
-      args.plugins.push([componentAnnotatePlugin, options]);
-    } else {
-      args.plugins.push(componentAnnotatePlugin);
-    }
+    const pluginOptions = {
+      autoInjectSentryLabel: true,
+      ...options,
+    };
+    args.plugins.push([componentAnnotatePlugin, pluginOptions]);
   }
 }

--- a/packages/core/test/tools/sentryBabelTransformer.test.ts
+++ b/packages/core/test/tools/sentryBabelTransformer.test.ts
@@ -45,20 +45,25 @@ describe('SentryBabelTransformer', () => {
       options: {
         projectRoot: 'project/root',
       },
-      plugins: [expect.any(Function), expect.any(Function)],
+      plugins: [expect.any(Function), [expect.any(Function), expect.objectContaining({ autoInjectSentryLabel: true })]],
     });
-    expect(MockDefaultBabelTransformer.transform.mock.calls[0][0]['plugins'][1].name).toEqual(
+    expect(MockDefaultBabelTransformer.transform.mock.calls[0][0]['plugins'][1][0].name).toEqual(
       'componentNameAnnotatePlugin',
     );
   });
 
-  test('transform adds plugin', () => {
+  test('transform adds plugin with autoInjectSentryLabel enabled by default', () => {
     createSentryBabelTransformer().transform?.(createMinimalMockedTransformOptions());
 
     expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledTimes(1);
     expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledWith(
       expect.objectContaining({
-        plugins: expect.arrayContaining([expect.objectContaining({ name: 'componentNameAnnotatePlugin' })]),
+        plugins: expect.arrayContaining([
+          [
+            expect.objectContaining({ name: 'componentNameAnnotatePlugin' }),
+            expect.objectContaining({ autoInjectSentryLabel: true }),
+          ],
+        ]),
       }),
     );
   });
@@ -79,6 +84,7 @@ describe('SentryBabelTransformer', () => {
           [
             expect.objectContaining({ name: 'componentNameAnnotatePlugin' }),
             expect.objectContaining({
+              autoInjectSentryLabel: true,
               ignoredComponents: ['MyCustomComponent'],
             }),
           ],
@@ -87,7 +93,31 @@ describe('SentryBabelTransformer', () => {
     );
   });
 
-  test('degrades gracefully if options can not be parsed, transform adds plugin without options', () => {
+  test('transform respects autoInjectSentryLabel: false override', () => {
+    process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = JSON.stringify({
+      annotateReactComponents: {
+        autoInjectSentryLabel: false,
+      },
+    });
+
+    createSentryBabelTransformer().transform?.(createMinimalMockedTransformOptions());
+
+    expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledTimes(1);
+    expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.arrayContaining([
+          [
+            expect.objectContaining({ name: 'componentNameAnnotatePlugin' }),
+            expect.objectContaining({
+              autoInjectSentryLabel: false,
+            }),
+          ],
+        ]),
+      }),
+    );
+  });
+
+  test('degrades gracefully if options can not be parsed, transform adds plugin with defaults', () => {
     process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = 'invalid json';
 
     createSentryBabelTransformer().transform?.(createMinimalMockedTransformOptions());
@@ -95,7 +125,12 @@ describe('SentryBabelTransformer', () => {
     expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledTimes(1);
     expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledWith(
       expect.objectContaining({
-        plugins: expect.arrayContaining([expect.objectContaining({ name: 'componentNameAnnotatePlugin' })]),
+        plugins: expect.arrayContaining([
+          [
+            expect.objectContaining({ name: 'componentNameAnnotatePlugin' }),
+            expect.objectContaining({ autoInjectSentryLabel: true }),
+          ],
+        ]),
       }),
     );
   });


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Passes `autoInjectSentryLabel: true` to `@sentry/babel-plugin-component-annotate` by default when `annotateReactComponents` is enabled in the Metro config. This enables automatic injection of `sentry-label` props from static text content at build time.

The Babel plugin (shipped in `@sentry/babel-plugin-component-annotate@5.3.0`, getsentry/sentry-javascript-bundler-plugins#925) extracts static text from children of touchable components and injects it as a `sentry-label` prop, improving touch breadcrumb and user interaction span labeling without requiring manual annotation.

Users can opt out:
```javascript
withSentryConfig(config, {
  annotateReactComponents: {
    autoInjectSentryLabel: false,
  },
});
```

## :bulb: Motivation and Context

Closes #6109. Part of the "Making breadcrumbs data more useful on React Native" project.

Currently, touch breadcrumbs show component names like "TouchableOpacity" unless developers manually add `sentry-label`, `accessibilityLabel`, or `testID` props. With this change, buttons like `<Pressable><Text>Save workout</Text></Pressable>` automatically get labeled "Save workout" in breadcrumbs and transaction names.

## :green_heart: How did you test it?

- `yarn build` — compiles without errors
- `npx jest --config jest.config.tools.js test/tools/sentryBabelTransformer.test.ts` — 8/8 pass
- `npx jest --config jest.config.tools.js test/tools/metroconfig.test.ts` — 142/142 pass
- `yarn lint` — no violations
- `yarn api-report` — API report up to date
- Added test for `autoInjectSentryLabel: false` override
- Updated existing tests to verify `autoInjectSentryLabel: true` is passed by default

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)