### PR TITLE
fix(ios): use framework-style import for SentrySwizzle.h

### DIFF
--- a/packages/core/ios/RNSentryRNSScreen.m
+++ b/packages/core/ios/RNSentryRNSScreen.m
@@ -4,7 +4,7 @@
 
 #    import "RNSentryDependencyContainer.h"
 #    import "RNSentryFramesTrackerListener.h"
-#    import "SentrySwizzle.h"
+#    import <Sentry/SentrySwizzle.h>
 @import Sentry;
 
 @implementation RNSentryRNSScreen


### PR DESCRIPTION
The quote-style `#import "SentrySwizzle.h"` only resolves when sentry-cocoa is consumed via CocoaPods source build, where the header sits on the HEADER_SEARCH_PATHS. When sentry-cocoa is consumed as a pre-built xcframework (via SPM `binaryTarget` or manual drop-in), the header lives in the framework's `PrivateHeaders/` directory and the quote-style import fails.

It's required for the sentry-cocoa SPM consumption: getsentry/sentry-react-native#6170.

## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
