### PR TITLE
fix: resolve sentry-cli relative to react-native package

### DIFF
--- a/packages/core/scripts/sentry-xcode-debug-files.sh
+++ b/packages/core/scripts/sentry-xcode-debug-files.sh
@@ -32,9 +32,10 @@ RN_PROJECT_ROOT="${SENTRY_PROJECT_ROOT:-${PROJECT_DIR}/..}"
 [ -z "$SOURCEMAP_FILE" ] && export SOURCEMAP_FILE="$DERIVED_FILE_DIR/main.jsbundle.map"
 
 if [ -z "$SENTRY_CLI_EXECUTABLE" ]; then
-  # Try standard resolution safely
+  # Resolve from @sentry/react-native so package managers with isolated dependencies
+  # can find the transitive @sentry/cli dependency.
   RESOLVED_PATH=$(
-    "$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/cli/package.json'))" 2>/dev/null
+    "$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/cli/package.json', { paths: [require.resolve('@sentry/react-native/package.json')] }))" 2>/dev/null
   ) || true
   if [ -n "$RESOLVED_PATH" ]; then
     SENTRY_CLI_PACKAGE_PATH="$RESOLVED_PATH/bin/sentry-cli"

--- a/packages/core/scripts/sentry-xcode.sh
+++ b/packages/core/scripts/sentry-xcode.sh
@@ -27,9 +27,10 @@ if [[ "$SOURCEMAP_FILE" != /* ]]; then
 fi
 
 if [ -z "$SENTRY_CLI_EXECUTABLE" ]; then
-  # Try standard resolution safely
+  # Resolve from @sentry/react-native so package managers with isolated dependencies
+  # can find the transitive @sentry/cli dependency.
   RESOLVED_PATH=$(
-    "$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/cli/package.json'))" 2>/dev/null
+    "$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/cli/package.json', { paths: [require.resolve('@sentry/react-native/package.json')] }))" 2>/dev/null
   ) || true
   if [ -n "$RESOLVED_PATH" ]; then
     SENTRY_CLI_PACKAGE_PATH="$RESOLVED_PATH/bin/sentry-cli"

--- a/packages/core/sentry.gradle.kts
+++ b/packages/core/sentry.gradle.kts
@@ -167,7 +167,13 @@ fun resolveSentryCliPackagePath(reactRoot: File): String {
     var resolvedCliPath: File? = null
     try {
         val process =
-            ProcessBuilder(listOf("node", "--print", "require.resolve('@sentry/cli/package.json')"))
+            ProcessBuilder(
+                listOf(
+                    "node",
+                    "--print",
+                    "require.resolve('@sentry/cli/package.json', { paths: [require.resolve('@sentry/react-native/package.json')] })",
+                ),
+            )
                 .directory(rootDir)
                 .start()
         val output =

--- a/packages/core/test/scripts/sentry-cli-resolution.test.ts
+++ b/packages/core/test/scripts/sentry-cli-resolution.test.ts
@@ -1,0 +1,25 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CORE_DIR = path.resolve(__dirname, '../..');
+const RELATIVE_SENTRY_CLI_RESOLVER =
+  "require.resolve('@sentry/cli/package.json', { paths: [require.resolve('@sentry/react-native/package.json')] })";
+
+describe('sentry-cli resolution', () => {
+  it('resolves @sentry/cli relative to @sentry/react-native on Android', () => {
+    const gradleScript = fs.readFileSync(path.join(CORE_DIR, 'sentry.gradle.kts'), 'utf8');
+
+    expect(gradleScript).toContain(RELATIVE_SENTRY_CLI_RESOLVER);
+  });
+
+  it('resolves @sentry/cli relative to @sentry/react-native on iOS', () => {
+    const xcodeScript = fs.readFileSync(path.join(CORE_DIR, 'scripts', 'sentry-xcode.sh'), 'utf8');
+    const xcodeDebugFilesScript = fs.readFileSync(
+      path.join(CORE_DIR, 'scripts', 'sentry-xcode-debug-files.sh'),
+      'utf8',
+    );
+
+    expect(xcodeScript).toContain(RELATIVE_SENTRY_CLI_RESOLVER);
+    expect(xcodeDebugFilesScript).toContain(RELATIVE_SENTRY_CLI_RESOLVER);
+  });
+});


### PR DESCRIPTION
## Summary

- resolve `@sentry/cli` from `@sentry/react-native`'s package location in the Android Gradle integration
- use the same dependency-relative resolver in both iOS Xcode upload scripts
- add a focused test that guards the resolver expression across Android and iOS scripts

## Why

Package managers with isolated dependency layouts, such as pnpm, may not make `@sentry/cli` directly resolvable from the app's native project directory even though it is available as a dependency of `@sentry/react-native`. Resolving with `{ paths: [require.resolve('@sentry/react-native/package.json')] }` lets Node resolve the CLI from the React Native SDK dependency graph before falling back to the existing pnpm shim parsing.

## Validation

- `bash -n packages/core/scripts/sentry-xcode.sh`
- `bash -n packages/core/scripts/sentry-xcode-debug-files.sh`
- `git diff --check`
- verified the new resolver returns the pnpm store `sentry-cli` path in a pnpm React Native app where plain `require.resolve('@sentry/cli/package.json')` fails