### PR TITLE
feat(replay): Expose captureSurfaceViews option for Android Session Replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Auto-inject `sentry-label` from static text content at build time when `annotateReactComponents` is enabled ([#6141](https://github.com/getsentry/sentry-react-native/pull/6141))
 - Respect Replay Mask boundaries when reading `sentry-label` for touch breadcrumbs ([#6142](https://github.com/getsentry/sentry-react-native/pull/6142))
 - Add `textComponentNames` option to `annotateReactComponents` for custom text components ([#6169](https://github.com/getsentry/sentry-react-native/pull/6169))
+- Expose `captureSurfaceViews` option for Android Session Replay ([#6175](https://github.com/getsentry/sentry-react-native/pull/6175))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Auto-inject `sentry-label` from static text content at build time when `annotateReactComponents` is enabled ([#6141](https://github.com/getsentry/sentry-react-native/pull/6141))
 - Respect Replay Mask boundaries when reading `sentry-label` for touch breadcrumbs ([#6142](https://github.com/getsentry/sentry-react-native/pull/6142))
 - Add `textComponentNames` option to `annotateReactComponents` for custom text components ([#6169](https://github.com/getsentry/sentry-react-native/pull/6169))
-- Expose `captureSurfaceViews` option for Android Session Replay ([#6175](https://github.com/getsentry/sentry-react-native/pull/6175))
+- Expose experimental `captureSurfaceViews` option for Android Session Replay ([#6175](https://github.com/getsentry/sentry-react-native/pull/6175))
 
 ### Fixes
 

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
@@ -419,6 +419,11 @@ final class RNSentryStart {
       androidReplayOptions.addMaskViewClass("com.horcrux.svg.SvgView"); // react-native-svg
     }
 
+    if (rnMobileReplayOptions.hasKey("captureSurfaceViews")) {
+      androidReplayOptions.setCaptureSurfaceViews(
+          rnMobileReplayOptions.getBoolean("captureSurfaceViews"));
+    }
+
     if (rnMobileReplayOptions.hasKey("screenshotStrategy")) {
       final String strategy = rnMobileReplayOptions.getString("screenshotStrategy");
       if ("canvas".equals(strategy)) {

--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -125,6 +125,20 @@ export interface MobileReplayOptions {
   screenshotStrategy?: ScreenshotStrategy;
 
   /**
+   * Enables capturing `SurfaceView` content in Session Replay on Android.
+   *
+   * This allows replays to include content from components that render outside the normal
+   * View hierarchy (e.g. video players, map SDKs) which otherwise appear as black regions.
+   *
+   * - Experiment: Masking granularity is at the `SurfaceView` level only.
+   * - Note: Only works with the `pixelCopy` screenshot strategy (the default).
+   *
+   * @default false
+   * @platform android
+   */
+  captureSurfaceViews?: boolean;
+
+  /**
    * Callback to determine if a replay should be captured for a specific error.
    * When this callback returns `false`, no replay will be captured for the error.
    * This callback is only called when an error occurs and `replaysOnErrorSampleRate` is set.


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Bridges the Android SDK's `captureSurfaceViews` option ([sentry-java#5333](https://github.com/getsentry/sentry-java/pull/5333)) to the React Native SDK.

This allows Session Replay to capture content rendered inside `SurfaceView` components (e.g. video players, map SDKs, Unity views) that otherwise appear as black or transparent regions in replays.

Changes:
- Added `captureSurfaceViews?: boolean` to `MobileReplayOptions` in TypeScript
- Read the option from `rnMobileReplayOptions` in `RNSentryStart.java` and pass it to `androidReplayOptions.setCaptureSurfaceViews()`

## :bulb: Motivation and Context

The Android SDK added experimental support for capturing `SurfaceView` content in v8.41.0. We already depend on that version, but the option wasn't bridged to React Native.

Closes #6107

## :green_heart: How did you test it?

- [x] Build passes (`yarn build:sdk`)
- [ ] Manual test with a sample app containing a `SurfaceView` (e.g. video player)

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed https://github.com/getsentry/sentry-docs/pull/17790
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
