### PR TITLE
fix(ios): Bump iOS binary size threshold for Cocoa 9.14.0

### DIFF
--- a/performance-tests/metrics-ios.yml
+++ b/performance-tests/metrics-ios.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 600 KiB
-  diffMax: 1570 KiB
+  diffMax: 1580 KiB


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

Bumps the iOS binary size diff threshold from 1570 KiB to 1580 KiB in `performance-tests/metrics-ios.yml`.

The `BinarySizeTest` was failing with `1608896 should be < 1607680` — the actual size exceeded the threshold by ~1.2 KiB.

## :bulb: Motivation and Context

Cocoa SDK 9.14.0 (bumped in #6204) adds standalone app start tracing and stack overflow crash report improvements, which slightly increase the iOS binary size.

## :green_heart: How did you test it?

CI metrics job should pass with the updated threshold.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps