### PR TITLE
feat(android): Warn when Gradle resolves unexpected sentry-android version

### DIFF
--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
@@ -362,6 +362,19 @@ final class RNSentryStart {
    * applied after the configureOptions callback during manual native initialization.
    */
   static void updateWithReactFinals(@NotNull SentryAndroidOptions options) {
+    if (!BuildConfig.VERSION_NAME.equals(RNSentryVersion.EXPECTED_ANDROID_SDK_VERSION)) {
+      options
+          .getLogger()
+          .log(
+              SentryLevel.WARNING,
+              "sentry-android resolved to %s, but @sentry/react-native expects %s. "
+                  + "This may cause crashes at startup. "
+                  + "If you use the Sentry Android Gradle Plugin, disable autoInstallation: "
+                  + "https://docs.sentry.io/platforms/react-native/manual-setup/manual-setup/",
+              BuildConfig.VERSION_NAME,
+              RNSentryVersion.EXPECTED_ANDROID_SDK_VERSION);
+    }
+
     BeforeSendCallback userBeforeSend = options.getBeforeSend();
     options.setBeforeSend(
         (event, hint) -> {

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryVersion.java
@@ -6,4 +6,5 @@ class RNSentryVersion {
   static final String NATIVE_SDK_NAME = "sentry.native.android.react-native";
   static final String ANDROID_SDK_NAME = "sentry.java.android.react-native";
   static final String REACT_NATIVE_SDK_NAME = "sentry.javascript.react-native";
+  static final String EXPECTED_ANDROID_SDK_VERSION = "8.41.0";
 }

--- a/scripts/update-android.sh
+++ b/scripts/update-android.sh
@@ -33,6 +33,12 @@ set-version)
     expoHandlerContent=$(echo "$expoHandlerContent" | sed -E "s/(io\.sentry:sentry-android:)([0-9\.]+)/\1$2/g")
     echo "$expoHandlerContent" >$expoHandlerFile
 
+    # Update expected version constant in RNSentryVersion.java
+    versionFile='src/main/java/io/sentry/react/RNSentryVersion.java'
+    versionContent=$(cat $versionFile)
+    versionContent=$(echo "$versionContent" | sed -E "s/(EXPECTED_ANDROID_SDK_VERSION = \")([0-9\.]+)/\1$2/")
+    echo "$versionContent" >$versionFile
+
     # Update replay-stubs to match
     cd $ORIGINAL_DIR
     ./update-android-stubs.sh set-version $2


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Adds a runtime warning (logged at `SentryLevel.WARNING`) when the resolved `sentry-android` version differs from what `@sentry/react-native` expects. The warning is visible when `debug: true` is enabled.

Changes:
- Add `EXPECTED_ANDROID_SDK_VERSION` constant to `RNSentryVersion.java`
- Compare it against `io.sentry.android.core.BuildConfig.VERSION_NAME` in `updateWithReactFinals` (runs after user configuration, so the debug logger is available)
- Update `scripts/update-android.sh` to bump the new constant alongside other version references


## :bulb: Motivation and Context

Closes https://github.com/getsentry/sentry-react-native/issues/3671

When `@sentry/react-native` is combined with the Sentry Android Gradle Plugin (SAGP), Gradle dependency resolution can pick a newer `sentry-android` version than the RN SDK expects. This version mismatch causes `IllegalStateException` crashes at app startup. This change warns users at runtime so they can fix the issue before it escalates.


## :green_heart: How did you test it?

- Verified `scripts/update-android.sh set-version` updates `RNSentryVersion.java` alongside `build.gradle`, `expo-handler/build.gradle`, and `replay-stubs`
- Verified round-trip version bump (set to 9.0.0, back to 8.41.0) keeps all files in sync


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

- Coordinate with https://github.com/getsentry/sentry-react-native/pull/6119