### PR TITLE
feat(core): Add OTA SDK version to native sdk.packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `textComponentNames` option to `annotateReactComponents` for custom text components ([#6169](https://github.com/getsentry/sentry-react-native/pull/6169))
 - Expose `addConsoleInstrumentationFilter` from `@sentry/core` ([#6180](https://github.com/getsentry/sentry-react-native/pull/6180))
 - Expose experimental `captureSurfaceViews` option for Android Session Replay ([#6175](https://github.com/getsentry/sentry-react-native/pull/6175))
+- Add OTA SDK version to native `sdk.packages` when JS bundle version differs from built-in version ([#6191](https://github.com/getsentry/sentry-react-native/pull/6191))
 
 ### Fixes
 

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
@@ -68,8 +68,11 @@ final class RNSentryStart {
       @Nullable Activity currentActivity,
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration,
       @NotNull ILogger logger) {
+    @Nullable
+    String jsSdkVersion =
+        rnOptions.hasKey("sdkVersion") ? rnOptions.getString("sdkVersion") : null;
     Sentry.OptionsConfiguration<SentryAndroidOptions> defaults =
-        options -> updateWithReactDefaults(options, currentActivity);
+        options -> updateWithReactDefaults(options, currentActivity, jsSdkVersion);
     Sentry.OptionsConfiguration<SentryAndroidOptions> rnConfigurationOptions =
         options -> getSentryAndroidOptions(options, rnOptions, logger);
     RNSentryCompositeOptionsConfiguration compositeConfiguration =
@@ -319,6 +322,13 @@ final class RNSentryStart {
    */
   static void updateWithReactDefaults(
       @NotNull SentryAndroidOptions options, @Nullable Activity currentActivity) {
+    updateWithReactDefaults(options, currentActivity, null);
+  }
+
+  static void updateWithReactDefaults(
+      @NotNull SentryAndroidOptions options,
+      @Nullable Activity currentActivity,
+      @Nullable String jsSdkVersion) {
     @Nullable SdkVersion sdkVersion = options.getSdkVersion();
     if (sdkVersion == null) {
       sdkVersion = new SdkVersion(RNSentryVersion.ANDROID_SDK_NAME, BuildConfig.VERSION_NAME);
@@ -328,6 +338,11 @@ final class RNSentryStart {
     sdkVersion.addPackage(
         RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_NAME,
         RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_VERSION);
+    if (jsSdkVersion != null
+        && !jsSdkVersion.equals(RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_VERSION)) {
+      sdkVersion.addPackage(
+          RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_NAME + ":ota", jsSdkVersion);
+    }
 
     options.setSentryClientName(sdkVersion.getName() + "/" + sdkVersion.getVersion());
     options.setNativeSdkName(RNSentryVersion.NATIVE_SDK_NAME);

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
@@ -69,8 +69,7 @@ final class RNSentryStart {
       @NotNull Sentry.OptionsConfiguration<SentryAndroidOptions> configuration,
       @NotNull ILogger logger) {
     @Nullable
-    String jsSdkVersion =
-        rnOptions.hasKey("sdkVersion") ? rnOptions.getString("sdkVersion") : null;
+    String jsSdkVersion = rnOptions.hasKey("sdkVersion") ? rnOptions.getString("sdkVersion") : null;
     Sentry.OptionsConfiguration<SentryAndroidOptions> defaults =
         options -> updateWithReactDefaults(options, currentActivity, jsSdkVersion);
     Sentry.OptionsConfiguration<SentryAndroidOptions> rnConfigurationOptions =
@@ -340,8 +339,7 @@ final class RNSentryStart {
         RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_VERSION);
     if (jsSdkVersion != null
         && !jsSdkVersion.equals(RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_VERSION)) {
-      sdkVersion.addPackage(
-          RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_NAME + ":ota", jsSdkVersion);
+      sdkVersion.addPackage(RNSentryVersion.REACT_NATIVE_SDK_PACKAGE_NAME + ":ota", jsSdkVersion);
     }
 
     options.setSentryClientName(sdkVersion.getName() + "/" + sdkVersion.getVersion());

--- a/packages/core/ios/RNSentryStart.m
+++ b/packages/core/ios/RNSentryStart.m
@@ -16,15 +16,33 @@
                                                          error:errorPointer];
     [self updateWithReactDefaults:options];
     [self updateWithReactFinals:options];
-    [self startWithOptions:options];
+    NSString *jsSdkVersion = nil;
+    id jsSdkVersionValue = javascriptOptions[@"sdkVersion"];
+    if ([jsSdkVersionValue isKindOfClass:[NSString class]]) {
+        jsSdkVersion = jsSdkVersionValue;
+    }
+    [self startWithOptions:options jsSdkVersion:jsSdkVersion];
 }
 
 + (void)startWithOptions:(SentryOptions *)options NS_SWIFT_NAME(start(options:))
+{
+    [self startWithOptions:options jsSdkVersion:nil];
+}
+
++ (void)startWithOptions:(SentryOptions *)options
+            jsSdkVersion:(NSString *_Nullable)jsSdkVersion
 {
     NSString *sdkVersion = [PrivateSentrySDKOnly getSdkVersionString];
     [PrivateSentrySDKOnly setSdkName:NATIVE_SDK_NAME andVersionString:sdkVersion];
     [PrivateSentrySDKOnly addSdkPackage:REACT_NATIVE_SDK_PACKAGE_NAME
                                 version:REACT_NATIVE_SDK_PACKAGE_VERSION];
+
+    if (jsSdkVersion != nil
+        && ![jsSdkVersion isEqualToString:REACT_NATIVE_SDK_PACKAGE_VERSION]) {
+        NSString *otaPackageName =
+            [REACT_NATIVE_SDK_PACKAGE_NAME stringByAppendingString:@":ota"];
+        [PrivateSentrySDKOnly addSdkPackage:otaPackageName version:jsSdkVersion];
+    }
 
     [SentrySDK startWithOptions:options];
 

--- a/packages/core/ios/RNSentryStart.m
+++ b/packages/core/ios/RNSentryStart.m
@@ -29,18 +29,15 @@
     [self startWithOptions:options jsSdkVersion:nil];
 }
 
-+ (void)startWithOptions:(SentryOptions *)options
-            jsSdkVersion:(NSString *_Nullable)jsSdkVersion
++ (void)startWithOptions:(SentryOptions *)options jsSdkVersion:(NSString *_Nullable)jsSdkVersion
 {
     NSString *sdkVersion = [PrivateSentrySDKOnly getSdkVersionString];
     [PrivateSentrySDKOnly setSdkName:NATIVE_SDK_NAME andVersionString:sdkVersion];
     [PrivateSentrySDKOnly addSdkPackage:REACT_NATIVE_SDK_PACKAGE_NAME
                                 version:REACT_NATIVE_SDK_PACKAGE_VERSION];
 
-    if (jsSdkVersion != nil
-        && ![jsSdkVersion isEqualToString:REACT_NATIVE_SDK_PACKAGE_VERSION]) {
-        NSString *otaPackageName =
-            [REACT_NATIVE_SDK_PACKAGE_NAME stringByAppendingString:@":ota"];
+    if (jsSdkVersion != nil && ![jsSdkVersion isEqualToString:REACT_NATIVE_SDK_PACKAGE_VERSION]) {
+        NSString *otaPackageName = [REACT_NATIVE_SDK_PACKAGE_NAME stringByAppendingString:@":ota"];
         [PrivateSentrySDKOnly addSdkPackage:otaPackageName version:jsSdkVersion];
     }
 

--- a/packages/core/src/js/wrapper.ts
+++ b/packages/core/src/js/wrapper.ts
@@ -35,6 +35,7 @@ import { isTurboModuleEnabled } from './utils/environment';
 import { convertToNormalizedObject } from './utils/normalize';
 import { ReactNativeLibraries } from './utils/rnlibraries';
 import { base64StringFromByteArray } from './vendor';
+import { SDK_VERSION } from './version';
 
 /**
  * Returns the RNSentry module. Dynamically resolves if NativeModule or TurboModule is used.
@@ -60,6 +61,7 @@ export type NativeSdkOptions = Partial<ReactNativeClientOptions> & {
   ignoreErrorsRegex?: string[] | undefined;
 } & {
   mobileReplayOptions: MobileReplayOptions | undefined;
+  sdkVersion?: string | undefined;
   profilingOptions?: ProfilingOptions | undefined;
   /** @deprecated Use `profilingOptions` instead. */
   androidProfilingOptions?: ProfilingOptions | undefined;
@@ -316,6 +318,8 @@ export const NATIVE: SentryNativeWrapper = {
         profilingOptions: resolvedProfilingOptions,
       };
     }
+
+    filteredOptions.sdkVersion = SDK_VERSION;
 
     const nativeIsReady = await RNSentry.initNativeSdk(filteredOptions);
 

--- a/packages/core/test/wrapper.test.ts
+++ b/packages/core/test/wrapper.test.ts
@@ -245,6 +245,23 @@ describe('Tests Native Wrapper', () => {
       expect(NATIVE.enableNative).toBe(true);
     });
 
+    test('passes sdkVersion to native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: VALID_DSN,
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        devServerUrl: undefined,
+        defaultSidecarUrl: undefined,
+        mobileReplayOptions: undefined,
+      });
+
+      expect(RNSentry.initNativeSdk).toHaveBeenCalled();
+      // @ts-expect-error mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).toHaveProperty('sdkVersion');
+      expect(typeof initParameter.sdkVersion).toBe('string');
+    });
+
     test('passes attachAllThreads to native SDK', async () => {
       await NATIVE.initNativeSdk({
         dsn: VALID_DSN,


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

When an OTA update (e.g. CodePush, Expo Updates) replaces the JS bundle, the runtime `@sentry/react-native` version can drift from the version baked into the native binary at build time.

This change passes the JS runtime SDK version to native during init. If it differs from the built-in version, an additional `npm:@sentry/react-native:ota` entry is added to `sdk.packages` with the actual runtime version. When versions match (the normal case), no extra entry is added.

## :bulb: Motivation and Context

Closes https://github.com/getsentry/sentry-react-native/issues/4385

OTA updates can cause native/JS SDK version misalignment, which may lead to unexpected behavior. Recording the actual JS version alongside the built-in one helps when debugging SDK issues — you can immediately see if an OTA mismatch is in play.

Improvement on https://github.com/getsentry/sentry-react-native/pull/4380, which added the built-in version to `sdk.packages`.

## :green_heart: How did you test it?

- Added unit test verifying `sdkVersion` is passed to native SDK during init
- All 1412 existing tests pass
- Lint, build, and circular dependency checks pass

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

- Native integration tests to verify the OTA package appears in events when versions differ