### PR TITLE
fix(ios): Use conditional import for SentrySwizzle.h

### DIFF
--- a/packages/core/ios/RNSentryRNSScreen.m
+++ b/packages/core/ios/RNSentryRNSScreen.m
@@ -4,7 +4,11 @@
 
 #    import "RNSentryDependencyContainer.h"
 #    import "RNSentryFramesTrackerListener.h"
-#    import <Sentry/SentrySwizzle.h>
+#    if __has_include(<Sentry/SentrySwizzle.h>)
+#        import <Sentry/SentrySwizzle.h>
+#    else
+#        import "SentrySwizzle.h"
+#    endif
 @import Sentry;
 
 @implementation RNSentryRNSScreen


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Uses `__has_include` to conditionally import `SentrySwizzle.h` with framework-style (`<Sentry/SentrySwizzle.h>`) when available, falling back to quote-style (`"SentrySwizzle.h"`) otherwise.

`SentrySwizzle.h` is a **private** header in sentry-cocoa (lives in `Sources/Sentry/include/`, not `Sources/Sentry/Public/`). The previous fix in #6181 switched to a framework-style import unconditionally, which broke CocoaPods source builds because private headers aren't exposed via `<Framework/...>` in that configuration. It was reverted.

Neither import style works for all consumption methods:
| Import style | CocoaPods (source) | SPM xcframework |
|---|---|---|
| `#import "SentrySwizzle.h"` | ✅ | ❌ |
| `#import <Sentry/SentrySwizzle.h>` | ❌ | ✅ |

The conditional `__has_include` resolves this by using whichever path is available at compile time.

## :bulb: Motivation and Context

Fixes the build regression from #6181 while still supporting SPM xcframework consumption (#6170, #6182).


## :green_heart: How did you test it?

- CocoaPods source build should resolve via the quote-style fallback (existing behavior)
- SPM xcframework build should resolve via the framework-style import

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps