### PR TITLE
feat(android): Warn when Gradle resolves unsupported sentry-android version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - Add `enableAutoConsoleLogs` option to opt out of automatic `console.*` capture while keeping `enableLogs: true` for manual `Sentry.logger.*` calls ([#6235](https://github.com/getsentry/sentry-react-native/pull/6235))
+- Warn when Gradle resolves `sentry-android` to a version incompatible with the SDK ([#6238](https://github.com/getsentry/sentry-react-native/pull/6238))
 
 ### Internal
 

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -52,11 +52,13 @@ android {
     }
 }
 
+def sentryAndroidVersion = '8.43.0'
+
 dependencies {
     compileOnly files('libs/replay-stubs.jar')
     implementation 'com.facebook.react:react-native:+'
-    api 'io.sentry:sentry-android:8.43.0'
-    debugImplementation 'io.sentry:sentry-spotlight:8.43.0'
+    api "io.sentry:sentry-android:$sentryAndroidVersion"
+    debugImplementation "io.sentry:sentry-spotlight:$sentryAndroidVersion"
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.12.0'

--- a/packages/core/sentry.gradle.kts
+++ b/packages/core/sentry.gradle.kts
@@ -3,8 +3,42 @@ import org.codehaus.groovy.runtime.DefaultGroovyMethods
 import org.gradle.api.tasks.Exec
 import java.io.FileInputStream
 import java.util.Properties
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.regex.Pattern
 import javax.inject.Inject
+
+val expectedSentryAndroidVersion = "8.43.0"
+
+val sentryVersionCheckWarned = AtomicBoolean(false)
+project.configurations.configureEach {
+    if (isCanBeResolved) {
+        incoming.afterResolve {
+            if (sentryVersionCheckWarned.get()) return@afterResolve
+            resolutionResult.allComponents {
+                val id = moduleVersion
+                if (id != null &&
+                    id.group == "io.sentry" &&
+                    id.name == "sentry-android-core" &&
+                    id.version != expectedSentryAndroidVersion
+                ) {
+                    if (sentryVersionCheckWarned.compareAndSet(false, true)) {
+                        logger.warn(
+                            "\nWARNING: @sentry/react-native depends on sentry-android " +
+                                "$expectedSentryAndroidVersion, but version ${id.version} was resolved. " +
+                                "This may cause build errors or unexpected behavior.\n" +
+                                "The most common cause is the Sentry Android Gradle Plugin (SAGP) " +
+                                "overriding the version via autoInstallation. To fix this, set " +
+                                "autoInstallation.enabled = false in your app/build.gradle.\n" +
+                                "Other causes include resolutionStrategy.force, BOMs, or another " +
+                                "library depending on a different sentry-android version.\n" +
+                                "See: https://docs.sentry.io/platforms/react-native/manual-setup/manual-setup/#android\n",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 extra["shouldSentryAutoUploadNative"] =
     object : groovy.lang.Closure<Boolean>(this) {

--- a/scripts/check-android-sdk-mismatch.js
+++ b/scripts/check-android-sdk-mismatch.js
@@ -85,13 +85,13 @@ module.exports = async function ({ fail, warn, __, ___, danger }) {
   }
 
   const buildGradleContent = fs.readFileSync(buildGradlePath, 'utf8');
-  const sentryAndroidVersionMatch = buildGradleContent.match(/api\s+['"]io\.sentry:sentry-android:([^'"]+)['"]/);
+  const sentryAndroidVersionMatch = buildGradleContent.match(/sentryAndroidVersion\s*=\s*'([^']+)'/);
 
   if (!sentryAndroidVersionMatch) {
     warn(
       createSectionWarning(
         'Android SDK Version Check',
-        'Could not parse `sentry-android` version from build.gradle',
+        'Could not parse `sentryAndroidVersion` from build.gradle',
         '⚠️',
       ),
     );

--- a/scripts/update-android.sh
+++ b/scripts/update-android.sh
@@ -5,27 +5,28 @@ ORIGINAL_DIR=$(cd "$(dirname "$0")" && pwd)
 cd $(dirname "$0")/../packages/core/android
 file='build.gradle'
 content=$(cat $file)
-regex='(io\.sentry:sentry-android:)([0-9\.]+)'
+regex="sentryAndroidVersion = '([0-9\.]+)'"
 if ! [[ $content =~ $regex ]]; then
-    echo "Failed to find the android plugin version in $file"
+    echo "Failed to find the sentryAndroidVersion in $file"
     exit 1
 fi
 
 case $1 in
 get-version)
-    echo ${BASH_REMATCH[2]}
+    echo ${BASH_REMATCH[1]}
     ;;
 get-repo)
     echo "https://github.com/getsentry/sentry-java.git"
     ;;
 set-version)
-    # Update all io.sentry dependencies to the same version
-    newContent="$content"
-    # Update sentry-android
-    newContent=$(echo "$newContent" | sed -E "s/(io\.sentry:sentry-android:)([0-9\.]+)/\1$2/g")
-    # Update sentry-spotlight
-    newContent=$(echo "$newContent" | sed -E "s/(io\.sentry:sentry-spotlight:)([0-9\.]+)/\1$2/g")
+    newContent=$(echo "$content" | sed -E "s/(sentryAndroidVersion = ')([0-9\.]+)(')/\1$2\3/g")
     echo "$newContent" >$file
+
+    # Update sentry.gradle.kts version check to match
+    sentryGradleFile='../sentry.gradle.kts'
+    sentryGradleContent=$(cat $sentryGradleFile)
+    sentryGradleContent=$(echo "$sentryGradleContent" | sed -E "s/(expectedSentryAndroidVersion = \")([0-9\.]+)(\")/\1$2\3/g")
+    echo "$sentryGradleContent" >$sentryGradleFile
 
     # Update expo-handler to match
     expoHandlerFile='expo-handler/build.gradle'

--- a/scripts/update-android.sh
+++ b/scripts/update-android.sh
@@ -25,6 +25,10 @@ set-version)
     # Update sentry.gradle.kts version check to match
     sentryGradleFile='../sentry.gradle.kts'
     sentryGradleContent=$(cat $sentryGradleFile)
+    if ! echo "$sentryGradleContent" | grep -q 'expectedSentryAndroidVersion'; then
+        echo "Failed to find expectedSentryAndroidVersion in $sentryGradleFile"
+        exit 1
+    fi
     sentryGradleContent=$(echo "$sentryGradleContent" | sed -E "s/(expectedSentryAndroidVersion = \")([0-9\.]+)(\")/\1$2\3/g")
     echo "$sentryGradleContent" >$sentryGradleFile
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

Adds a build-time warning when the resolved `sentry-android-core` version differs from what `@sentry/react-native` expects. The check runs in `sentry.gradle.kts`, which is applied in the app project's context and therefore sees the app's final resolved dependency graph.

Example warning output:
```
WARNING: @sentry/react-native depends on sentry-android 8.43.0, but version 8.42.0 was resolved.
This may cause build errors or unexpected behavior.
The most common cause is the Sentry Android Gradle Plugin (SAGP) overriding the version via
autoInstallation. To fix this, set autoInstallation.enabled = false in your app/build.gradle.
Other causes include resolutionStrategy.force, BOMs, or another library depending on a different
sentry-android version.
```

Also extracts the `sentry-android` version to a variable in `build.gradle` and updates the bump script (`update-android.sh`) to maintain the version in both `build.gradle` and `sentry.gradle.kts`.


## :bulb: Motivation and Context

When `@sentry/react-native` is combined with SAGP (or other dependency management), Gradle may resolve `sentry-android` to a version different from what the RN SDK was built against. This causes cryptic build errors or runtime crashes that are hard to diagnose:
- https://github.com/getsentry/sentry-react-native/issues/3560
- https://github.com/getsentry/sentry-react-native/issues/3570
- https://github.com/getsentry/sentry-react-native/issues/3497

Closes RN-111


## :green_heart: How did you test it?

Tested locally against the sample app (Gradle 9.3.1 / JDK 17):

1. **Mismatch detected:** Added `resolutionStrategy.force 'io.sentry:sentry-android-core:8.42.0'` to `samples/react-native/android/app/build.gradle` → warning appeared in build output.
2. **No false positive:** Removed the force → no warning emitted.
3. **Bump script round-trip:** `update-android.sh set-version` updates both `build.gradle` and `sentry.gradle.kts` correctly.
4. **`yarn build` passes.**


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps