### PR TITLE
fix(deps): Resolve shell-quote to >=1.8.4 (Dependabot #547)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,8 @@
     "postcss": "^8.5.10",
     "socks": "^2.8.8",
     "@appium/support@npm:7.0.6/uuid": "^13.0.1",
-    "node-simctl@npm:8.1.6/uuid": "^13.0.1"
+    "node-simctl@npm:8.1.6/uuid": "^13.0.1",
+    "shell-quote": "^1.8.4"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30236,17 +30236,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3, shell-quote@npm:^1.7.2, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 550dd84e677f8915eb013d43689c80bb114860649ec5298eb978f40b8f3d4bc4ccb072b82c094eb3548dc587144bb3965a8676f0d685c1cf4c40b5dc27166242
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.6.1, shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.1":
-  version: 1.8.1
-  resolution: "shell-quote@npm:1.8.1"
-  checksum: 5f01201f4ef504d4c6a9d0d283fa17075f6770bfbe4c5850b074974c68062f37929ca61700d95ad2ac8822e14e8c4b990ca0e6e9272e64befd74ce5e19f0736b
+"shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 082dc836baa8ade01144ee3068af487ea45ba570ea6ab13a5eddc11ab16a976b8857b51ef2caf7dc9a1e173ff0aea685b8f78b4f6f5a0a1ef24c7b17c51350e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description

Adds a Yarn `resolutions` entry to force all transitive `shell-quote` instances to `>=1.8.4`, fixing the critical command injection vulnerability ([Dependabot #547](https://github.com/getsentry/sentry-react-native/security/dependabot/547)).

`shell-quote`'s `quote()` did not escape newlines in object `.op` values, allowing shell command injection. The fix replaces per-character escaping with strict allowlist validation.

## :bulb: Motivation and Context

`shell-quote` is not a direct dependency — it's pulled in transitively by dev/test tooling (`@react-native-community/cli-tools`, `detox`, `npm-run-all2`, `react-devtools-core`, `launch-editor`, `@appium/support`). None of these ship in the published SDK, so end users are not affected. Resolving it clears the critical Dependabot alert.

## :green_heart: How did you test it?

- `yarn why shell-quote` confirms all instances resolve to `1.8.4`
- `yarn build` passes
- `yarn test` passes

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps