### PR TITLE
chore(ci): Upgrade Gradle action from v3 to v6

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -48,7 +48,7 @@ jobs:
           java-version: '17'
           distribution: "adopt"
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
       - name: Install Dependencies
         run: yarn install
       - name: Codegen

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -48,7 +48,7 @@ jobs:
           java-version: '17'
           distribution: "adopt"
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
       - name: Install Dependencies
         run: yarn install
       - name: Codegen

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - uses: ruby/setup-ruby@v1
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' }}
@@ -333,7 +333,7 @@ jobs:
 
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Setup Global Tools
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
@@ -465,7 +465,7 @@ jobs:
 
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Setup KVM
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - uses: ruby/setup-ruby@v1
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' }}
@@ -333,7 +333,7 @@ jobs:
 
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Setup Global Tools
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
@@ -465,7 +465,7 @@ jobs:
 
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Setup KVM
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -118,7 +118,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run unit tests
         working-directory: packages/core/RNSentryAndroidTester

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -118,7 +118,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Run unit tests
         working-directory: packages/core/RNSentryAndroidTester

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -167,7 +167,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Install SDK Dependencies
         run: yarn install

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -167,7 +167,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Install SDK Dependencies
         run: yarn install

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -170,7 +170,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Install SDK Dependencies
         run: yarn install

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -170,7 +170,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Install SDK Dependencies
         run: yarn install

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -59,7 +59,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Install SDK Dependencies
         run: yarn install

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -59,7 +59,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Gradle cache
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Install SDK Dependencies
         run: yarn install


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description

Replaces the deprecated `gradle/gradle-build-action@v3` with `gradle/actions/setup-gradle@v6` across all CI workflows (8 occurrences in 6 files).

The `gradle-build-action` repo is deprecated — Gradle consolidated all actions under `gradle/actions`. The v6 action provides enhanced caching and is the actively maintained replacement.

## :bulb: Motivation and Context

Gradle has [legal approval](https://github.com/getsentry/sentry-android-gradle-plugin/pull/1237) for using v6 with enhanced caching and Develocity Build Scans. This PR applies the action upgrade; the Build Scan plugin is not applicable here since the SDK's Android module is a library without its own `settings.gradle`.

## :green_heart: How did you test it?

CI workflows should run on this PR and validate the new action works correctly.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog