### PR TITLE
test(core): Resolve @sentry/* to CJS builds in Jest

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -15,6 +15,13 @@ module.exports = {
     ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  // As of v10.58.0 the JS SDK packages expose a `react-native` export condition that points at
+  // their ESM build. The `react-native` Jest preset's test environment sets
+  // `customExportConditions = ['require', 'react-native']`, so Jest resolves that condition and
+  // loads untransformed ESM (including transitive subpaths like `@sentry/core/browser`), failing
+  // with "Unexpected token 'export'". Use a test environment that drops the `react-native`
+  // condition so these packages resolve to their CJS builds, as they did before the condition.
+  testEnvironment: '<rootDir>/test/RNTestEnvironment.js',
   testPathIgnorePatterns: ['<rootDir>/test/e2e/', '<rootDir>/test/tools/', '<rootDir>/test/react-native/versions'],
   testMatch: ['**/*.test.(ts|tsx)'],
 };

--- a/packages/core/test/RNTestEnvironment.js
+++ b/packages/core/test/RNTestEnvironment.js
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+const ReactNativeEnv = require('react-native/jest/react-native-env');
+
+// Extends the `react-native` preset's test environment but drops the `react-native` export
+// condition. Since v10.58.0 the JS SDK packages expose a `react-native` condition pointing at
+// their ESM build; resolving it makes Jest load untransformed ESM. Dropping it makes them resolve
+// to their CJS builds (via the `require` condition), restoring the pre-10.58.0 behaviour.
+module.exports = class extends ReactNativeEnv {
+  customExportConditions = ['require'];
+};


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Stacked on top of #6296. As of JS SDK **v10.58.0** the `@sentry/*` packages expose a `react-native` export condition that points at their **ESM** build. The `react-native` Jest preset's test environment sets `customExportConditions = ['require', 'react-native']`, so Jest resolves that condition and loads untransformed ESM — including transitive subpaths like `@sentry/core/browser` — failing with:

```
SyntaxError: Unexpected token 'export'
  node_modules/@sentry/core/build/esm/index.js:1
  export { registerSpanErrorInstrumentation } from './tracing/errors.js';
```

This broke the `Test` job on #6296 (94 suites failed). It is **not** a runtime/user-facing issue: app builds resolve `@sentry/*` through Metro, which is the intended consumer of the `react-native` condition and handles ESM natively. Only Jest's Node test environment is affected.

The fix adds a custom test environment (`test/RNTestEnvironment.js`) that extends the `react-native` preset's environment but drops the `react-native` export condition, so these packages resolve to their CJS builds — exactly as they did before 10.58.0.

## :bulb: Motivation and Context

The 10.58.0 bump (#6296) is otherwise correct, but the new export condition makes Jest load ESM it can't parse. This restores green tests on the bump. Keeping it as a separate PR because the updater branch is force-pushed on every regeneration.

## :green_heart: How did you test it?

- Reproduced the failure locally on the #6296 branch after `yarn install`.
- After the fix: full suite green — **122/122 suites, 1617/1617 tests pass**.
- `lint:oxlint` (0 errors) and `lint:fmt` pass.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

Merge #6296 first (or retarget this PR to `main` after #6296 lands), since the updater branch is regenerated/force-pushed by the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)