### PR TITLE
fix(ci): Support version catalog in android SDK version check

### DIFF
--- a/scripts/check-android-sdk-mismatch.js
+++ b/scripts/check-android-sdk-mismatch.js
@@ -9,35 +9,49 @@ const createSectionWarning = (title, content, icon = '❌') => {
   return `### ${icon} ${title}\n\n${content}\n`;
 };
 
-/**
- * Fetches the SDK version from gradle.properties in the gradle plugin GitHub repo.
- * The file contains a line like: sdk_version = X.Y.Z
- */
-function fetchBundledSentryAndroidVersion(gradlePluginVersion) {
+function fetchFileContent(url) {
   return new Promise((resolve, reject) => {
-    const url = `https://raw.githubusercontent.com/getsentry/sentry-android-gradle-plugin/${gradlePluginVersion}/plugin-build/gradle.properties`;
-
     https
       .get(url, res => {
         if (res.statusCode !== 200) {
-          reject(new Error(`Could not fetch gradle.properties for version ${gradlePluginVersion}`));
+          reject(new Error(`HTTP ${res.statusCode} for ${url}`));
           return;
         }
 
         let data = '';
         res.on('data', chunk => (data += chunk));
-        res.on('end', () => {
-          // Look for: sdk_version = X.Y.Z
-          const versionMatch = data.match(/sdk_version\s*=\s*(\S+)/);
-          if (versionMatch) {
-            resolve(versionMatch[1]);
-          } else {
-            reject(new Error(`Could not find sdk_version in gradle.properties`));
-          }
-        });
+        res.on('end', () => resolve(data));
       })
       .on('error', reject);
   });
+}
+
+/**
+ * Fetches the SDK version from the gradle plugin GitHub repo.
+ *
+ * Checks gradle.properties first (sdk_version = X.Y.Z, pre-6.10.0),
+ * then falls back to gradle/libs.versions.toml (sentry = "X.Y.Z", 6.10.0+).
+ */
+function fetchBundledSentryAndroidVersion(gradlePluginVersion) {
+  const base = `https://raw.githubusercontent.com/getsentry/sentry-android-gradle-plugin/${gradlePluginVersion}`;
+
+  return fetchFileContent(`${base}/plugin-build/gradle.properties`)
+    .then(data => {
+      const match = data.match(/sdk_version\s*=\s*(\S+)/);
+      if (match) {
+        return match[1];
+      }
+      throw new Error('sdk_version not found');
+    })
+    .catch(() =>
+      fetchFileContent(`${base}/gradle/libs.versions.toml`).then(data => {
+        const match = data.match(/^sentry\s*=\s*"([^"]+)"/m);
+        if (match) {
+          return match[1];
+        }
+        throw new Error(`Could not find sentry-android version for gradle plugin ${gradlePluginVersion}`);
+      }),
+    );
 }
 
 module.exports = async function ({ fail, warn, __, ___, danger }) {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

The Danger check `check-android-sdk-mismatch.js` fetches the bundled `sentry-android` version from the gradle plugin repo by reading `plugin-build/gradle.properties`. Starting with gradle plugin 6.10.0, the `sdk_version` property was moved to `gradle/libs.versions.toml` (Gradle version catalog), causing the check to fail with:

> Could not find sdk_version in gradle.properties

This PR extracts an `fetchFileContent` helper and chains a TOML fallback when `gradle.properties` doesn't contain `sdk_version`.

## :bulb: Motivation and Context

The warning appeared on #6275 (gradle plugin bump to 6.11.0), masking the actual version mismatch info that the check is meant to surface.

## :green_heart: How did you test it?

Tested with https://github.com/getsentry/sentry-react-native/pull/6285

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
