### PR TITLE
fix: Bump tmp to 0.2.7 to resolve path traversal vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -31467,9 +31467,9 @@ __metadata:
   linkType: hard
 
 "tmp@npm:^0.2.4":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 9d18e58060114154939930457b9e198b34f9495bcc05a343bc0a0a29aa546d2c1c2b343dae05b87b17c8fde0af93ab7d8fe8574a8f6dc2cd8fd3f2ca1ad0d8e1
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 45dec2fc288ad368eeff7268cb6d5d33452c6d35f4f7d9b1b5e023409a141dab57a3c08b5f505daf3af6d69667a5f544fc1a5b6a27c6f9396a5a1b4002912f1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
Bumps the `tmp` dev dependency from 0.2.5 to 0.2.7 in the lockfile to resolve a path traversal vulnerability (CWE-22) reported by Dependabot (#543).

The `tmp` package is only used by dev/build tooling (`@nx/devkit`, `detox`, `jscodeshift`, etc.) — the SDK source code never imports it directly.

## :bulb: Motivation and Context
Resolves https://github.com/getsentry/sentry-react-native/security/dependabot/543

Versions < 0.2.6 allow path traversal via unsanitized `prefix`/`postfix`/`dir` options. While the practical risk to this repo is negligible (dev-only dependency, no user-controlled input), bumping clears the alert.

## :green_heart: How did you test it?
- `yarn why tmp` confirms all resolutions now point to 0.2.7
- Only `yarn.lock` changed; no source code modifications

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
None — Dependabot alert should auto-close when this merges.