### PR TITLE
fix(android): Accept RegularFile in Gradle bundle task path guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Fix Android Gradle source map upload being silently skipped on some occasions ([#6319](https://github.com/getsentry/sentry-react-native/issues/6319))
+- Fix Android Gradle source map upload being silently skipped on some occasions ([#6320](https://github.com/getsentry/sentry-react-native/pull/6320))
 
 ## 8.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Fix Android Gradle source map upload being silently skipped on some occasions ([#6319](https://github.com/getsentry/sentry-react-native/issues/6319))
+
 ## 8.15.0
 
 ### Features

--- a/packages/core/sentry.gradle.kts
+++ b/packages/core/sentry.gradle.kts
@@ -253,19 +253,25 @@ fun extractBundleTaskArguments(
     val jsSourceMapsDir = (props["jsSourceMapsDir"] as? org.gradle.api.provider.Provider<*>)?.orNull
     val jsIntermediateSourceMapsDir = (props["jsIntermediateSourceMapsDir"] as? org.gradle.api.provider.Provider<*>)?.orNull
 
+    // React Native's BundleHermesCTask declares `jsIntermediateSourceMapsDir` as a `RegularFileProperty`
+    // (and other versions may do the same for the bundle/sourcemap dirs) even though they hold a
+    // directory path, so accept both `Directory` and `RegularFile` here.
     val bundleDirFile =
         when (jsBundleDir) {
             is org.gradle.api.file.Directory -> jsBundleDir.asFile
+            is org.gradle.api.file.RegularFile -> jsBundleDir.asFile
             else -> return BundleTaskArgs(null, null, null, null)
         }
     val sourcemapsDirFile =
         when (jsSourceMapsDir) {
             is org.gradle.api.file.Directory -> jsSourceMapsDir.asFile
+            is org.gradle.api.file.RegularFile -> jsSourceMapsDir.asFile
             else -> return BundleTaskArgs(null, null, null, null)
         }
     val intermediateSourcemapsDirFile =
         when (jsIntermediateSourceMapsDir) {
             is org.gradle.api.file.Directory -> jsIntermediateSourceMapsDir.asFile
+            is org.gradle.api.file.RegularFile -> jsIntermediateSourceMapsDir.asFile
             else -> return BundleTaskArgs(null, null, null, null)
         }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The Kotlin rewrite of the Gradle integration (`sentry.gradle.kts`, shipped in 8.14.0 via #6119) guards the bundle task path properties with a strict `is org.gradle.api.file.Directory` check in `extractBundleTaskArguments`, returning all-null otherwise:

```kotlin
val intermediateSourcemapsDirFile =
    when (jsIntermediateSourceMapsDir) {
        is org.gradle.api.file.Directory -> jsIntermediateSourceMapsDir.asFile
        else -> return BundleTaskArgs(null, null, null, null)   // ← bails out
    }
```

React Native's `BundleHermesCTask` declares `jsIntermediateSourceMapsDir` as a `RegularFileProperty` (it holds a directory path but `mkdirs()` is called on it), so `.orNull` resolves to a `RegularFile`, the `is Directory` branch is skipped, and the function returns all-null. The caller then logs `[sentry] Could not extract bundle task arguments for '…'. Source maps will not be uploaded.` and silently skips the upload.

The legacy fallback (`extractBundleTaskArgumentsLegacy`) can't rescue it because the modern `BundleHermesCTask` is a plain `DefaultTask` with no command-line `args`. The previous Groovy script read the path untyped (`props.jsIntermediateSourceMapsDir.get().asFile.absolutePath`), which is why this only regressed with the Kotlin rewrite.

This PR makes all three guards accept both `Directory` and `RegularFile`.

### Scope note
The linked issue attributes this to RN 0.85, but `jsIntermediateSourceMapsDir` has been a `RegularFileProperty` for much longer — verified in RN 0.80.1 and 0.86.0. So the regression affects a wide range of RN versions on SDK 8.14.0+, not just 0.85.


## :bulb: Motivation and Context
Fixes #6319. Without source map upload, production Hermes stack traces are never symbolicated.


## :green_heart: How did you test it?
No automated test was added — the affected code lives in an `apply from:` Gradle script, so its top-level functions aren't reachable from a unit test, and the only faithful coverage (Gradle TestKit applying the real script) is disproportionate infrastructure for a type-guard fix and isn't part of the current TS/Jest CI.

Verification is manual: on a release Android build with a RN version whose `BundleHermesCTask.jsIntermediateSourceMapsDir` is a `RegularFileProperty` (e.g. 0.80–0.86) and `SENTRY_AUTH_TOKEN` set, confirm `sentry-cli sourcemaps upload` runs and an artifact bundle with a matching Debug ID appears under Project → Settings → Source Maps, instead of the "Could not extract bundle task arguments" warning.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
Consider adding Gradle-level test coverage (e.g. TestKit) for `sentry.gradle.kts` to catch bundle-task extraction regressions in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)