### PR TITLE
feat(core): Expose `addConsoleInstrumentationFilter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Auto-inject `sentry-label` from static text content at build time when `annotateReactComponents` is enabled ([#6141](https://github.com/getsentry/sentry-react-native/pull/6141))
 - Respect Replay Mask boundaries when reading `sentry-label` for touch breadcrumbs ([#6142](https://github.com/getsentry/sentry-react-native/pull/6142))
 - Add `textComponentNames` option to `annotateReactComponents` for custom text components ([#6169](https://github.com/getsentry/sentry-react-native/pull/6169))
+- Expose `addConsoleInstrumentationFilter` from `@sentry/core` ([#6180](https://github.com/getsentry/sentry-react-native/pull/6180))
 
 ### Fixes
 

--- a/packages/core/etc/sentry-react-native.api.md
+++ b/packages/core/etc/sentry-react-native.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { addBreadcrumb } from '@sentry/core';
+import { addConsoleInstrumentationFilter } from '@sentry/core';
 import { addEventProcessor } from '@sentry/core';
 import { addIntegration } from '@sentry/core';
 import { AnthropicAiClient } from '@sentry/core';
@@ -117,6 +118,8 @@ import { withErrorBoundary } from '@sentry/react';
 import { withProfiler } from '@sentry/react';
 
 export { addBreadcrumb }
+
+export { addConsoleInstrumentationFilter }
 
 export { addEventProcessor }
 

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -54,6 +54,7 @@ export {
   createLangChainCallbackHandler,
   instrumentLangGraph,
   instrumentStateGraphCompile,
+  addConsoleInstrumentationFilter,
 } from '@sentry/core';
 
 export type {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Re-exports `addConsoleInstrumentationFilter` from `@sentry/core`, allowing users to selectively filter which console messages are captured as breadcrumbs.

## :bulb: Motivation and Context

Currently the SDK only supports an all-or-nothing `console: true/false` toggle via `breadcrumbsIntegration`. `@sentry/core` v10.53.0 added `addConsoleInstrumentationFilter` ([getsentry/sentry-javascript#20790](https://github.com/getsentry/sentry-javascript/pull/20790)) which enables granular filtering by string or regex pattern.

This is useful in React Native where console output is often noisy with library warnings, deprecation notices, and require cycle messages.

Closes https://github.com/getsentry/sentry-react-native/issues/6140

## :green_heart: How did you test it?

- Build passes (`yarn build`)
- API report check passes (`yarn api-report:check`)

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps