### PR TITLE
feat(core): Surface textComponentNames option in Metro config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Extract text content from children of touched components as a label fallback for touch breadcrumbs ([#6106](https://github.com/getsentry/sentry-react-native/pull/6106))
 - Auto-inject `sentry-label` from static text content at build time when `annotateReactComponents` is enabled ([#6141](https://github.com/getsentry/sentry-react-native/pull/6141))
 - Respect Replay Mask boundaries when reading `sentry-label` for touch breadcrumbs ([#6142](https://github.com/getsentry/sentry-react-native/pull/6142))
+- Add `textComponentNames` option to `annotateReactComponents` for custom text components ([#6169](https://github.com/getsentry/sentry-react-native/pull/6169))
 
 ### Fixes
 

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -201,7 +201,9 @@ function loadExpoMetroConfigModule(): {
  */
 export function withSentryBabelTransformer(
   config: MetroConfig,
-  annotateReactComponents: true | { ignoredComponents?: string[]; autoInjectSentryLabel?: boolean; textComponentNames?: string[] },
+  annotateReactComponents:
+    | true
+    | { ignoredComponents?: string[]; autoInjectSentryLabel?: boolean; textComponentNames?: string[] },
 ): MetroConfig {
   const defaultBabelTransformerPath = config.transformer?.babelTransformerPath;
   debug.log('Default Babel transformer path from `config.transformer`:', defaultBabelTransformerPath);

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -41,6 +41,14 @@ export interface SentryMetroConfigOptions {
          * @default true when `annotateReactComponents` is enabled
          */
         autoInjectSentryLabel?: boolean;
+        /**
+         * Component names whose children's text content should be used for
+         * `sentry-label` injection. Useful for apps with custom text wrapper
+         * components.
+         *
+         * @default ['Text']
+         */
+        textComponentNames?: string[];
       };
   /**
    * Adds the Sentry replay package for web.
@@ -193,7 +201,7 @@ function loadExpoMetroConfigModule(): {
  */
 export function withSentryBabelTransformer(
   config: MetroConfig,
-  annotateReactComponents: true | { ignoredComponents?: string[] },
+  annotateReactComponents: true | { ignoredComponents?: string[]; autoInjectSentryLabel?: boolean; textComponentNames?: string[] },
 ): MetroConfig {
   const defaultBabelTransformerPath = config.transformer?.babelTransformerPath;
   debug.log('Default Babel transformer path from `config.transformer`:', defaultBabelTransformerPath);

--- a/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
+++ b/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
@@ -8,6 +8,7 @@ export type SentryBabelTransformerOptions = {
   annotateReactComponents?: {
     ignoredComponents?: string[];
     autoInjectSentryLabel?: boolean;
+    textComponentNames?: string[];
   };
 };
 

--- a/packages/core/test/tools/sentryBabelTransformer.test.ts
+++ b/packages/core/test/tools/sentryBabelTransformer.test.ts
@@ -117,6 +117,31 @@ describe('SentryBabelTransformer', () => {
     );
   });
 
+  test('transform passes textComponentNames to plugin', () => {
+    process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = JSON.stringify({
+      annotateReactComponents: {
+        textComponentNames: ['Text', 'MyText', 'Typography'],
+      },
+    });
+
+    createSentryBabelTransformer().transform?.(createMinimalMockedTransformOptions());
+
+    expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledTimes(1);
+    expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plugins: expect.arrayContaining([
+          [
+            expect.objectContaining({ name: 'componentNameAnnotatePlugin' }),
+            expect.objectContaining({
+              autoInjectSentryLabel: true,
+              textComponentNames: ['Text', 'MyText', 'Typography'],
+            }),
+          ],
+        ]),
+      }),
+    );
+  });
+
   test('degrades gracefully if options can not be parsed, transform adds plugin with defaults', () => {
     process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = 'invalid json';
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Surfaces the `textComponentNames` option from `@sentry/babel-plugin-component-annotate` through the Metro config's `annotateReactComponents` option.

Apps with custom text wrapper components (e.g., `MyText`, `Typography`) can now tell the Babel plugin to recognize those components for `sentry-label` injection:

```js
withSentryConfig(config, {
  annotateReactComponents: {
    textComponentNames: ['Text', 'MyText', 'Typography'],
  },
});
```

The option threads through the existing env var plumbing — same mechanism as `ignoredComponents` and `autoInjectSentryLabel`.

## :bulb: Motivation and Context

Closes #6146

The `autoInjectSentryLabel` feature (enabled by default via #6141) only recognizes RN's `Text` component. Most production apps use custom text wrappers for consistent styling, so their text content is missed.

## :green_heart: How did you test it?

- Added test verifying `textComponentNames` passes through to the Babel plugin
- All 9 babel transformer tests pass
- All 142 metroconfig tests pass
- Build and API report up to date

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed https://github.com/getsentry/sentry-docs/pull/17786
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps