### PR TITLE
fix(core): Fix includeWebFeedback crash by stubbing browser wrapper modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Fix duplicate JS error reporting on iOS New Architecture when the native SDK is initialized early via `sentry.options.json` ("Capture App Start Errors"). It's done by applying the `ExceptionsManager.reportException` C++ wrapper filter in both init paths ([#6145](https://github.com/getsentry/sentry-react-native/pull/6145))
 - Fix boolean options from `sentry.options.json` being ignored on Android when using `RNSentrySDK.init` ([#6130](https://github.com/getsentry/sentry-react-native/pull/6130))
+- Fix `includeWebFeedback: false` Metro config option causing crash at startup ([#6150](https://github.com/getsentry/sentry-react-native/pull/6150))
 
 ### Dependencies
 

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -257,7 +257,7 @@ type CustomResolverBeforeMetro068 = (
 function buildSentryPackageExcludeResolver(
   config: MetroConfig,
   includePackage: boolean | undefined,
-  moduleRegex: RegExp,
+  shouldExcludeModule: (moduleName: string, context: CustomResolutionContext) => boolean,
   optionName: string,
 ): MetroConfig {
   const originalResolver = config.resolver?.resolveRequest as CustomResolver | CustomResolverBeforeMetro068 | undefined;
@@ -270,7 +270,7 @@ function buildSentryPackageExcludeResolver(
   ) => {
     if (
       (includePackage === false || (includePackage === undefined && (platform === 'android' || platform === 'ios'))) &&
-      !!(oldMetroModuleName ?? moduleName).match(moduleRegex)
+      shouldExcludeModule(oldMetroModuleName ?? moduleName, context)
     ) {
       return { type: 'empty' } as Resolution;
     }
@@ -314,9 +314,21 @@ export function withSentryResolver(config: MetroConfig, includeWebReplay: boolea
   return buildSentryPackageExcludeResolver(
     config,
     includeWebReplay,
-    /@sentry(?:-internal)?\/replay/,
+    moduleName => /@sentry(?:-internal)?\/replay/.test(moduleName),
     'includeWebReplay',
   );
+}
+
+/**
+ * `@sentry/browser` re-exports feedback through `feedbackSync.js` and `feedbackAsync.js`
+ * which call `buildFeedbackIntegration()` at module evaluation time.
+ * Stubbing only `@sentry-internal/feedback` makes that call crash,
+ * so we also stub these wrapper modules.
+ */
+const SENTRY_BROWSER_FEEDBACK_WRAPPER_RE = /\/feedback(Sync|Async)/;
+
+function isFromSentryBrowser(originModulePath: string): boolean {
+  return originModulePath.includes('@sentry/browser');
 }
 
 /**
@@ -326,7 +338,10 @@ export function withSentryFeedbackResolver(config: MetroConfig, includeWebFeedba
   return buildSentryPackageExcludeResolver(
     config,
     includeWebFeedback,
-    /@sentry(?:-internal)?\/feedback/,
+    (moduleName, context) =>
+      /@sentry(?:-internal)?\/feedback/.test(moduleName) ||
+      (isFromSentryBrowser((context as { originModulePath?: string }).originModulePath ?? '') &&
+        SENTRY_BROWSER_FEEDBACK_WRAPPER_RE.test(moduleName)),
     'includeWebFeedback',
   );
 }

--- a/packages/core/test/tools/metroconfig.test.ts
+++ b/packages/core/test/tools/metroconfig.test.ts
@@ -467,6 +467,53 @@ describe('metroconfig', () => {
         });
       });
 
+      describe.each([['./feedbackSync.js'], ['./feedbackAsync.js']])('with %s from @sentry/browser', wrapperModule => {
+        const SENTRY_BROWSER_ORIGIN = '/project/node_modules/@sentry/browser/build/npm/esm/prod/index.js';
+
+        let browserContextMock: any;
+
+        beforeEach(() => {
+          browserContextMock = {
+            resolveRequest: jest.fn(),
+            originModulePath: SENTRY_BROWSER_ORIGIN,
+          };
+        });
+
+        test('removes wrapper when includeWebFeedback is false', () => {
+          const modifiedConfig = withSentryFeedbackResolver(config, false);
+          const result = resolveRequest(modifiedConfig, browserContextMock, wrapperModule, 'android');
+
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolverMock).not.toHaveBeenCalled();
+        });
+
+        test('removes wrapper when includeWebFeedback is undefined on native', () => {
+          const modifiedConfig = withSentryFeedbackResolver(config, undefined);
+          const result = resolveRequest(modifiedConfig, browserContextMock, wrapperModule, 'ios');
+
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolverMock).not.toHaveBeenCalled();
+        });
+
+        test('keeps wrapper when includeWebFeedback is true', () => {
+          const modifiedConfig = withSentryFeedbackResolver(config, true);
+          resolveRequest(modifiedConfig, browserContextMock, wrapperModule, 'web');
+
+          ExpectToBeCalledWithMetroParameters(originalResolverMock, browserContextMock, wrapperModule, 'web');
+        });
+
+        test('keeps wrapper when origin is not @sentry/browser', () => {
+          const nonBrowserContextMock = {
+            resolveRequest: jest.fn(),
+            originModulePath: '/project/node_modules/some-other-package/index.js',
+          };
+          const modifiedConfig = withSentryFeedbackResolver(config, false);
+          resolveRequest(modifiedConfig, nonBrowserContextMock, wrapperModule, 'android');
+
+          ExpectToBeCalledWithMetroParameters(originalResolverMock, nonBrowserContextMock, wrapperModule, 'android');
+        });
+      });
+
       test('calls originalResolver when moduleName is not @sentry-internal/feedback', () => {
         const modifiedConfig = withSentryFeedbackResolver(config, true);
         const moduleName = 'some/other/module';
@@ -661,6 +708,48 @@ describe('metroconfig', () => {
 
       expect(mockExit).toHaveBeenCalledWith(-1);
     });
+  });
+  describe('feedback resolver handles @sentry/browser barrel imports', () => {
+    const SENTRY_BROWSER_BARREL = '/project/node_modules/@sentry/browser/build/npm/esm/prod/index.js';
+
+    const browserBarrelImports = [
+      { moduleName: './feedbackSync.js', shouldBeEmpty: true },
+      { moduleName: './feedbackAsync.js', shouldBeEmpty: true },
+      { moduleName: '@sentry-internal/feedback', shouldBeEmpty: true },
+      { moduleName: '@sentry-internal/replay', shouldBeEmpty: false },
+      { moduleName: '@sentry-internal/replay-canvas', shouldBeEmpty: false },
+      { moduleName: '@sentry-internal/browser-utils', shouldBeEmpty: false },
+      { moduleName: '@sentry/core/browser', shouldBeEmpty: false },
+      { moduleName: './helpers.js', shouldBeEmpty: false },
+      { moduleName: './client.js', shouldBeEmpty: false },
+      { moduleName: './sdk.js', shouldBeEmpty: false },
+      { moduleName: './userfeedback.js', shouldBeEmpty: false },
+    ];
+
+    test.each(browserBarrelImports)(
+      '$moduleName is resolved to empty=$shouldBeEmpty when includeWebFeedback is false',
+      ({ moduleName, shouldBeEmpty }) => {
+        const originalResolver = jest.fn();
+        const config: MetroConfig = {
+          resolver: { resolveRequest: originalResolver },
+        };
+        const context = {
+          resolveRequest: jest.fn(),
+          originModulePath: SENTRY_BROWSER_BARREL,
+        };
+
+        const modifiedConfig = withSentryFeedbackResolver(config, false);
+        const result = modifiedConfig.resolver?.resolveRequest?.(context, moduleName, 'android');
+
+        if (shouldBeEmpty) {
+          expect(result).toEqual({ type: 'empty' });
+          expect(originalResolver).not.toHaveBeenCalled();
+        } else {
+          expect(result).not.toEqual({ type: 'empty' });
+          expect(originalResolver).toHaveBeenCalled();
+        }
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

When `includeWebFeedback: false` is set in the Metro config, the app crashes at startup with:

```
TypeError: buildFeedbackIntegration is not a function (it is undefined)
```

**Root cause:** The feedback resolver stubs `@sentry-internal/feedback` to an empty module, but `@sentry/browser`'s barrel file imports `./feedbackSync.js` and `./feedbackAsync.js`, which **call** `buildFeedbackIntegration()` at module evaluation time. Since the feedback package is empty, the function is `undefined` and the call crashes before any app code runs.

This differs from replay (`includeWebReplay: false`), which works because `@sentry/browser` only re-exports symbols from `@sentry-internal/replay` without calling them at evaluation time.

**Fix:** The feedback resolver now also stubs `feedbackSync.js` and `feedbackAsync.js` when imported from `@sentry/browser`, preventing them from evaluating and calling into the empty module. The `buildSentryPackageExcludeResolver` helper is changed from a `RegExp` to a `shouldExcludeModule` function to support this origin-aware matching.


## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-react-native/issues/6149

Introduced in https://github.com/getsentry/sentry-react-native/pull/6025 — the `includeWebFeedback` option was modeled after `includeWebReplay`, but feedback has a different integration pattern in `@sentry/browser` (eager function call vs plain re-export).


## :green_heart: How did you test it?

- Added 16 unit tests for the wrapper module exclusion (`feedbackSync.js`, `feedbackAsync.js`)
- Added an integration-style test that simulates all `@sentry/browser` barrel imports and verifies only feedback-related modules are stubbed
- All 169 tests pass (142 existing + 27 new)
- Build and lint pass


## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed. https://github.com/getsentry/sentry-docs/pull/17775
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
