### PR TITLE
fix(core): Align SENTRY_ENVIRONMENT/RELEASE/DIST in JS bundled options with native SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Apply `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` and `SENTRY_DIST` build-time overrides to the JS bundled options to match the native SDKs ([#6329](https://github.com/getsentry/sentry-react-native/issues/6329))
+- Apply `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` and `SENTRY_DIST` build-time overrides to the JS bundled options to match the native SDKs ([#6330](https://github.com/getsentry/sentry-react-native/pull/6330))
 - Fix user `geo` being dropped from the native scope by forwarding it as a structured object instead of a JSON string ([#6309](https://github.com/getsentry/sentry-react-native/pull/6309))
 - Remove unused `React/RCTTextView.h` import that broke iOS builds on React Native 0.87, where the header was removed as part of the legacy architecture cleanup ([#6322](https://github.com/getsentry/sentry-react-native/pull/6322))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Apply `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` and `SENTRY_DIST` build-time overrides to the JS bundled options to match the native SDKs ([#6329](https://github.com/getsentry/sentry-react-native/issues/6329))
 - Fix user `geo` being dropped from the native scope by forwarding it as a structured object instead of a JSON string ([#6309](https://github.com/getsentry/sentry-react-native/pull/6309))
 - Remove unused `React/RCTTextView.h` import that broke iOS builds on React Native 0.87, where the header was removed as part of the legacy architecture cleanup ([#6322](https://github.com/getsentry/sentry-react-native/pull/6322))
 

--- a/packages/core/src/js/tools/sentryOptionsSerializer.ts
+++ b/packages/core/src/js/tools/sentryOptionsSerializer.ts
@@ -90,6 +90,8 @@ function createSentryOptionsModule(filePath: string): Module<VirtualJSOutput> | 
     return null;
   }
 
+  applySentryOptionsEnvOverrides(parsedContent);
+
   const minifiedContent = JSON.stringify(parsedContent);
   const optionsCode = `var __SENTRY_OPTIONS__=${minifiedContent};`;
 
@@ -110,4 +112,33 @@ function createSentryOptionsModule(filePath: string): Module<VirtualJSOutput> | 
       },
     ],
   };
+}
+
+/**
+ * Applies the `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` and `SENTRY_DIST` build-time overrides to the
+ * options bundled into the JS (`__SENTRY_OPTIONS__`).
+ *
+ * The native build steps (`sentry-xcode.sh`, `sentry.gradle.kts`) already apply these env variables
+ * to the native copy of `sentry.options.json`. Without mirroring them here, the native SDK (which owns
+ * release health sessions on mobile) and the JS layer can end up with a different `environment`,
+ * `release` or `dist`, splitting session and event data across releases/environments.
+ */
+function applySentryOptionsEnvOverrides(options: Record<string, unknown>): void {
+  // The options file is expected to contain a JSON object. Guard against valid-but-unexpected JSON
+  // (e.g. a primitive or `null`), where assigning a property would throw in strict mode.
+  if (typeof options !== 'object' || options === null) {
+    return;
+  }
+  if (process.env.SENTRY_ENVIRONMENT) {
+    options.environment = process.env.SENTRY_ENVIRONMENT;
+    logger.debug(`[@sentry/react-native/metro] Overriding 'environment' from SENTRY_ENVIRONMENT environment variable`);
+  }
+  if (process.env.SENTRY_RELEASE) {
+    options.release = process.env.SENTRY_RELEASE;
+    logger.debug(`[@sentry/react-native/metro] Overriding 'release' from SENTRY_RELEASE environment variable`);
+  }
+  if (process.env.SENTRY_DIST) {
+    options.dist = process.env.SENTRY_DIST;
+    logger.debug(`[@sentry/react-native/metro] Overriding 'dist' from SENTRY_DIST environment variable`);
+  }
 }

--- a/packages/core/test/sdk.test.ts
+++ b/packages/core/test/sdk.test.ts
@@ -220,6 +220,19 @@ describe('Tests the SDK functionality', () => {
         });
         expect(usedOptions()?.environment).toBe(undefined);
       });
+
+      it('uses environment from __SENTRY_OPTIONS__ instead of the default when not set in init', () => {
+        (getDefaultEnvironment as jest.Mock).mockImplementation(() => 'production');
+        RN_GLOBAL_OBJ.__SENTRY_OPTIONS__ = {
+          environment: 'staging',
+        };
+        try {
+          init({});
+          expect(usedOptions()?.environment).toBe('staging');
+        } finally {
+          delete RN_GLOBAL_OBJ.__SENTRY_OPTIONS__;
+        }
+      });
     });
 
     describe('release', () => {

--- a/packages/core/test/tools/sentryOptionsSerializer.test.ts
+++ b/packages/core/test/tools/sentryOptionsSerializer.test.ts
@@ -17,10 +17,20 @@ const loggerErrorSpy = jest.spyOn(logger, 'error');
 const customSerializerMock = jest.fn();
 let mockedPreModules: Module[] = [];
 
+const originalEnv = process.env;
+
 describe('Sentry Options Serializer', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockedPreModules = createMockedPreModules();
+    process.env = { ...originalEnv };
+    delete process.env.SENTRY_ENVIRONMENT;
+    delete process.env.SENTRY_RELEASE;
+    delete process.env.SENTRY_DIST;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
   });
 
   afterAll(() => {
@@ -100,6 +110,61 @@ describe('Sentry Options Serializer', () => {
     );
     expect(mockedPreModules.at(-1).getSource().toString()).toEqual(mockedPreModules.at(-1).output[0].data.code);
     expect(loggerDebugSpy).toHaveBeenCalledWith(expect.stringContaining('options added to the bundle'));
+  });
+
+  test.each([
+    ['SENTRY_ENVIRONMENT', 'environment', 'staging'],
+    ['SENTRY_RELEASE', 'release', 'my-app@1.2.3'],
+    ['SENTRY_DIST', 'dist', '42'],
+  ])('overrides %s from the environment variable into the bundled options', (envKey, optionKey, envValue) => {
+    process.env[envKey] = envValue;
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ environment: 'production', other: 'value' }));
+
+    const emitted = getEmittedOptions();
+
+    expect(emitted[optionKey]).toEqual(envValue);
+    expect(emitted.other).toEqual('value');
+  });
+
+  test('overrides all of environment, release and dist at once', () => {
+    process.env.SENTRY_ENVIRONMENT = 'staging';
+    process.env.SENTRY_RELEASE = 'my-app@1.2.3';
+    process.env.SENTRY_DIST = '42';
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      JSON.stringify({ environment: 'production', release: 'old', dist: '1' }),
+    );
+
+    expect(getEmittedOptions()).toEqual(
+      expect.objectContaining({ environment: 'staging', release: 'my-app@1.2.3', dist: '42' }),
+    );
+  });
+
+  test('does not override when env variable is an empty string', () => {
+    process.env.SENTRY_ENVIRONMENT = '';
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ environment: 'production' }));
+
+    expect(getEmittedOptions().environment).toEqual('production');
+  });
+
+  test('keeps file value when env variable is not set', () => {
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ environment: 'production' }));
+
+    expect(getEmittedOptions().environment).toEqual('production');
+  });
+
+  test('does not throw when file content is valid JSON but not an object and env override is set', () => {
+    process.env.SENTRY_ENVIRONMENT = 'staging';
+    (fs.readFileSync as jest.Mock).mockReturnValue(JSON.stringify('not-an-object'));
+
+    const config = {
+      projectRoot: '/test',
+      serializer: { customSerializer: customSerializerMock },
+    };
+
+    expect(() =>
+      withSentryOptionsFromFile(config, true).serializer?.customSerializer(null, mockedPreModules, null, null),
+    ).not.toThrow();
+    expect(mockedPreModules.at(-1)?.output[0].data.code).toEqual('var __SENTRY_OPTIONS__="not-an-object";');
   });
 
   test('logs error and does not add module when file does not exist', () => {
@@ -237,6 +302,24 @@ describe('Sentry Options Serializer', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith('/absolute/path.json', expect.anything());
   });
 });
+
+function getEmittedOptions(): Record<string, unknown> {
+  const config = {
+    projectRoot: '/test',
+    serializer: {
+      customSerializer: customSerializerMock,
+    },
+  };
+
+  withSentryOptionsFromFile(config, true).serializer?.customSerializer(null, mockedPreModules, null, null);
+
+  const code = mockedPreModules.at(-1)?.output[0].data.code as string;
+  const match = code.match(/^var __SENTRY_OPTIONS__=(.*);$/);
+  if (!match) {
+    throw new Error(`Unexpected emitted options code: ${code}`);
+  }
+  return JSON.parse(match[1]);
+}
 
 function createMockedPreModules(): Module[] {
   return [createMinimalModule()];


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
The native build steps apply the `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` and `SENTRY_DIST` build-time overrides to the native copy of `sentry.options.json` (`sentry-xcode.sh`, `sentry.gradle.kts`), but the Metro serializer that produces the `__SENTRY_OPTIONS__` blob bundled into JS read the raw source file and applied **no** overrides.

This change mirrors those three overrides in `createSentryOptionsModule` (`sentryOptionsSerializer.ts`), so the JS-bundled options match the native SDKs.

## :bulb: Motivation and Context
This came up while investigating #6329

## :green_heart: How did you test it?
- Unit tests for the serializer: each override, all-three, empty-string is skipped (matches `sentry-xcode.sh` truthy semantics), unset keeps the file value, and a guard so a non-object options file doesn't throw.
- Integration test in `sdk.test.ts`: an `environment` from `__SENTRY_OPTIONS__` is used instead of the default.
- End-to-end with a real Metro bundle of `samples/react-native` (file has `environment: "dev"`):
  - `SENTRY_ENVIRONMENT=staging` -> `__SENTRY_OPTIONS__.environment === "staging"`
  - no env vars -> stays `"dev"`
  - `SENTRY_RELEASE`/`SENTRY_DIST` -> injected; `environment` unchanged

## :pencil: Checklist
- [x] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed https://github.com/getsentry/sentry-docs/pull/18508
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
