### PR TITLE
chore(e2e): Bump concurrent-ruby to 1.3.7 in samples and perf-tests

### DIFF
--- a/performance-tests/TestAppPlain/Gemfile
+++ b/performance-tests/TestAppPlain/Gemfile
@@ -7,7 +7,7 @@ ruby ">= 2.6.10"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 7.2.3.1', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/performance-tests/TestAppSentry/Gemfile
+++ b/performance-tests/TestAppSentry/Gemfile
@@ -7,7 +7,7 @@ ruby ">= 2.6.10"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 7.2.3.1', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
-gem 'concurrent-ruby', '< 1.3.4'
+gem 'concurrent-ruby', '>= 1.3.7'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
 gem 'bigdecimal'

--- a/samples/react-native/Gemfile.lock
+++ b/samples/react-native/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     csv (3.3.5)
     declarative (0.0.20)


### PR DESCRIPTION
## 📜 Description

Bumps `concurrent-ruby` to `1.3.7` to resolve open Dependabot alerts:

- `samples/react-native/Gemfile.lock`: `1.3.6 → 1.3.7` (lockfile-only change via `bundle lock --update=concurrent-ruby`).
- `performance-tests/TestAppPlain/Gemfile` & `TestAppSentry/Gemfile`: relax the pin `< 1.3.4 → >= 1.3.7`.

The `< 1.3.4` pin was a redundant workaround for the concurrent-ruby 1.3.5 regression that dropped the implicit `logger` dependency — already covered by the existing `gem 'logger'` declaration. Both Gemfiles re-resolve cleanly to 1.3.7 with the existing cocoapods/activesupport/xcodeproj constraints intact.

### Dependabot alerts resolved (9)

`AtomicReference#update` livelock on `Float::NAN` (high):
- https://github.com/getsentry/sentry-react-native/security/dependabot/571 — `samples/react-native/Gemfile.lock`
- https://github.com/getsentry/sentry-react-native/security/dependabot/563 — `performance-tests/TestAppSentry/Gemfile`
- https://github.com/getsentry/sentry-react-native/security/dependabot/560 — `performance-tests/TestAppPlain/Gemfile`

`ReentrantReadWriteLock` read-count overflow (low):
- https://github.com/getsentry/sentry-react-native/security/dependabot/572 — `samples/react-native/Gemfile.lock`
- https://github.com/getsentry/sentry-react-native/security/dependabot/564 — `performance-tests/TestAppSentry/Gemfile`
- https://github.com/getsentry/sentry-react-native/security/dependabot/561 — `performance-tests/TestAppPlain/Gemfile`

`ReadWriteLock` wrong-thread write release (low):
- https://github.com/getsentry/sentry-react-native/security/dependabot/573 — `samples/react-native/Gemfile.lock`
- https://github.com/getsentry/sentry-react-native/security/dependabot/565 — `performance-tests/TestAppSentry/Gemfile`
- https://github.com/getsentry/sentry-react-native/security/dependabot/562 — `performance-tests/TestAppPlain/Gemfile`

## 💚 How did you test it?

Verified dependency resolution: ran `bundle lock` against each perf-test Gemfile in isolation — both resolve to `concurrent-ruby 1.3.7` with all other constraints satisfied. Native sample/perf builds run in CI.

## 📝 Checklist

- [x] No breaking changes — dev/sample/CI tooling only; not part of the published SDK.
- [x] All tests pass (dependency resolution verified; native builds run in CI).

## 🔮 Next steps
