### PR TITLE
fix(android): Prevent breadcrumb loss from numeric timestamp ClassCastException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Record XHR request/response headers and (optionally) bodies in Mobile Session Replay. Opt in via `mobileReplayIntegration` with `networkDetailAllowUrls` to capture headers; set `networkCaptureBodies: true` to also capture bodies. Other options: `networkDetailDenyUrls`, `networkRequestHeaders`, `networkResponseHeaders`. Authorization-like headers are always stripped, bodies are capped at ~150 KB. Covers XHR-based clients like `axios`; fetch will follow. See [Network Details](https://docs.sentry.io/platforms/react-native/session-replay/#network-details) for details. ([#6288](https://github.com/getsentry/sentry-react-native/pull/6288))
 - Warn during dev builds when multiple versions of Sentry JS SDK are detected ([#6269](https://github.com/getsentry/sentry-react-native/pull/6269))
 
+### Fixes
+
+- Fix Android `ClassCastException` when syncing breadcrumbs with a numeric timestamp to the native scope ([#6306](https://github.com/getsentry/sentry-react-native/issues/6306))
+
 ### Dependencies
 
 - Bump Android SDK from v8.43.1 to v8.43.2 ([#6273](https://github.com/getsentry/sentry-react-native/pull/6273))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixes
 
-- Fix Android `ClassCastException` when syncing breadcrumbs with a numeric timestamp to the native scope ([#6306](https://github.com/getsentry/sentry-react-native/issues/6306))
+- Fix Android `ClassCastException` when syncing breadcrumbs with a numeric timestamp to the native scope ([#6308](https://github.com/getsentry/sentry-react-native/pull/6308))
 
 ### Dependencies
 

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryBreadcrumbTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryBreadcrumbTest.kt
@@ -69,6 +69,21 @@ class RNSentryBreadcrumbTest {
     }
 
     @Test
+    fun parsesNumericTimestampWithoutDiscardingBreadcrumb() {
+        // The JS SDK stamps `timestamp` as a number (epoch seconds), which arrives over the bridge
+        // as a Double. The native deserializer expects an ISO-8601 string, so without normalization
+        // this throws a ClassCastException and the whole breadcrumb is discarded (see #6306).
+        val map = JavaOnlyMap()
+        map.putString("message", "testMessage")
+        map.putDouble("timestamp", 1_700_000_000.5)
+        val actual = RNSentryBreadcrumb.fromMap(map, logger)
+        assertEquals("testMessage", actual.message)
+        assertEquals("react-native", actual.origin)
+        assertNotNull(actual.timestamp)
+        assertEquals(1_700_000_000_500L, actual.timestamp.time)
+    }
+
+    @Test
     fun reactNativeForMissingOrigin() {
         val map =
             JavaOnlyMap.of(

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryBreadcrumb.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryBreadcrumb.java
@@ -4,9 +4,11 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 import io.sentry.Breadcrumb;
+import io.sentry.DateUtils;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.util.MapObjectReader;
+import java.util.Date;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,7 +44,18 @@ public final class RNSentryBreadcrumb {
   @NotNull
   public static Breadcrumb fromMap(ReadableMap from, @NotNull ILogger logger) {
     try {
-      final @NotNull MapObjectReader reader = new MapObjectReader(toDeepHashMap(from));
+      final @NotNull Map<String, Object> map = toDeepHashMap(from);
+
+      // The JS SDK stamps `timestamp` as a number (epoch seconds), which arrives over the bridge as
+      // a Double. The native Breadcrumb deserializer expects an ISO-8601 string, so normalize it
+      // before deserializing to avoid a ClassCastException.
+      final @Nullable Object timestamp = map.get("timestamp");
+      if (timestamp instanceof Number) {
+        final long millis = (long) (((Number) timestamp).doubleValue() * 1000);
+        map.put("timestamp", DateUtils.getTimestamp(new Date(millis)));
+      }
+
+      final @NotNull MapObjectReader reader = new MapObjectReader(map);
       final @NotNull Breadcrumb breadcrumb =
           new Breadcrumb.Deserializer().deserialize(reader, logger);
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description
On Android, every breadcrumb synced from JS to the native scope was being discarded since `8.14.0`.

The JS SDK stamps `breadcrumb.timestamp` as a **number** (epoch seconds), which arrives over the bridge as a `java.lang.Double`. Since #6261, `RNSentryBreadcrumb.fromMap` feeds the map to the native `Breadcrumb.Deserializer`, which reads `timestamp` via `MapObjectReader.nextDateOrNull` → `nextStringOrNull` and requires an ISO-8601 **string**. A `Double` throws `ClassCastException`, the breadcrumb is dropped, and an empty fallback (only `origin = "react-native"`) is returned — so native/tombstone crash reports lose breadcrumb context.

```
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.String
	at io.sentry.util.MapObjectReader.nextStringOrNull(MapObjectReader.java:321)
	at io.sentry.util.MapObjectReader.nextDateOrNull(MapObjectReader.java:146)
	at io.sentry.Breadcrumb$Deserializer.deserialize(Breadcrumb.java:872)
	at io.sentry.react.RNSentryBreadcrumb.fromMap(RNSentryBreadcrumb.java:47)
```

This PR normalizes a numeric `timestamp` to an ISO-8601 string before deserializing, preserving millisecond precision. Existing behavior is unchanged for ISO-string and missing timestamps. iOS is unaffected (Cocoa's `initWithDictionary:` is lenient).

## :bulb: Motivation and Context
Fixes #6306. Regression introduced in `8.14.0` by #6261 ("Use native SDK deserializers for User and Breadcrumb").

## :green_heart: How did you test it?
Added `RNSentryBreadcrumbTest.parsesNumericTimestampWithoutDiscardingBreadcrumb`, which feeds a numeric timestamp and asserts the breadcrumb survives with its fields and correct timestamp. Verified it **fails** (`message` is `null`) without the fix and **passes** with it. Full Android unit suite green.

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
A follow-up PR will fix a separate, pre-existing issue surfaced during this investigation: user `geo` is JSON-stringified before crossing the bridge, so the native deserializer drops it (and on Android, the whole user). That fix touches the JS layer and coordinates with #6289.
