### PR TITLE
chore(deps): bump jwt in /samples/react-native

### DIFF
--- a/samples/react-native/Gemfile.lock
+++ b/samples/react-native/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
-    base64 (0.2.0)
+    base64 (0.3.0)
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     claide (1.1.0)
@@ -224,7 +224,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
     json (2.7.3)
-    jwt (2.9.3)
+    jwt (2.10.3)
       base64
     logger (1.7.0)
     memoist (0.16.2)


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Bump `jwt` gem from 2.9.3 to 2.10.3 in the React Native sample app's `Gemfile.lock`.

## :bulb: Motivation and Context
Fixes [Dependabot alert #546](https://github.com/getsentry/sentry-react-native/security/dependabot/546) — high severity empty-key HMAC bypass vulnerability (CVE-2026-44351).

The macos sample and performance-tests were already bumped in #6247 and #6246.

## :green_heart: How did you test it?
`bundle update jwt` resolved successfully. This only affects the sample app's transitive dependency.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps