### PR TITLE
chore(ios): Bump iOS binary size limit to 1590 KiB

### DIFF
--- a/performance-tests/metrics-ios.yml
+++ b/performance-tests/metrics-ios.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 600 KiB
-  diffMax: 1580 KiB
+  diffMax: 1590 KiB


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

Bumps the iOS binary size limit from 1580 KiB to 1590 KiB to accommodate the JS SDK 10.55.0 update.

## :bulb: Motivation and Context

The JS SDK bump to 10.55.0 (#6222) increased the iOS binary size diff to ~1545 KiB, which exceeds the previous 1580 KiB limit (actual: 1,620,533 bytes vs allowed 1,617,920 bytes — ~2.5 KiB over).

## :green_heart: How did you test it?

CI size check should pass with the updated limit.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps