### PR TITLE
fix: update React Native repo URL to new GitHub org

### DIFF
--- a/scripts/update-rn.sh
+++ b/scripts/update-rn.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 tagPrefix='v' # wizard has a prefix in the repo, but the package.json doesn't have that - we must align
-repo="https://github.com/facebook/react-native.git"
+repo="https://github.com/react/react-native.git"
 packages=('react-native')
 
 . $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Updates the React Native repository URL in `scripts/update-rn.sh` from `facebook/react-native` to `react/react-native` following the [repo migration](https://reactnative.dev/blog/2026/06/11/react-native-0.86#a-new-home-for-react-native).

GitHub auto-redirects work, but the updater workflow should reference the canonical URL.

## :bulb: Motivation and Context

The React Native repository moved to the `react` GitHub organization as part of the transition to the React Foundation. The old URL still works via redirect, but the dependency updater workflow (`Update Dependencies`) fetches tags from this repo — using the canonical URL avoids relying on redirects.

Relates to #6267.

## :green_heart: How did you test it?

One-line change to a URL, verified the new URL resolves correctly.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps