### PR TITLE
chore(ci): Pin all GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -144,24 +144,24 @@ jobs:
       - name: Build
         run: yarn build
       - name: Archive dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: packages/core/dist
       - name: Archive ts3.8
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ts3.8
           path: packages/core/ts3.8
       - name: Archive Expo Plugin
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: expo-plugin
           path: packages/core/plugin/build
       - name: Pack
         run: yarn build:tarball
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ github.sha }}
           path: |
@@ -179,7 +179,7 @@ jobs:
         with:
           node-version: 18
       - name: Download tarball artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ github.sha }}
           path: artifacts
@@ -268,12 +268,12 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Download dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: packages/core/dist
       - name: Download ts3.8
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ts3.8
           path: packages/core/ts3.8
@@ -299,12 +299,12 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Download dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: packages/core/dist
       - name: Download Expo Plugin
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: expo-plugin
           path: packages/core/plugin/build
@@ -328,7 +328,7 @@ jobs:
       - name: Install Dependencies
         run: yarn install
       - name: Download dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: packages/core/dist

--- a/.github/workflows/cancel-pr-workflows.yml
+++ b/.github/workflows/cancel-pr-workflows.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel in-progress workflow runs
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment on PR to notify of changes in high risk files
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           high_risk_code: ${{ needs.files-changed.outputs.high_risk_code_files }}
         with:

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -43,7 +43,7 @@ jobs:
           node-version: 18
           cache: 'yarn'
           cache-dependency-path: yarn.lock
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: "adopt"

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -79,7 +79,7 @@ jobs:
       needs_sample_expo: ${{ steps.evaluate.outputs.needs_sample_expo }}
       needs_web: ${{ steps.evaluate.outputs.needs_web }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Detect changed paths
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         with:
           java-version: '17'
@@ -113,7 +113,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' }}
         with:
           ruby-version: '3.3.0'
@@ -130,7 +130,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         run: yarn build
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         id: app-plain-cache
         with:
@@ -325,7 +325,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         with:
           java-version: '17'
@@ -348,7 +348,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         run: yarn install
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' }}
         with:
           ruby-version: '3.3.0'
@@ -363,7 +363,7 @@ jobs:
 
       - name: Upload App
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.build-type == 'production' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-app-package
           path: dev-packages/e2e-tests/RnDiffApp.ap*
@@ -371,7 +371,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() && steps.platform-check.outputs.skip != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: rn-build-logs-${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}
           path: dev-packages/e2e-tests/react-native-versions/${{ matrix.rn-version }}/RnDiffApp/ios/*.log
@@ -436,7 +436,7 @@ jobs:
 
       - name: Download App Package
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.build-type == 'production' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-app-package
           path: dev-packages/e2e-tests
@@ -457,7 +457,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         with:
           java-version: '17'
@@ -536,7 +536,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() && steps.platform-check.outputs.skip != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-logs
           path: |

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install SDK JS Dependencies
         run: yarn install
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           ruby-version: '3.3.0'
         env:
@@ -112,7 +112,7 @@ jobs:
 
       - uses: ./.github/actions/disk-cleanup
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/release-comment-issues.yml
+++ b/.github/workflows/release-comment-issues.yml
@@ -32,7 +32,7 @@ jobs:
           && !contains(steps.get_version.outputs.version, '-beta.')
           && !contains(steps.get_version.outputs.version, '-alpha.')
           && !contains(steps.get_version.outputs.version, '-rc.')
-        uses: getsentry/release-comment-issues-gh-action@v1
+        uses: getsentry/release-comment-issues-gh-action@52e08022ca721e701515ede89edd224b63b180eb # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -64,7 +64,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           working-directory: samples/expo
           ruby-version: '3.3.0' # based on what is used in the sample
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-sample-expo-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-logs
           path: samples/expo/ios/*.log
@@ -161,7 +161,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-sample-expo-android-${{ matrix.build-type }}-logs
           path: samples/expo/android/*.log

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -73,7 +73,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           working-directory: ${{ env.REACT_NATIVE_SAMPLE_PATH }}
           ruby-version: '3.3.0' # based on what is used in the sample
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload iOS APP
         if: ${{ matrix.rn-architecture == 'new' && matrix.build-type == 'production' && matrix.ios-use-frameworks == 'no-frameworks' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sample-rn-${{ matrix.rn-architecture }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-ios
           path: ${{ env.IOS_APP_ARCHIVE_PATH }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-sample-${{ matrix.rn-architecture }}-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-logs
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/ios/*.log
@@ -164,7 +164,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '17'
           distribution: 'adopt'
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload Android APK
         if: ${{ matrix.rn-architecture == 'new' && matrix.build-type == 'production' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sample-rn-${{ matrix.rn-architecture }}-${{ matrix.build-type }}-android
           path: ${{ env.ANDROID_APP_ARCHIVE_PATH }}
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-sample-${{ matrix.rn-architecture }}-android-${{ matrix.build-type }}-no-frameworks-logs
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/android/*.log
@@ -239,7 +239,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           working-directory: samples/react-native-macos
           ruby-version: '3.3.0' # based on what is used in the sample
@@ -283,7 +283,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-sample-legacy-macos-${{ matrix.build-type }}-no-frameworks-logs
           path: samples/react-native-macos/macos/*.log
@@ -307,7 +307,7 @@ jobs:
           version: ${{env.MAESTRO_VERSION}}
 
       - name: Download iOS App Archive
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sample-rn-new-production-no-frameworks-ios
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}
@@ -387,7 +387,7 @@ jobs:
           version: ${{env.MAESTRO_VERSION}}
 
       - name: Download Android APK
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: sample-rn-new-production-android
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}

--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -108,7 +108,7 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: yarn.lock
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           working-directory: ${{ env.REACT_NATIVE_SAMPLE_PATH }}
           ruby-version: '3.3.0'
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: size-analysis-ios-logs
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/ios/xcodebuild-size-analysis.log

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1
         with:
           working-directory: samples/react-native
           ruby-version: '3.3.0' # based on what is used in the sample
@@ -71,7 +71,7 @@ jobs:
           bundle exec fastlane ios upload_react_native_sample_to_testflight
 
       - name: Upload Xcode Archive
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sentry-react-native-sample-xcode-archive-for-testflight
           path: samples/react-native/sentryreactnativesample.xcarchive

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -13,7 +13,7 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-android.sh
           name: Android SDK
@@ -22,7 +22,7 @@ jobs:
   cocoa:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-cocoa.sh
           name: Cocoa SDK
@@ -31,7 +31,7 @@ jobs:
   javascript:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-javascript.sh
           name: JavaScript SDK
@@ -40,7 +40,7 @@ jobs:
   wizard:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-wizard.sh
           name: Wizard
@@ -50,7 +50,7 @@ jobs:
   cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-cli.sh
           name: CLI
@@ -59,7 +59,7 @@ jobs:
   bundler-plugins:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-bundler-plugins.sh
           name: Bundler Plugins
@@ -68,7 +68,7 @@ jobs:
   sample-rn:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-rn.sh
           name: React Native
@@ -79,7 +79,7 @@ jobs:
   maestro:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-maestro.sh
           name: Maestro
@@ -90,7 +90,7 @@ jobs:
   sentry-android-gradle-plugin:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/updater@v3
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           path: scripts/update-sentry-android-gradle-plugin.sh
           name: Sentry Android Gradle Plugin


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

Pin all remaining GitHub Actions references from mutable version tags (e.g. `@v7`) to full commit SHAs with the version preserved as a trailing comment (e.g. `@043fb46d…  # v7`).

**Actions pinned:**

| Action | Version | Occurrences |
|--------|---------|-------------|
| `actions/upload-artifact` | v7 | 14 |
| `actions/download-artifact` | v8 | 8 |
| `actions/github-script` | v9 | 2 |
| `actions/setup-java` | v5 | 5 |
| `actions/checkout` | v6 | 1 |
| `actions/cache` | v5 | 1 |
| `ruby/setup-ruby` | v1 | 6 |
| `getsentry/release-comment-issues-gh-action` | v1 | 1 |
| `getsentry/github-workflows/updater` | v3 | 9 |

## :bulb: Motivation and Context

Reduces supply chain risk by ensuring CI workflows are pinned to immutable references. Mutable tags can be force-pushed by upstream maintainers (or attackers who compromise their accounts), silently changing the code that runs in our CI.

Part of the cross-SDK dependency pinning audit — see https://github.com/getsentry/sentry-react-native/issues/6239.

Closes https://github.com/getsentry/sentry-react-native/issues/6244.

## :green_heart: How did you test it?

Each SHA was verified to resolve to the same commit as the mutable tag it replaced:
- Lightweight tags: SHA taken directly from the tag ref
- Annotated tags (e.g. `actions/github-script@v9`): dereferenced through the tag object to the underlying commit
- Branch refs (e.g. `ruby/setup-ruby@v1`): resolved to the current branch HEAD

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps