### PR TITLE
fix(ci): Remove @sentry/types from JS SDK updater script

### DIFF
--- a/scripts/update-javascript.sh
+++ b/scripts/update-javascript.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 tagPrefix=''
 repo="https://github.com/getsentry/sentry-javascript.git"
-packages=('@sentry/browser' '@sentry/core' '@sentry/react' '@sentry/types' '@sentry-internal/typescript')
+packages=('@sentry/browser' '@sentry/core' '@sentry/react' '@sentry-internal/typescript')
 packages+=('@sentry-internal/eslint-plugin-sdk')
 
 . $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

Remove `@sentry/types` from the packages list in `scripts/update-javascript.sh`. This package is no longer a dependency in any workspace since types were merged into `@sentry/core`.

## :bulb: Motivation and Context

The [JS SDK updater CI workflow is failing](https://github.com/getsentry/sentry-react-native/actions/runs/26505395417/job/78056319547) because `yarn up @sentry/types@10.54.0` errors with "pattern doesn't match any packages referenced by any workspace".

## :green_heart: How did you test it?

Verified `@sentry/types` is not referenced in any `package.json` in the repo.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps