### PR TITLE
fix(core): Preserve Metro config object identity in serializer wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix boolean options from `sentry.options.json` being ignored on Android when using `RNSentrySDK.init` ([#6130](https://github.com/getsentry/sentry-react-native/pull/6130))
 - Fix `includeWebFeedback: false` Metro config option causing crash at startup ([#6150](https://github.com/getsentry/sentry-react-native/pull/6150))
 - Fix `sentry-expo-upload-sourcemaps` failing for projects with `devEngines.packageManager` set to non-npm managers ([#6155](https://github.com/getsentry/sentry-react-native/pull/6155))
+- Fix Metro serializer wrapper breaking `getModulesRunBeforeMainModule` for third-party plugins like `react-native-worklets` `bundleMode` ([#6188](https://github.com/getsentry/sentry-react-native/pull/6188))
 
 ### Dependencies
 

--- a/packages/core/src/js/tools/sentryOptionsSerializer.ts
+++ b/packages/core/src/js/tools/sentryOptionsSerializer.ts
@@ -57,13 +57,15 @@ export function withSentryOptionsFromFile(config: MetroConfig, optionsFile: stri
     return originalSerializer(entryPoint, preModules, graph, options);
   };
 
-  return {
-    ...config,
-    serializer: {
-      ...config.serializer,
-      customSerializer: sentryOptionsSerializer,
-    },
-  };
+  // Preserve Expo's __originalSerializer marker so Expo can detect user-provided serializers
+  if ('__originalSerializer' in originalSerializer) {
+    Object.assign(sentryOptionsSerializer, {
+      __originalSerializer: (originalSerializer as Record<string, unknown>).__originalSerializer,
+    });
+  }
+
+  config.serializer.customSerializer = sentryOptionsSerializer;
+  return config;
 }
 
 function createSentryOptionsModule(filePath: string): Module<VirtualJSOutput> | null {

--- a/packages/core/test/tools/sentryOptionsSerializer.test.ts
+++ b/packages/core/test/tools/sentryOptionsSerializer.test.ts
@@ -165,6 +165,53 @@ describe('Sentry Options Serializer', () => {
     expect(actualResult).toEqual(mockedResult);
   });
 
+  test('mutates config in place to preserve object identity for Expo serializer closures', () => {
+    const config = {
+      projectRoot: '/test',
+      serializer: {
+        customSerializer: customSerializerMock,
+        getModulesRunBeforeMainModule: jest.fn(),
+      },
+    };
+    const originalSerializerObj = config.serializer;
+
+    const result = withSentryOptionsFromFile(config, true);
+
+    expect(result).toBe(config);
+    expect(result.serializer).toBe(originalSerializerObj);
+    expect(result.serializer?.customSerializer).not.toBe(customSerializerMock);
+    expect(result.serializer?.getModulesRunBeforeMainModule).toBe(config.serializer.getModulesRunBeforeMainModule);
+  });
+
+  test('preserves __originalSerializer marker from Expo serializer', () => {
+    const expoSerializer = Object.assign(jest.fn(), { __originalSerializer: null });
+    const config = {
+      projectRoot: '/test',
+      serializer: {
+        customSerializer: expoSerializer,
+      },
+    };
+
+    const result = withSentryOptionsFromFile(config, true);
+
+    expect('__originalSerializer' in (result.serializer?.customSerializer as Record<string, unknown>)).toBe(true);
+    expect((result.serializer?.customSerializer as Record<string, unknown>).__originalSerializer).toBeNull();
+  });
+
+  test('does not add __originalSerializer when original serializer lacks it', () => {
+    const plainSerializer = jest.fn();
+    const config = {
+      projectRoot: '/test',
+      serializer: {
+        customSerializer: plainSerializer,
+      },
+    };
+
+    const result = withSentryOptionsFromFile(config, true);
+
+    expect('__originalSerializer' in (result.serializer?.customSerializer as Record<string, unknown>)).toBe(false);
+  });
+
   test('uses custom file path when optionsFile is a string', () => {
     const config = () => ({
       projectRoot: '/test',


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

`withSentryOptionsFromFile` was creating a new config object via object spread when wrapping the Metro serializer. This broke object identity: Expo's serializer holds a closure over the original `config` object and reads `config.serializer.getModulesRunBeforeMainModule` at serialization time. Because the spread created a new `serializer` object, any downstream mutations to it (e.g. from `react-native-worklets`' `getBundleModeMetroConfig`) were invisible to Expo's closure.

The fix mutates `config.serializer.customSerializer` in place and preserves Expo's `__originalSerializer` marker on the wrapper function.

## :bulb: Motivation and Context

Fixes #6151

When using `@sentry/react-native` with `react-native-worklets` in `bundleMode`, production builds (`expo export` / EAS Build) crash with:

```
Cannot read property 'code' of undefined
```

This happens because the worklet runtime entry module is dropped from the bundle. The `getModulesRunBeforeMainModule` entries added by `react-native-worklets` are written to the new config's serializer object, but Expo's serializer reads from the original one where those entries don't exist.

## :green_heart: How did you test it?

- Reproduced the issue with a minimal Expo project using `getSentryExpoConfig` + `getBundleModeMetroConfig` + `react-native-keyboard-controller`
- Verified via `expo export` bundle output:
  - **Without fix:** `__r(4); __r(541); __r(2); __r(0);` (worklet runtime entry missing)
  - **With fix:** `__r(1705); __r(4); __r(541); __r(2); __r(0);` (worklet runtime entry present)
- Verified Release build on iOS simulator runs without crash
- Added 3 new unit tests covering object identity preservation, `__originalSerializer` marker forwarding, and the no-marker case

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
