### PR TITLE
fix(deps): bump js-yaml from ^4.1.1 to ^4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@yarnpkg/parsers@npm:3.0.0-rc.46/js-yaml": "^3.14.2",
     "cosmiconfig@npm:5.2.1/js-yaml": "^3.14.2",
     "front-matter@npm:4.0.2/js-yaml": "^3.14.2",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "detox@npm:20.46.0/ajv": "^8.18.0",
     "@expo/fingerprint@npm:0.6.1/minimatch": "^3.1.3",
     "@lerna/create@npm:8.1.8/minimatch": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21492,14 +21492,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  checksum: 86bd35548a0c19cd1f5861147c09aa1f52eb0fc9464f34023524d22bbe079c62c30fd00750e63f632e8d12c12ad36ea0dd1e6bec5171c492ecad433d8db295eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
Bumps the `js-yaml` resolution from `^4.1.1` to `^4.2.0` to fix a medium-severity quadratic-complexity DoS vulnerability in merge key handling via repeated aliases.

Resolves Dependabot alert [#554](https://github.com/getsentry/sentry-react-native/security/dependabot/554).

## :bulb: Motivation and Context
`js-yaml` versions before 4.2.0 are vulnerable to quadratic-complexity DoS when parsing YAML with repeated aliases in merge keys. Bumping the resolution range ensures all transitive consumers resolve to a patched version.

## :green_heart: How did you test it?
- `yarn install` completes successfully
- CI will validate no regressions

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps