### PR TITLE
fix(ios): Filter ExceptionsManager.reportException duplicates in app-start init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- Fix duplicate JS error reporting on iOS New Architecture when the native SDK is initialized early via `sentry.options.json` ("Capture App Start Errors"). The `ExceptionsManager.reportException` C++ wrapper filter is now applied in both init paths, matching the JS-init dedup added in `7.9.0` ([#6116](https://github.com/getsentry/sentry-react-native/issues/6116))
 - Fix the issue with uploading iOS Debug Symbols in EAS Build when using pnpm ([#6076](https://github.com/getsentry/sentry-react-native/issues/6076))
 - Improve frame delay collection performance by using sentry-java `getFramesDelay` API ([#6074](https://github.com/getsentry/sentry-react-native/pull/6074))
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartTests.swift
@@ -121,6 +121,52 @@ final class RNSentryStartTests: XCTestCase {
         }
     }
 
+    func testStartIgnoresJsErrorCppExceptionWrapper() throws {
+        // Reproduces getsentry/sentry-react-native#6116:
+        // When the native SDK is started early via sentry.options.json ("Capture App Start
+        // Errors"), New Architecture wraps unhandled JS errors in a C++ exception that the
+        // native crash handler captures. Without dedup in updateWithReactFinals, both the JS
+        // event and the C++ wrapper are sent. Cover both init paths to keep them aligned.
+        let testCases: [() throws -> Void] = [
+            {
+                RNSentrySDK.start { options in
+                    options.dsn = "https://abcd@efgh.ingest.sentry.io/123456"
+                }
+            },
+            {
+                try self.startFromRN(options: [
+                    "dsn": "https://abcd@efgh.ingest.sentry.io/123456"
+                ])
+            }
+        ]
+
+        for startMethod in testCases {
+            try startMethod()
+
+            let actualOptions = PrivateSentrySDKOnly.options
+
+            let cppWrapperEvent = Event()
+            cppWrapperEvent.exceptions = [
+                Exception(
+                    value: "N8facebook3jsi7JSErrorE: ExceptionsManager.reportException raised an exception: Unhandled JS Exception: Error: Test error",
+                    type: "C++ Exception"
+                )
+            ]
+            XCTAssertNil(actualOptions.beforeSend!(cppWrapperEvent),
+                "Event with ExceptionsManager.reportException in value should be dropped")
+
+            let legitimateCppEvent = Event()
+            legitimateCppEvent.exceptions = [
+                Exception(
+                    value: "std::runtime_error: Some other C++ error occurred",
+                    type: "C++ Exception"
+                )
+            ]
+            XCTAssertNotNil(actualOptions.beforeSend!(legitimateCppEvent),
+                "Legitimate C++ exception without ExceptionsManager.reportException should not be dropped")
+        }
+    }
+
     func testStartSetsNativeEventOrigin() throws {
         let testCases: [() throws -> Void] = [
             {

--- a/packages/core/ios/RNSentryStart.m
+++ b/packages/core/ios/RNSentryStart.m
@@ -203,6 +203,19 @@
             return nil;
         }
 
+        // With New Architecture, React Native wraps JS errors in C++ exceptions.
+        // These exceptions are caught by the native crash handler and should be filtered out
+        // since the JS error is already reported by the JS error handler.
+        // The key indicator is "ExceptionsManager.reportException" in the exception value,
+        // which is React Native's mechanism for reporting JS errors to the native layer.
+        for (SentryException *exception in event.exceptions) {
+            if (nil != exception.value &&
+                [exception.value rangeOfString:@"ExceptionsManager.reportException"].location
+                    != NSNotFound) {
+                return nil;
+            }
+        }
+
         [self setEventOriginTag:event];
         if (userBeforeSend == nil) {
             return event;


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Port the `ExceptionsManager.reportException` dedup filter into `RNSentryStart.updateWithReactFinals` so the file-based / early-native init path filters the same New Architecture C++ wrapper events as the JS-initiated path.

Background: there are two iOS `beforeSend` filter sites that both exist to drop JS errors the JS SDK already reported:

- `RNSentry.mm` → `prepareOptions:` — used when JS calls `initNativeSdk` (default `autoInitializeNativeSdk: true`). Filters both `"Unhandled JS Exception"` types and any exception whose value contains `"ExceptionsManager.reportException"` (the New Architecture C++ wrapper, added in #5532 / 7.9.0 to fix #5529).
- `RNSentryStart.m` → `updateWithReactFinals:` — used when the native SDK is started early via `sentry.options.json` (the v8 "Capture App Start Errors" feature, #5582) and when `autoInitializeNativeSdk: false`. Filtered only `"Unhandled JS Exception"` types.

The C++ wrapper filter from #5532 was never ported into `updateWithReactFinals`, so users hitting the file-based init path on RN New Architecture see two events per JS error: the JS one and the C++ wrapper one captured by the native crash handler.

This PR adds the same `ExceptionsManager.reportException` value check in `updateWithReactFinals` so both init paths behave identically.

Android is unaffected: `updateWithReactDefaults` registers `addIgnoredExceptionForType(JavascriptException.class)` and is shared by both Android init paths.


## :bulb: Motivation and Context

Fixes #6116. The previous fix for this class of duplicate (#5532, fix for #5529) only covered the JS-initiated init path. With v8's "Capture App Start Errors", the native SDK can be started before JS via `sentry.options.json`, which goes through a different filter site that didn't have the C++ wrapper check.


## :green_heart: How did you test it?

- New Swift test `testStartIgnoresJsErrorCppExceptionWrapper` in `RNSentryStartTests.swift` exercises both `RNSentrySDK.start(configureOptions:)` and the dictionary-based `RNSentryStart.start(options:)` path (which is what `sentry.options.json` ends up calling). Verifies that:
  - an event with `"ExceptionsManager.reportException"` in its exception value is dropped, and
  - a legitimate `C++ Exception` (e.g. `std::runtime_error`) without that marker is kept.
- Mirrors the existing JS-init coverage in `RNSentryTests.m` (`testStartBeforeSendFiltersOutJSErrorCppException`).
- `yarn lint:clang`, `yarn lint:swift`, `yarn lint:lerna` clean.


## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
