### PR TITLE
feat(core): Use react-native-quick-base64 for envelope encoding when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 
 - Add `nativeStackAndroid` support to `NativeLinkedErrors`, capturing the JVM stack trace of rejected native module promises as a linked exception ([#6278](https://github.com/getsentry/sentry-react-native/pull/6278))
 - Record XHR request/response headers and (optionally) bodies in Mobile Session Replay. Opt in via `mobileReplayIntegration` with `networkDetailAllowUrls` to capture headers; set `networkCaptureBodies: true` to also capture bodies. Other options: `networkDetailDenyUrls`, `networkRequestHeaders`, `networkResponseHeaders`. Authorization-like headers are always stripped, bodies are capped at ~150 KB. Covers XHR-based clients like `axios`; fetch will follow. See [Network Details](https://docs.sentry.io/platforms/react-native/session-replay/#network-details) for details. ([#6288](https://github.com/getsentry/sentry-react-native/pull/6288))
-- Use `react-native-quick-base64` for envelope encoding when installed, providing a ~10x speedup over the bundled JS encoder. Install it alongside `@sentry/react-native` to opt in; the SDK falls back to the JS encoder if the package is absent ([#4884](https://github.com/getsentry/sentry-react-native/issues/4884))
+- Use the optional `react-native-quick-base64` peer dependency for envelope base64 encoding when installed, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if the package is absent. ([#6314](https://github.com/getsentry/sentry-react-native/pull/6314))
 - Warn during dev builds when multiple versions of Sentry JS SDK are detected ([#6269](https://github.com/getsentry/sentry-react-native/pull/6269))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Features
+
+- Use the optional `react-native-quick-base64` peer dependency for envelope base64 encoding when installed, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if the package is absent. ([#6314](https://github.com/getsentry/sentry-react-native/pull/6314))
+
 ### Fixes
 
 - Remove unused `React/RCTTextView.h` import that broke iOS builds on React Native 0.87, where the header was removed as part of the legacy architecture cleanup ([#6322](https://github.com/getsentry/sentry-react-native/pull/6322))
@@ -30,7 +34,6 @@
 
 - Add `nativeStackAndroid` support to `NativeLinkedErrors`, capturing the JVM stack trace of rejected native module promises as a linked exception ([#6278](https://github.com/getsentry/sentry-react-native/pull/6278))
 - Record XHR request/response headers and (optionally) bodies in Mobile Session Replay. Opt in via `mobileReplayIntegration` with `networkDetailAllowUrls` to capture headers; set `networkCaptureBodies: true` to also capture bodies. Other options: `networkDetailDenyUrls`, `networkRequestHeaders`, `networkResponseHeaders`. Authorization-like headers are always stripped, bodies are capped at ~150 KB. Covers XHR-based clients like `axios`; fetch will follow. See [Network Details](https://docs.sentry.io/platforms/react-native/session-replay/#network-details) for details. ([#6288](https://github.com/getsentry/sentry-react-native/pull/6288))
-- Use the optional `react-native-quick-base64` peer dependency for envelope base64 encoding when installed, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if the package is absent. ([#6314](https://github.com/getsentry/sentry-react-native/pull/6314))
 - Warn during dev builds when multiple versions of Sentry JS SDK are detected ([#6269](https://github.com/getsentry/sentry-react-native/pull/6269))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 - Add `nativeStackAndroid` support to `NativeLinkedErrors`, capturing the JVM stack trace of rejected native module promises as a linked exception ([#6278](https://github.com/getsentry/sentry-react-native/pull/6278))
 - Record XHR request/response headers and (optionally) bodies in Mobile Session Replay. Opt in via `mobileReplayIntegration` with `networkDetailAllowUrls` to capture headers; set `networkCaptureBodies: true` to also capture bodies. Other options: `networkDetailDenyUrls`, `networkRequestHeaders`, `networkResponseHeaders`. Authorization-like headers are always stripped, bodies are capped at ~150 KB. Covers XHR-based clients like `axios`; fetch will follow. See [Network Details](https://docs.sentry.io/platforms/react-native/session-replay/#network-details) for details. ([#6288](https://github.com/getsentry/sentry-react-native/pull/6288))
+- Use `react-native-quick-base64` for envelope encoding when installed, providing a ~10x speedup over the bundled JS encoder. Install it alongside `@sentry/react-native` to opt in; the SDK falls back to the JS encoder if the package is absent ([#4884](https://github.com/getsentry/sentry-react-native/issues/4884))
 - Warn during dev builds when multiple versions of Sentry JS SDK are detected ([#6269](https://github.com/getsentry/sentry-react-native/pull/6269))
 
 ### Fixes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,7 +70,8 @@
   "peerDependencies": {
     "expo": ">=49.0.0",
     "react": ">=17.0.0",
-    "react-native": ">=0.65.0"
+    "react-native": ">=0.65.0",
+    "react-native-quick-base64": ">=3.0.0"
   },
   "dependencies": {
     "@sentry/babel-plugin-component-annotate": "5.3.0",
@@ -129,6 +130,9 @@
   },
   "peerDependenciesMeta": {
     "expo": {
+      "optional": true
+    },
+    "react-native-quick-base64": {
       "optional": true
     }
   }

--- a/packages/core/src/js/utils/base64.ts
+++ b/packages/core/src/js/utils/base64.ts
@@ -1,0 +1,56 @@
+import { debug } from '@sentry/core';
+
+import { base64StringFromByteArray } from '../vendor';
+
+type FromByteArray = (bytes: Uint8Array, urlSafe?: boolean) => string;
+
+let cachedEncoder: FromByteArray | null = null;
+let resolved = false;
+
+/**
+ * Resolves the base64 encoder once. If the optional peer dependency
+ * `react-native-quick-base64` is installed, its native JSI encoder is used
+ * (~10x faster than the pure-JS fallback). Otherwise the bundled JS encoder
+ * from `vendor/base64-js` is used.
+ *
+ * The resolution is cached so the require cost is paid at most once.
+ */
+function resolveEncoder(): FromByteArray {
+  if (resolved) {
+    return cachedEncoder ?? base64StringFromByteArray;
+  }
+  resolved = true;
+
+  try {
+    // Optional peer dependency — only loaded if the consumer installed it.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
+    const quickBase64 = require('react-native-quick-base64') as { fromByteArray?: FromByteArray };
+    if (quickBase64 && typeof quickBase64.fromByteArray === 'function') {
+      cachedEncoder = quickBase64.fromByteArray;
+      debug.log('Using react-native-quick-base64 for envelope encoding.');
+      return cachedEncoder;
+    }
+  } catch (_e) {
+    // Not installed — fall through to JS encoder.
+  }
+
+  cachedEncoder = base64StringFromByteArray;
+  return cachedEncoder;
+}
+
+/**
+ * Encode a byte array to a base64 string. Prefers the native
+ * `react-native-quick-base64` encoder when available, otherwise uses the
+ * bundled JS implementation.
+ */
+export function encodeToBase64(input: Uint8Array): string {
+  return resolveEncoder()(input);
+}
+
+/**
+ * @internal Test helper. Resets the cached encoder so the next call re-resolves.
+ */
+export function _resetBase64EncoderForTesting(): void {
+  cachedEncoder = null;
+  resolved = false;
+}

--- a/packages/core/src/js/utils/base64.ts
+++ b/packages/core/src/js/utils/base64.ts
@@ -9,9 +9,8 @@ let resolved = false;
 
 /**
  * Resolves the base64 encoder once. If the optional peer dependency
- * `react-native-quick-base64` is installed, its native JSI encoder is used
- * (~10x faster than the pure-JS fallback). Otherwise the bundled JS encoder
- * from `vendor/base64-js` is used.
+ * `react-native-quick-base64` is installed, its native JSI encoder is used.
+ * Otherwise the bundled JS encoder from `vendor/base64-js` is used.
  *
  * The resolution is cached so the require cost is paid at most once.
  */
@@ -26,6 +25,9 @@ function resolveEncoder(): FromByteArray {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
     const quickBase64 = require('react-native-quick-base64') as { fromByteArray?: FromByteArray };
     if (quickBase64 && typeof quickBase64.fromByteArray === 'function') {
+      // Probe the native binding so that a broken native module falls through
+      // to the JS encoder instead of throwing on every envelope.
+      quickBase64.fromByteArray(new Uint8Array([0]));
       cachedEncoder = quickBase64.fromByteArray;
       debug.log('Using react-native-quick-base64 for envelope encoding.');
       return cachedEncoder;

--- a/packages/core/src/js/wrapper.ts
+++ b/packages/core/src/js/wrapper.ts
@@ -30,11 +30,11 @@ import type { MobileReplayOptions } from './replay/mobilereplay';
 import type { RequiredKeysUser } from './user';
 
 import { isHardCrash } from './misc';
+import { encodeToBase64 } from './utils/base64';
 import { encodeUTF8 } from './utils/encode';
 import { isTurboModuleEnabled } from './utils/environment';
 import { convertToNormalizedObject } from './utils/normalize';
 import { ReactNativeLibraries } from './utils/rnlibraries';
-import { base64StringFromByteArray } from './vendor';
 import { SDK_VERSION } from './version';
 
 /**
@@ -231,7 +231,7 @@ export const NATIVE: SentryNativeWrapper = {
       envelopeBytes = newBytes;
     }
 
-    await RNSentry.captureEnvelope(base64StringFromByteArray(envelopeBytes), { hardCrashed });
+    await RNSentry.captureEnvelope(encodeToBase64(envelopeBytes), { hardCrashed });
   },
 
   /**

--- a/packages/core/test/utils/base64.test.ts
+++ b/packages/core/test/utils/base64.test.ts
@@ -1,0 +1,43 @@
+import { _resetBase64EncoderForTesting, encodeToBase64 } from '../../src/js/utils/base64';
+
+jest.mock(
+  'react-native-quick-base64',
+  () => ({
+    __esModule: true,
+    fromByteArray: jest.fn((bytes: Uint8Array) => `quick:${bytes.length}`),
+  }),
+  { virtual: true },
+);
+
+describe('encodeToBase64', () => {
+  beforeEach(() => {
+    _resetBase64EncoderForTesting();
+    jest.resetModules();
+  });
+
+  test('uses react-native-quick-base64 when available', () => {
+    // The module mock above provides a fake `fromByteArray` returning a sentinel.
+    const result = encodeToBase64(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]));
+    expect(result).toBe('quick:6');
+  });
+
+  test('falls back to the JS encoder when react-native-quick-base64 is not installed', () => {
+    jest.isolateModules(() => {
+      jest.doMock(
+        'react-native-quick-base64',
+        () => {
+          throw new Error('Cannot find module');
+        },
+        { virtual: true },
+      );
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const {
+        encodeToBase64: isolatedEncode,
+        _resetBase64EncoderForTesting: isolatedReset,
+      } = require('../../src/js/utils/base64');
+      isolatedReset();
+      // "sentry" => "c2VudHJ5"
+      expect(isolatedEncode(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]))).toBe('c2VudHJ5');
+    });
+  });
+});

--- a/packages/core/test/utils/base64.test.ts
+++ b/packages/core/test/utils/base64.test.ts
@@ -1,10 +1,12 @@
 import { _resetBase64EncoderForTesting, encodeToBase64 } from '../../src/js/utils/base64';
 
+const quickFromByteArray = jest.fn((bytes: Uint8Array) => Buffer.from(bytes).toString('base64'));
+
 jest.mock(
   'react-native-quick-base64',
   () => ({
     __esModule: true,
-    fromByteArray: jest.fn((bytes: Uint8Array) => `quick:${bytes.length}`),
+    fromByteArray: quickFromByteArray,
   }),
   { virtual: true },
 );
@@ -12,13 +14,17 @@ jest.mock(
 describe('encodeToBase64', () => {
   beforeEach(() => {
     _resetBase64EncoderForTesting();
+    quickFromByteArray.mockClear();
     jest.resetModules();
   });
 
   test('uses react-native-quick-base64 when available', () => {
-    // The module mock above provides a fake `fromByteArray` returning a sentinel.
+    // "sentry" => "c2VudHJ5"
     const result = encodeToBase64(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]));
-    expect(result).toBe('quick:6');
+    expect(result).toBe('c2VudHJ5');
+    // Probe call during resolution + the actual encode call.
+    expect(quickFromByteArray).toHaveBeenCalledTimes(2);
+    expect(quickFromByteArray).toHaveBeenLastCalledWith(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]));
   });
 
   test('falls back to the JS encoder when react-native-quick-base64 is not installed', () => {
@@ -38,6 +44,26 @@ describe('encodeToBase64', () => {
       isolatedReset();
       // "sentry" => "c2VudHJ5"
       expect(isolatedEncode(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]))).toBe('c2VudHJ5');
+    });
+  });
+
+  test('falls back to the JS encoder when the native binding throws on probe', () => {
+    jest.isolateModules(() => {
+      const brokenFromByteArray = jest.fn(() => {
+        throw new Error('native module not linked');
+      });
+      jest.doMock('react-native-quick-base64', () => ({ __esModule: true, fromByteArray: brokenFromByteArray }), {
+        virtual: true,
+      });
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const {
+        encodeToBase64: isolatedEncode,
+        _resetBase64EncoderForTesting: isolatedReset,
+      } = require('../../src/js/utils/base64');
+      isolatedReset();
+      expect(isolatedEncode(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]))).toBe('c2VudHJ5');
+      // Probe was attempted exactly once; the broken binding is not used for the real encode.
+      expect(brokenFromByteArray).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10931,8 +10931,11 @@ __metadata:
     expo: ">=49.0.0"
     react: ">=17.0.0"
     react-native: ">=0.65.0"
+    react-native-quick-base64: ">=3.0.0"
   peerDependenciesMeta:
     expo:
+      optional: true
+    react-native-quick-base64:
       optional: true
   bin:
     sentry-eas-build-on-complete: scripts/eas-build-hook.js


### PR DESCRIPTION
## 📢 Type of change

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring

## 📜 Description

Adds [`react-native-quick-base64`](<https://github.com/craftzdog/react-native-quick-base64>) as an **optional peer dependency** of `@sentry/react-native`. When the package is installed by the consumer, the SDK uses its native JSI base64 encoder (\~10x faster than the bundled JS implementation) for envelope payloads on the `RNSentry.captureEnvelope` hot path. When the package is absent the SDK falls back to the existing `base64-js`-derived encoder in `vendor/base64-js` — no behavior change for users who do not opt in.

Changes:

* New `packages/core/src/js/utils/base64.ts` — `encodeToBase64()` resolves the encoder once and caches it. Tries `require('react-native-quick-base64')` first; falls back to `base64StringFromByteArray` from `vendor/base64-js`.
* `packages/core/src/js/wrapper.ts` — `captureEnvelope` now calls `encodeToBase64(envelopeBytes)` instead of `base64StringFromByteArray(envelopeBytes)` directly.
* `packages/core/package.json` — `react-native-quick-base64 >=3.0.0` added to `peerDependencies` and marked `optional: true` in `peerDependenciesMeta`. No new required deps.
* `CHANGELOG.md` — entry under Unreleased / Features.

## 💡 Motivation and Context

Closes getsentry/sentry-react-native#4884.

## 💚 How did you test it?

Addded tests!

## :pencil: Checklist

- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [X] All tests passing
- [X] No breaking changes

## 🔮 Next steps

* Real-device benchmark on a large envelope (profile / replay) to confirm the headline \~10x figure in our pipeline.
* Optionally mention `react-native-quick-base64` in the Sentry docs as a recommended performance install for users shipping large payloads.