### PR TITLE
chore(deps): Remove unused `@sentry/types` dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "test:sdk-local": "jest --maxWorkers=8",
     "test:tools": "npx jest --config jest.config.tools.js",
     "test:watch": "npx jest --watch",
-    "yalc:add:sentry-javascript": "yalc add @sentry/browser @sentry/core @sentry/react @sentry/types",
+    "yalc:add:sentry-javascript": "yalc add @sentry/browser @sentry/core @sentry/react",
     "fix": "npx run-s fix:oxlint fix:fmt",
     "fix:oxlint": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint --type-aware --tsconfig tsconfig.lint.json --fix",
     "fix:fmt": "oxfmt \"{src,test,scripts,plugin/src}/**/**.ts\" \"{src,test}/**/**.tsx\"",
@@ -78,8 +78,7 @@
     "@sentry/cli": "3.4.2",
     "@sentry/core": "10.53.1",
     "@sentry/expo-upload-sourcemaps": "workspace:*",
-    "@sentry/react": "10.53.1",
-    "@sentry/types": "10.53.1"
+    "@sentry/react": "10.53.1"
   },
   "devDependencies": {
     "@babel/core": "^7.26.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10894,7 +10894,6 @@ __metadata:
     "@sentry/core": 10.53.1
     "@sentry/expo-upload-sourcemaps": "workspace:*"
     "@sentry/react": 10.53.1
-    "@sentry/types": 10.53.1
     "@sentry/wizard": 6.12.0
     "@testing-library/react-native": ^13.2.2
     "@types/jest": ^29.5.13
@@ -10949,15 +10948,6 @@ __metadata:
   peerDependencies:
     react: ^16.14.0 || 17.x || 18.x || 19.x
   checksum: 1ed54d1fb6307b79e9e97adc529aa0049c2b402cc0e6e4da7bf4c194a71b61ee4bc5c294bb9fcfb2d3bb6df8005a66b96593f11b79779db2fa7cf2fbc57117ff
-  languageName: node
-  linkType: hard
-
-"@sentry/types@npm:10.53.1":
-  version: 10.53.1
-  resolution: "@sentry/types@npm:10.53.1"
-  dependencies:
-    "@sentry/core": 10.53.1
-  checksum: 152275487a3557098dd3d40229a88da7ea4dd4bf41c6cc25762f4092ab20428509ab64e0f279b8a94ce69620cce2e962af218c3ca8554dab06d9fa9f3b6c64a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description

Removes the direct dependency on `@sentry/types`, which is deprecated and will be removed in the next major version of the JavaScript SDK. All types are now exported from `@sentry/core`.

No source files import from `@sentry/types` — it was an unused direct dependency. Also removes it from the `yalc:add:sentry-javascript` script.


## :bulb: Motivation and Context

`@sentry/types` is deprecated in favor of `@sentry/core`, which re-exports all types. Other JS SDKs have already moved away from it.

Closes #6200


## :green_heart: How did you test it?

- `yarn build` — passes
- `yarn test` — all tests pass
- `yarn lint` — no violations
- `yarn circularDepCheck` — no circular dependencies
- `yarn api-report:check` — API report unchanged


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps