### PR TITLE
fix(replay): Guard against non-dictionary touch breadcrumb path elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Fix fatal `NSInvalidArgumentException` crash in `RNSentryReplayBreadcrumbConverter` when a touch breadcrumb path contains a non-dictionary element ([#6342](https://github.com/getsentry/sentry-react-native/issues/6342))
+- Fix fatal `NSInvalidArgumentException` crash in `RNSentryReplayBreadcrumbConverter` when a touch breadcrumb path contains a non-dictionary element ([#6346](https://github.com/getsentry/sentry-react-native/pull/6346))
 - Apply `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` and `SENTRY_DIST` build-time overrides to the JS bundled options to match the native SDKs ([#6330](https://github.com/getsentry/sentry-react-native/pull/6330))
 - Fix user `geo` being dropped from the native scope by forwarding it as a structured object instead of a JSON string ([#6309](https://github.com/getsentry/sentry-react-native/pull/6309))
 - Remove unused `React/RCTTextView.h` import that broke iOS builds on React Native 0.87, where the header was removed as part of the legacy architecture cleanup ([#6322](https://github.com/getsentry/sentry-react-native/pull/6322))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Fix fatal `NSInvalidArgumentException` crash in `RNSentryReplayBreadcrumbConverter` when a touch breadcrumb path contains a non-dictionary element ([#6342](https://github.com/getsentry/sentry-react-native/issues/6342))
 - Apply `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` and `SENTRY_DIST` build-time overrides to the JS bundled options to match the native SDKs ([#6330](https://github.com/getsentry/sentry-react-native/pull/6330))
 - Fix user `geo` being dropped from the native scope by forwarding it as a structured object instead of a JSON string ([#6309](https://github.com/getsentry/sentry-react-native/pull/6309))
 - Remove unused `React/RCTTextView.h` import that broke iOS builds on React Native 0.87, where the header was removed as part of the legacy architecture cleanup ([#6322](https://github.com/getsentry/sentry-react-native/pull/6322))

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayBreadcrumbConverterTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayBreadcrumbConverterTests.swift
@@ -206,6 +206,53 @@ final class RNSentryReplayBreadcrumbConverterTests: XCTestCase {
         XCTAssertEqual(actual, nil)
     }
 
+    // Reproduces https://github.com/getsentry/sentry-react-native/issues/6342
+    // A non-dictionary element in the path (e.g. an NSString) must not crash with
+    // `-[__NSCFString objectForKey:]: unrecognized selector sent to instance`.
+    func testTouchMessageReturnsNilOnNonDictionaryPathElement() throws {
+        let testPath: [Any?] = ["not-a-dictionary"]
+        let actual = RNSentryReplayBreadcrumbConverter.getTouchPathMessage(from: testPath as [Any])
+        XCTAssertEqual(actual, nil)
+    }
+
+    func testTouchMessageReturnsNilWhenAnyPathElementIsNotADictionary() throws {
+        let testPath: [Any?] = [
+            ["name": "name1"],
+            "not-a-dictionary",
+            ["name": "name3"]
+        ]
+        let actual = RNSentryReplayBreadcrumbConverter.getTouchPathMessage(from: testPath as [Any])
+        XCTAssertEqual(actual, nil)
+    }
+
+    func testConvertTouchBreadcrumbWithNonDictionaryPathElementDoesNotCrash() {
+        let converter = RNSentryReplayBreadcrumbConverter()
+        let testBreadcrumb = Breadcrumb()
+        testBreadcrumb.timestamp = Date()
+        testBreadcrumb.level = .info
+        testBreadcrumb.type = "user"
+        testBreadcrumb.category = "touch"
+        testBreadcrumb.data = [
+            "path": ["not-a-dictionary"]
+        ]
+        // Must not raise NSInvalidArgumentException.
+        _ = converter.convert(from: testBreadcrumb)
+    }
+
+    func testConvertTouchBreadcrumbWithNonArrayPathDoesNotCrash() {
+        let converter = RNSentryReplayBreadcrumbConverter()
+        let testBreadcrumb = Breadcrumb()
+        testBreadcrumb.timestamp = Date()
+        testBreadcrumb.level = .info
+        testBreadcrumb.type = "user"
+        testBreadcrumb.category = "touch"
+        testBreadcrumb.data = [
+            "path": "not-an-array"
+        ]
+        // Must not raise (NSString does not respond to `count`/`objectAtIndex:`).
+        _ = converter.convert(from: testBreadcrumb)
+    }
+
     func testTouchMessageReturnsMessageOnValidPathExample1() throws {
         let testPath: [Any?] = [
             ["label": "label0"],

--- a/packages/core/ios/RNSentryReplayBreadcrumbConverter.m
+++ b/packages/core/ios/RNSentryReplayBreadcrumbConverter.m
@@ -69,8 +69,12 @@
         return nil;
     }
 
-    NSMutableArray *path = [breadcrumb.data valueForKey:@"path"];
-    NSString *message = [RNSentryReplayBreadcrumbConverter getTouchPathMessageFrom:path];
+    id maybePath = [breadcrumb.data valueForKey:@"path"];
+    if (![maybePath isKindOfClass:[NSArray class]]) {
+        return nil;
+    }
+
+    NSString *message = [RNSentryReplayBreadcrumbConverter getTouchPathMessageFrom:maybePath];
 
     return [SentrySessionReplayHybridSDK createBreadcrumbwithTimestamp:breadcrumb.timestamp
                                                               category:@"ui.tap"
@@ -112,10 +116,11 @@
 
     NSMutableString *message = [[NSMutableString alloc] init];
     for (NSInteger i = MIN(3, pathCount - 1); i >= 0; i--) {
-        NSDictionary *item = [path objectAtIndex:i];
-        if (item == nil) {
-            return nil; // There should be no nil (undefined) from JS, but to be safe we check it
-                        // here
+        id item = [path objectAtIndex:i];
+        if (![item isKindOfClass:[NSDictionary class]]) {
+            return nil; // There should be no nil (undefined) or non-dictionary entry from JS, but
+                        // to be safe we check it here. See
+                        // https://github.com/getsentry/sentry-react-native/issues/6342
         }
 
         id name = [item objectForKey:@"name"];


### PR DESCRIPTION
## 📜 Description

Fixes a fatal `NSInvalidArgumentException` crash in `RNSentryReplayBreadcrumbConverter` (Session Replay on iOS):

```
-[__NSCFString objectForKey:]: unrecognized selector sent to instance
```

`getTouchPathMessageFrom:` iterated over a touch breadcrumb's `path` array and treated every element as an `NSDictionary`, only guarding against `nil`. When an element was a non-dictionary (e.g. an `NSString`), calling `objectForKey:` on it raised `NSInvalidArgumentException` → `SIGABRT`.

Two gaps are addressed:

1. **`getTouchPathMessageFrom:`** — each element is now validated with `isKindOfClass:[NSDictionary class]` before any dictionary access (the same pattern already used in `convertNavigation:`).
2. **`convertTouch:`** — now guards that `path` is an `NSArray` before use, matching the existing `convertMultiClick:` implementation. Previously a non-array `path` would crash on `[path count]` (`NSString` does not respond to `count`).

## 💡 Motivation and Context

Reported in #6342 — observed as a fatal crash in production on iOS with Session Replay enabled (RN 0.81.5, Expo SDK 54, New Architecture + Hermes). The malformed touch-path element bypassed all existing guards.

Closes #6342

## 💚 How did you test it?

Added unit tests to `RNSentryReplayBreadcrumbConverterTests.swift` that reproduce the crash and assert it no longer occurs:

- `testTouchMessageReturnsNilOnNonDictionaryPathElement` — the exact reported case (a string element).
- `testTouchMessageReturnsNilWhenAnyPathElementIsNotADictionary` — non-dict element mixed with valid dicts.
- `testConvertTouchBreadcrumbWithNonDictionaryPathElementDoesNotCrash` — exercised end-to-end via `convert(from:)`.
- `testConvertTouchBreadcrumbWithNonArrayPathDoesNotCrash` — non-array `path`.

These crash on the previous code and pass with the fix. Ran clang-format on the modified ObjC file.

## 📝 Checklist

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPii` is enabled.
- [x] I updated the docs if needed.
- [x] All tests passing.
- [x] No breaking changes.

## 🔮 Next steps

None.
