### PR TITLE
fix(ci): Update renamed @sentry-internal/* packages in JS updater script

### DIFF
--- a/scripts/update-javascript.sh
+++ b/scripts/update-javascript.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 tagPrefix=''
 repo="https://github.com/getsentry/sentry-javascript.git"
-packages=('@sentry/browser' '@sentry/core' '@sentry/react' '@sentry-internal/typescript')
-packages+=('@sentry-internal/eslint-plugin-sdk')
+packages=('@sentry/browser' '@sentry/core' '@sentry/react' '@sentry/typescript')
+packages+=('@sentry/eslint-plugin-sdk')
 
 . $(dirname "$0")/update-package-json.sh


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Updates `scripts/update-javascript.sh` to use the new `@sentry/*` package names after the upstream rename in sentry-javascript 10.58.0:

- `@sentry-internal/typescript` → `@sentry/typescript`
- `@sentry-internal/eslint-plugin-sdk` → `@sentry/eslint-plugin-sdk`

## :bulb: Motivation and Context

The [JavaScript SDK dependency updater is failing on main](https://github.com/getsentry/sentry-react-native/actions/runs/27599289677/job/81597002866) because `@sentry-internal/eslint-plugin-sdk@npm:10.58.0` no longer exists — the package was renamed to `@sentry/eslint-plugin-sdk` in [getsentry/sentry-javascript#21371](https://github.com/getsentry/sentry-javascript/pull/21371).

## :green_heart: How did you test it?

Verified the new package names match the upstream rename PR.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps