### PR TITLE
fix(core): Exclude additional server-only modules from native bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixes
 
+- Exclude additional server-only modules (`express`, `postgresjs`, `requestdata`, `consola`, `spanStreaming`) from native bundles ([#6263](https://github.com/getsentry/sentry-react-native/pull/6263))
 - Enable fetch instrumentation when Expo SDK 56's native `expo/fetch` is active ([#6226](https://github.com/getsentry/sentry-react-native/pull/6226))
 
 ### Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@
 
 - Exclude additional server-only modules (`express`, `postgresjs`, `requestdata`, `consola`, `spanStreaming`) from native bundles ([#6263](https://github.com/getsentry/sentry-react-native/pull/6263))
 - Enable fetch instrumentation when Expo SDK 56's native `expo/fetch` is active ([#6226](https://github.com/getsentry/sentry-react-native/pull/6226))
-
-### Fixes
-
 - Resolve `sentry-cli` in isolated dependency layouts ([#6242](https://github.com/getsentry/sentry-react-native/pull/6242))
 
 ### Internal

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -364,7 +364,7 @@ export function withSentryFeedbackResolver(config: MetroConfig, includeWebFeedba
  * the `moduleName` will be `./integrations/mcp-server/index.js`.
  */
 const SERVER_ONLY_MODULE_RE =
-  /\/(mcp-server|integrations\/http|tracing\/(vercel-ai|openai|anthropic-ai|google-genai|langchain|langgraph)|utils\/ai)(\/|$)/;
+  /\/(mcp-server|integrations\/(http|express|postgresjs|requestdata|consola|spanStreaming)|tracing\/(vercel-ai|openai|anthropic-ai|google-genai|langchain|langgraph)|utils\/ai)(\/|\.js|$)/;
 
 function isFromSentryCore(originModulePath: string): boolean {
   return originModulePath.includes('@sentry/core');

--- a/packages/core/test/tools/metroconfig.test.ts
+++ b/packages/core/test/tools/metroconfig.test.ts
@@ -622,6 +622,11 @@ describe('metroconfig', () => {
     describe.each([
       ['./integrations/mcp-server/index.js'],
       ['./integrations/http/index.js'],
+      ['./integrations/express.js'],
+      ['./integrations/postgresjs.js'],
+      ['./integrations/requestdata.js'],
+      ['./integrations/consola.js'],
+      ['./integrations/spanStreaming.js'],
       ['./tracing/openai/index.js'],
       ['./tracing/anthropic-ai/index.js'],
       ['./tracing/google-genai/index.js'],


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

Expands the Metro resolver's `SERVER_ONLY_MODULE_RE` regex to exclude additional server-only modules from Android/iOS bundles:

- `integrations/express`
- `integrations/postgresjs`
- `integrations/requestdata`
- `integrations/consola`
- `integrations/spanStreaming`

Also fixes the regex terminator from `(\/|$)` to `(\/|\.js|$)` so it correctly matches single-file modules like `postgresjs.js` (not just directory-style paths like `mcp-server/`).

## :bulb: Motivation and Context

Related: #6262


## :green_heart: How did you test it?

- Added test cases for all 5 new modules (20 new tests) — all pass
- Verified via source map analysis that all listed modules are excluded from the Android bundle
- Confirmed bundle size reduction from 5.09 MB → 4.31 MB in the sample app


## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
