### PR TITLE
docs(replay): clarify fast renderer option docs

### DIFF
--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -75,7 +75,7 @@ export interface MobileReplayOptions {
    * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing
    * interruptions and visual lag.
    *
-   * - Note: This flag can only be used together with `enableExperimentalViewRenderer` with up to 20% faster render times.
+   * - Note: This flag only has an effect when `enableViewRendererV2` is enabled, with up to 20% faster render times.
    * - Experiment: This is an experimental feature and is therefore disabled by default.
    *
    * @default false


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This updates the `enableFastViewRendering` JSDoc to reference `enableViewRendererV2` instead of the deprecated `enableExperimentalViewRenderer`.
The runtime behavior is unchanged; this only clarifies the current Mobile Replay iOS option pairing.

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous comment suggested that `enableFastViewRendering` should be used with `enableExperimentalViewRenderer`, but that option is deprecated in favor of `enableViewRendererV2`.
This makes the documentation match the current default option pairing used by Mobile Replay on iOS.

## :green_heart: How did you test it?
- `git diff --check`
Not run:
- `yarn workspace @sentry/react-native lint:fmt` could not complete because this checkout does not have a `node_modules` install state.
- Full build/test suite, because this is a JSDoc-only change.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
None
