### PR TITLE
Expo Router ErrorBoundary auto wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
   ```
 
   Render-phase errors that reach the boundary are captured with route context (`route.name`, `route.path`, `route.params`), the in-flight navigation transaction is tagged as errored, and a breadcrumb is emitted. Concrete paths and params are gated behind `sendDefaultPii`.
+- Auto-wrap Expo Router's `ErrorBoundary` re-exports at build time
+
+  `getSentryExpoConfig` now ships a Babel plugin that rewrites `export { ErrorBoundary } from 'expo-router'` into a wrapped re-export, so the boundary is auto-instrumented without changing your route files. Opt out with `autoWrapExpoRouterErrorBoundary: false`. For non-Expo Metro setups, `withSentryConfig` exposes the same option (off by default).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@
 ### Features
 
 - Use the runtime's native `btoa` for envelope base64 encoding when available, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if `btoa` is missing ([#6351](https://github.com/getsentry/sentry-react-native/pull/6351)).
+- Opt-in build-time auto-wrap for Expo Router's per-route `ErrorBoundary` ([#6347](https://github.com/getsentry/sentry-react-native/pull/6347))
+
+  Enable `autoWrapExpoRouterErrorBoundary: true` in `getSentryExpoConfig` (or `withSentryConfig`) and the Sentry Babel plugin rewrites `export { ErrorBoundary } from 'expo-router'` into a `wrapExpoRouterErrorBoundary` call at build time — no route-file edits needed:
+
+  ```js
+  // metro.config.js
+  module.exports = getSentryExpoConfig(__dirname, {
+    autoWrapExpoRouterErrorBoundary: true,
+  });
+  ```
+
+### Fixes
+
+- The Sentry Babel transformer no longer injects `@sentry/babel-plugin-component-annotate` unless `annotateReactComponents` is explicitly enabled ([#6347](https://github.com/getsentry/sentry-react-native/pull/6347))
 
 ### Dependencies
 
@@ -35,9 +49,6 @@
   ```
 
   Render-phase errors that reach the boundary are captured with route context (`route.name`, `route.path`, `route.params`), the in-flight navigation transaction is tagged as errored, and a breadcrumb is emitted. Concrete paths and params are gated behind `sendDefaultPii`.
-- Auto-wrap Expo Router's `ErrorBoundary` re-exports at build time
-
-  `getSentryExpoConfig` now ships a Babel plugin that rewrites `export { ErrorBoundary } from 'expo-router'` into a wrapped re-export, so the boundary is auto-instrumented without changing your route files. Opt out with `autoWrapExpoRouterErrorBoundary: false`. For non-Expo Metro setups, `withSentryConfig` exposes the same option (off by default).
 
 ### Fixes
 

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -85,7 +85,7 @@ export interface SentryMetroConfigOptions {
    * wrapped boundary instead. Files that already import
    * `wrapExpoRouterErrorBoundary` are left untouched.
    *
-   * @default false for `withSentryConfig`, true for `getSentryExpoConfig`
+   * @default false
    */
   autoWrapExpoRouterErrorBoundary?: boolean;
 }
@@ -169,7 +169,7 @@ export function getSentryExpoConfig(
   });
 
   let newConfig = withSentryFramesCollapsed(config);
-  const autoWrapExpoRouterErrorBoundary = options.autoWrapExpoRouterErrorBoundary ?? true;
+  const autoWrapExpoRouterErrorBoundary = options.autoWrapExpoRouterErrorBoundary ?? false;
   if (options.annotateReactComponents || autoWrapExpoRouterErrorBoundary) {
     newConfig = withSentryBabelTransformer(
       newConfig,

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -74,6 +74,20 @@ export interface SentryMetroConfigOptions {
    * @default '{projectRoot}/sentry.options.json'
    */
   optionsFile?: string | boolean;
+  /**
+   * Auto-wrap Expo Router's per-route `ErrorBoundary` re-exports with
+   * `Sentry.wrapExpoRouterErrorBoundary` at build time so render-phase errors
+   * that hit the fallback are captured without requiring the user to change
+   * their route files.
+   *
+   * Detects `export { ErrorBoundary } from 'expo-router'` (and aliased
+   * variants) in non-`node_modules` files and rewrites them to import the
+   * wrapped boundary instead. Files that already import
+   * `wrapExpoRouterErrorBoundary` are left untouched.
+   *
+   * @default false for `withSentryConfig`, true for `getSentryExpoConfig`
+   */
+  autoWrapExpoRouterErrorBoundary?: boolean;
 }
 
 export interface SentryExpoConfigOptions {
@@ -104,6 +118,7 @@ export function withSentryConfig(
     includeWebFeedback = true,
     enableSourceContextInDevelopment = true,
     optionsFile = true,
+    autoWrapExpoRouterErrorBoundary = false,
   }: SentryMetroConfigOptions = {},
 ): MetroConfig {
   setSentryMetroDevServerEnvFlag();
@@ -112,8 +127,8 @@ export function withSentryConfig(
 
   newConfig = withSentryDebugId(newConfig);
   newConfig = withSentryFramesCollapsed(newConfig);
-  if (annotateReactComponents) {
-    newConfig = withSentryBabelTransformer(newConfig, annotateReactComponents);
+  if (annotateReactComponents || autoWrapExpoRouterErrorBoundary) {
+    newConfig = withSentryBabelTransformer(newConfig, annotateReactComponents, autoWrapExpoRouterErrorBoundary);
   }
   if (includeWebReplay === false) {
     newConfig = withSentryResolver(newConfig, includeWebReplay);
@@ -154,8 +169,13 @@ export function getSentryExpoConfig(
   });
 
   let newConfig = withSentryFramesCollapsed(config);
-  if (options.annotateReactComponents) {
-    newConfig = withSentryBabelTransformer(newConfig, options.annotateReactComponents);
+  const autoWrapExpoRouterErrorBoundary = options.autoWrapExpoRouterErrorBoundary ?? true;
+  if (options.annotateReactComponents || autoWrapExpoRouterErrorBoundary) {
+    newConfig = withSentryBabelTransformer(
+      newConfig,
+      options.annotateReactComponents ?? false,
+      autoWrapExpoRouterErrorBoundary,
+    );
   }
 
   if (options.includeWebReplay === false) {
@@ -202,8 +222,9 @@ function loadExpoMetroConfigModule(): {
 export function withSentryBabelTransformer(
   config: MetroConfig,
   annotateReactComponents:
-    | true
+    | boolean
     | { ignoredComponents?: string[]; autoInjectSentryLabel?: boolean; textComponentNames?: string[] },
+  autoWrapExpoRouterErrorBoundary: boolean = false,
 ): MetroConfig {
   const defaultBabelTransformerPath = config.transformer?.babelTransformerPath;
   debug.log('Default Babel transformer path from `config.transformer`:', defaultBabelTransformerPath);
@@ -221,11 +242,10 @@ export function withSentryBabelTransformer(
     setSentryDefaultBabelTransformerPathEnv(defaultBabelTransformerPath);
   }
 
-  if (typeof annotateReactComponents === 'object') {
-    setSentryBabelTransformerOptions({
-      annotateReactComponents,
-    });
-  }
+  setSentryBabelTransformerOptions({
+    ...(typeof annotateReactComponents === 'object' ? { annotateReactComponents } : {}),
+    autoWrapExpoRouterErrorBoundary,
+  });
 
   return {
     ...config,

--- a/packages/core/src/js/tools/metroconfig.ts
+++ b/packages/core/src/js/tools/metroconfig.ts
@@ -243,7 +243,9 @@ export function withSentryBabelTransformer(
   }
 
   setSentryBabelTransformerOptions({
-    ...(typeof annotateReactComponents === 'object' ? { annotateReactComponents } : {}),
+    ...(annotateReactComponents
+      ? { annotateReactComponents: typeof annotateReactComponents === 'object' ? annotateReactComponents : {} }
+      : {}),
     autoWrapExpoRouterErrorBoundary,
   });
 

--- a/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
+++ b/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
@@ -4,12 +4,15 @@ import * as process from 'process';
 
 import type { BabelTransformer, BabelTransformerArgs } from './vendor/metro/metroBabelTransformer';
 
+import sentryExpoRouterAutoWrapBabelPlugin from './sentryExpoRouterAutoWrapBabelPlugin';
+
 export type SentryBabelTransformerOptions = {
   annotateReactComponents?: {
     ignoredComponents?: string[];
     autoInjectSentryLabel?: boolean;
     textComponentNames?: string[];
   };
+  autoWrapExpoRouterErrorBoundary?: boolean;
 };
 
 export const SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH = 'SENTRY_DEFAULT_BABEL_TRANSFORMER_PATH';
@@ -98,6 +101,9 @@ export function createSentryBabelTransformer(): BabelTransformer {
     const transformerArgs = args[0];
 
     addSentryComponentAnnotatePlugin(transformerArgs, options?.annotateReactComponents);
+    if (options?.autoWrapExpoRouterErrorBoundary) {
+      addSentryExpoRouterAutoWrapPlugin(transformerArgs);
+    }
 
     return defaultTransformer.transform(...args);
   };
@@ -123,4 +129,14 @@ function addSentryComponentAnnotatePlugin(
     };
     args.plugins.push([componentAnnotatePlugin, pluginOptions]);
   }
+}
+
+function addSentryExpoRouterAutoWrapPlugin(args: BabelTransformerArgs | undefined): void {
+  if (!args || typeof args.filename !== 'string' || !Array.isArray(args.plugins)) {
+    return undefined;
+  }
+  if (args.filename.includes('node_modules')) {
+    return undefined;
+  }
+  args.plugins.push([sentryExpoRouterAutoWrapBabelPlugin, {}]);
 }

--- a/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
+++ b/packages/core/src/js/tools/sentryBabelTransformerUtils.ts
@@ -100,7 +100,9 @@ export function createSentryBabelTransformer(): BabelTransformer {
   const transform: BabelTransformer['transform'] = (...args) => {
     const transformerArgs = args[0];
 
-    addSentryComponentAnnotatePlugin(transformerArgs, options?.annotateReactComponents);
+    if (options?.annotateReactComponents !== undefined) {
+      addSentryComponentAnnotatePlugin(transformerArgs, options.annotateReactComponents);
+    }
     if (options?.autoWrapExpoRouterErrorBoundary) {
       addSentryExpoRouterAutoWrapPlugin(transformerArgs);
     }

--- a/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
+++ b/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { NodePath, PluginObj, PluginPass, types as BabelTypes } from '@babel/core';
 
 /**

--- a/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
+++ b/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
@@ -69,15 +69,15 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
           ? boundarySpecifier.exported.name
           : boundarySpecifier.exported.value;
 
-        // Emit the two helper imports only on the first wrap in this file.
-        // Multiple `export { ErrorBoundary } from 'expo-router'` declarations
-        // in the same file would otherwise inject duplicate module bindings,
-        // which is illegal in ES modules.
+        // Hoist the two helper imports to the top of the Program body so
+        // they sit alongside the file's other `import` declarations rather
+        // than landing mid-file. Some toolchains (e.g. Hermes) are strict
+        // about import placement, and mid-file imports are also harder to
+        // read. Inject once per file so a second wrap reuses the bindings.
         const HELPERS_KEY = 'sentryAutoWrapHelpersInjected';
-        const helpersAlreadyInjected = state.get(HELPERS_KEY) === true;
-        const replacements: BabelTypes.Statement[] = [];
-        if (!helpersAlreadyInjected) {
-          replacements.push(
+        if (state.get(HELPERS_KEY) !== true) {
+          const program = path.scope.getProgramParent().path as NodePath<BabelTypes.Program>;
+          program.unshiftContainer('body', [
             t.importDeclaration(
               [t.importSpecifier(t.identifier(ORIGINAL_BOUNDARY_LOCAL), t.identifier(BOUNDARY_EXPORT))],
               t.stringLiteral(EXPO_ROUTER_PACKAGE),
@@ -86,10 +86,11 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
               [t.importSpecifier(t.identifier(WRAP_FN_LOCAL), t.identifier('wrapExpoRouterErrorBoundary'))],
               t.stringLiteral(SENTRY_PACKAGE),
             ),
-          );
+          ]);
           state.set(HELPERS_KEY, true);
         }
-        replacements.push(
+
+        const replacements: BabelTypes.Statement[] = [
           t.exportNamedDeclaration(
             t.variableDeclaration('const', [
               t.variableDeclarator(
@@ -99,7 +100,7 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
             ]),
             [],
           ),
-        );
+        ];
 
         const remainingSpecifiers = node.specifiers.filter((_, i) => i !== boundarySpecifierIndex);
         if (remainingSpecifiers.length > 0) {

--- a/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
+++ b/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
@@ -90,16 +90,20 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
           state.set(HELPERS_KEY, true);
         }
 
+        // Generate a unique local binding for the wrapped boundary instead of
+        // declaring `const <exportedName> = ...` directly. That avoids clashing
+        // with an existing top-level binding of the same name in the file
+        // (e.g. `import { ErrorBoundary } from 'expo-router'` used elsewhere)
+        // which would otherwise produce a duplicate-binding compile error.
+        const wrappedLocal = path.scope.generateUidIdentifier(`wrapped${exportedName}`);
         const replacements: BabelTypes.Statement[] = [
-          t.exportNamedDeclaration(
-            t.variableDeclaration('const', [
-              t.variableDeclarator(
-                t.identifier(exportedName),
-                t.callExpression(t.identifier(WRAP_FN_LOCAL), [t.identifier(ORIGINAL_BOUNDARY_LOCAL)]),
-              ),
-            ]),
-            [],
-          ),
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              wrappedLocal,
+              t.callExpression(t.identifier(WRAP_FN_LOCAL), [t.identifier(ORIGINAL_BOUNDARY_LOCAL)]),
+            ),
+          ]),
+          t.exportNamedDeclaration(null, [t.exportSpecifier(t.cloneNode(wrappedLocal), t.identifier(exportedName))]),
         ];
 
         const remainingSpecifiers = node.specifiers.filter((_, i) => i !== boundarySpecifierIndex);

--- a/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
+++ b/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
@@ -106,7 +106,13 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
           t.exportNamedDeclaration(null, [t.exportSpecifier(t.cloneNode(wrappedLocal), t.identifier(exportedName))]),
         ];
 
-        const remainingSpecifiers = node.specifiers.filter((_, i) => i !== boundarySpecifierIndex);
+        const remainingSpecifiers = node.specifiers
+          .filter((_, i) => i !== boundarySpecifierIndex)
+          // Clone the reused specifier nodes so we don't share AST nodes
+          // between the original `path.node` (about to be replaced) and the
+          // new export declaration — Babel docs warn that reusing nodes can
+          // corrupt the scope cache.
+          .map(s => t.cloneNode(s));
         if (remainingSpecifiers.length > 0) {
           replacements.push(t.exportNamedDeclaration(null, remainingSpecifiers, t.cloneNode(node.source)));
         }

--- a/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
+++ b/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
@@ -69,28 +69,39 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
           ? boundarySpecifier.exported.name
           : boundarySpecifier.exported.value;
 
-        // Build the replacement nodes.
-        const originalImport = t.importDeclaration(
-          [t.importSpecifier(t.identifier(ORIGINAL_BOUNDARY_LOCAL), t.identifier(BOUNDARY_EXPORT))],
-          t.stringLiteral(EXPO_ROUTER_PACKAGE),
-        );
-        const wrapImport = t.importDeclaration(
-          [t.importSpecifier(t.identifier(WRAP_FN_LOCAL), t.identifier('wrapExpoRouterErrorBoundary'))],
-          t.stringLiteral(SENTRY_PACKAGE),
-        );
-        const wrappedExport = t.exportNamedDeclaration(
-          t.variableDeclaration('const', [
-            t.variableDeclarator(
-              t.identifier(exportedName),
-              t.callExpression(t.identifier(WRAP_FN_LOCAL), [t.identifier(ORIGINAL_BOUNDARY_LOCAL)]),
+        // Emit the two helper imports only on the first wrap in this file.
+        // Multiple `export { ErrorBoundary } from 'expo-router'` declarations
+        // in the same file would otherwise inject duplicate module bindings,
+        // which is illegal in ES modules.
+        const HELPERS_KEY = 'sentryAutoWrapHelpersInjected';
+        const helpersAlreadyInjected = state.get(HELPERS_KEY) === true;
+        const replacements: BabelTypes.Statement[] = [];
+        if (!helpersAlreadyInjected) {
+          replacements.push(
+            t.importDeclaration(
+              [t.importSpecifier(t.identifier(ORIGINAL_BOUNDARY_LOCAL), t.identifier(BOUNDARY_EXPORT))],
+              t.stringLiteral(EXPO_ROUTER_PACKAGE),
             ),
-          ]),
-          [],
+            t.importDeclaration(
+              [t.importSpecifier(t.identifier(WRAP_FN_LOCAL), t.identifier('wrapExpoRouterErrorBoundary'))],
+              t.stringLiteral(SENTRY_PACKAGE),
+            ),
+          );
+          state.set(HELPERS_KEY, true);
+        }
+        replacements.push(
+          t.exportNamedDeclaration(
+            t.variableDeclaration('const', [
+              t.variableDeclarator(
+                t.identifier(exportedName),
+                t.callExpression(t.identifier(WRAP_FN_LOCAL), [t.identifier(ORIGINAL_BOUNDARY_LOCAL)]),
+              ),
+            ]),
+            [],
+          ),
         );
 
         const remainingSpecifiers = node.specifiers.filter((_, i) => i !== boundarySpecifierIndex);
-
-        const replacements: BabelTypes.Statement[] = [originalImport, wrapImport, wrappedExport];
         if (remainingSpecifiers.length > 0) {
           replacements.push(t.exportNamedDeclaration(null, remainingSpecifiers, t.cloneNode(node.source)));
         }

--- a/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
+++ b/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
@@ -25,8 +25,9 @@ import type { NodePath, PluginObj, PluginPass, types as BabelTypes } from '@babe
  * `export { ErrorBoundary, Stack } from 'expo-router'` keep the non-boundary
  * specifiers in place.
  *
- * The transform is idempotent: a file that has already been transformed
- * (recognised by the marker import) is left alone on subsequent runs.
+ * The transform is structurally idempotent: after the rewrite the re-export
+ * is no longer an `export ... from 'expo-router'`, so a second pass over the
+ * same file finds nothing to transform.
  *
  * Files inside `node_modules` are never transformed.
  */
@@ -48,13 +49,6 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
       ExportNamedDeclaration(path: NodePath<BabelTypes.ExportNamedDeclaration>, state: PluginPass) {
         const node = path.node;
         if (!node.source || node.source.value !== EXPO_ROUTER_PACKAGE) {
-          return;
-        }
-
-        // Idempotency: if we've already injected the wrap import in this file,
-        // don't re-transform any re-exports below it.
-        const program = path.findParent(p => p.isProgram()) as NodePath<BabelTypes.Program> | null;
-        if (program && hasMarkerImport(t, program)) {
           return;
         }
 
@@ -105,15 +99,4 @@ export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelA
       },
     },
   };
-}
-
-function hasMarkerImport(t: typeof BabelTypes, program: NodePath<BabelTypes.Program>): boolean {
-  return program.node.body.some(stmt => {
-    if (!t.isImportDeclaration(stmt) || stmt.source.value !== SENTRY_PACKAGE) {
-      return false;
-    }
-    return stmt.specifiers.some(
-      s => t.isImportSpecifier(s) && t.isIdentifier(s.local) && s.local.name === WRAP_FN_LOCAL,
-    );
-  });
 }

--- a/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
+++ b/packages/core/src/js/tools/sentryExpoRouterAutoWrapBabelPlugin.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { NodePath, PluginObj, PluginPass, types as BabelTypes } from '@babel/core';
+
+/**
+ * Babel plugin that auto-wraps Expo Router's per-route `ErrorBoundary` so the
+ * Sentry SDK captures render-phase errors that hit the fallback without
+ * requiring the user to change their route file.
+ *
+ * It rewrites:
+ *
+ * ```ts
+ * export { ErrorBoundary } from 'expo-router';
+ * ```
+ *
+ * into:
+ *
+ * ```ts
+ * import { ErrorBoundary as __sentryOriginalExpoErrorBoundary } from 'expo-router';
+ * import { wrapExpoRouterErrorBoundary as __sentryWrapExpoRouterErrorBoundary } from '@sentry/react-native';
+ * export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary);
+ * ```
+ *
+ * Aliased re-exports (`export { ErrorBoundary as Foo } from 'expo-router'`)
+ * are preserved — the wrapped export keeps the user-chosen name. Mixed
+ * re-exports such as
+ * `export { ErrorBoundary, Stack } from 'expo-router'` keep the non-boundary
+ * specifiers in place.
+ *
+ * The transform is idempotent: a file that has already been transformed
+ * (recognised by the marker import) is left alone on subsequent runs.
+ *
+ * Files inside `node_modules` are never transformed.
+ */
+
+const ORIGINAL_BOUNDARY_LOCAL = '__sentryOriginalExpoErrorBoundary';
+const WRAP_FN_LOCAL = '__sentryWrapExpoRouterErrorBoundary';
+const SENTRY_PACKAGE = '@sentry/react-native';
+const EXPO_ROUTER_PACKAGE = 'expo-router';
+const BOUNDARY_EXPORT = 'ErrorBoundary';
+
+interface BabelApi {
+  types: typeof BabelTypes;
+}
+
+export default function sentryExpoRouterAutoWrapBabelPlugin({ types: t }: BabelApi): PluginObj {
+  return {
+    name: 'sentry-expo-router-auto-wrap-error-boundary',
+    visitor: {
+      ExportNamedDeclaration(path: NodePath<BabelTypes.ExportNamedDeclaration>, state: PluginPass) {
+        const node = path.node;
+        if (!node.source || node.source.value !== EXPO_ROUTER_PACKAGE) {
+          return;
+        }
+
+        // Idempotency: if we've already injected the wrap import in this file,
+        // don't re-transform any re-exports below it.
+        const program = path.findParent(p => p.isProgram()) as NodePath<BabelTypes.Program> | null;
+        if (program && hasMarkerImport(t, program)) {
+          return;
+        }
+
+        const filename = (state.file?.opts?.filename as string | undefined) ?? '';
+        if (filename.includes('node_modules')) {
+          return;
+        }
+
+        const boundarySpecifierIndex = node.specifiers.findIndex(
+          s => t.isExportSpecifier(s) && t.isIdentifier(s.local) && s.local.name === BOUNDARY_EXPORT,
+        );
+        if (boundarySpecifierIndex === -1) {
+          return;
+        }
+
+        const boundarySpecifier = node.specifiers[boundarySpecifierIndex] as BabelTypes.ExportSpecifier;
+        const exportedName = t.isIdentifier(boundarySpecifier.exported)
+          ? boundarySpecifier.exported.name
+          : boundarySpecifier.exported.value;
+
+        // Build the replacement nodes.
+        const originalImport = t.importDeclaration(
+          [t.importSpecifier(t.identifier(ORIGINAL_BOUNDARY_LOCAL), t.identifier(BOUNDARY_EXPORT))],
+          t.stringLiteral(EXPO_ROUTER_PACKAGE),
+        );
+        const wrapImport = t.importDeclaration(
+          [t.importSpecifier(t.identifier(WRAP_FN_LOCAL), t.identifier('wrapExpoRouterErrorBoundary'))],
+          t.stringLiteral(SENTRY_PACKAGE),
+        );
+        const wrappedExport = t.exportNamedDeclaration(
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              t.identifier(exportedName),
+              t.callExpression(t.identifier(WRAP_FN_LOCAL), [t.identifier(ORIGINAL_BOUNDARY_LOCAL)]),
+            ),
+          ]),
+          [],
+        );
+
+        const remainingSpecifiers = node.specifiers.filter((_, i) => i !== boundarySpecifierIndex);
+
+        const replacements: BabelTypes.Statement[] = [originalImport, wrapImport, wrappedExport];
+        if (remainingSpecifiers.length > 0) {
+          replacements.push(t.exportNamedDeclaration(null, remainingSpecifiers, t.cloneNode(node.source)));
+        }
+
+        path.replaceWithMultiple(replacements);
+      },
+    },
+  };
+}
+
+function hasMarkerImport(t: typeof BabelTypes, program: NodePath<BabelTypes.Program>): boolean {
+  return program.node.body.some(stmt => {
+    if (!t.isImportDeclaration(stmt) || stmt.source.value !== SENTRY_PACKAGE) {
+      return false;
+    }
+    return stmt.specifiers.some(
+      s => t.isImportSpecifier(s) && t.isIdentifier(s.local) && s.local.name === WRAP_FN_LOCAL,
+    );
+  });
+}

--- a/packages/core/test/tools/metroconfig.test.ts
+++ b/packages/core/test/tools/metroconfig.test.ts
@@ -160,6 +160,7 @@ describe('metroconfig', () => {
           annotateReactComponents: {
             ignoredComponents: ['MyCustomComponent'],
           },
+          autoWrapExpoRouterErrorBoundary: false,
         }),
       );
     });

--- a/packages/core/test/tools/sentryBabelTransformer.test.ts
+++ b/packages/core/test/tools/sentryBabelTransformer.test.ts
@@ -31,6 +31,10 @@ describe('SentryBabelTransformer', () => {
   });
 
   test('transform calls the original transformer with the annotation plugin', () => {
+    process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = JSON.stringify({
+      annotateReactComponents: {},
+    });
+
     createSentryBabelTransformer().transform?.({
       filename: '/project/file',
       options: {
@@ -53,6 +57,10 @@ describe('SentryBabelTransformer', () => {
   });
 
   test('transform adds plugin with autoInjectSentryLabel enabled by default', () => {
+    process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = JSON.stringify({
+      annotateReactComponents: {},
+    });
+
     createSentryBabelTransformer().transform?.(createMinimalMockedTransformOptions());
 
     expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledTimes(1);
@@ -142,21 +150,31 @@ describe('SentryBabelTransformer', () => {
     );
   });
 
-  test('degrades gracefully if options can not be parsed, transform adds plugin with defaults', () => {
+  test('degrades gracefully if options can not be parsed, transform skips opt-in plugins', () => {
     process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = 'invalid json';
 
     createSentryBabelTransformer().transform?.(createMinimalMockedTransformOptions());
 
     expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledTimes(1);
-    expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledWith(
-      expect.objectContaining({
-        plugins: expect.arrayContaining([
-          [
-            expect.objectContaining({ name: 'componentNameAnnotatePlugin' }),
-            expect.objectContaining({ autoInjectSentryLabel: true }),
-          ],
-        ]),
-      }),
+    // When persisted options are unparseable, opt-in Babel plugins must not be
+    // silently injected — we cannot tell what the user asked for.
+    const calledArgs = MockDefaultBabelTransformer.transform.mock.calls[0][0] as BabelTransformerArgs;
+    expect(calledArgs.plugins).not.toEqual(
+      expect.arrayContaining([[expect.objectContaining({ name: 'componentNameAnnotatePlugin' }), expect.anything()]]),
+    );
+  });
+
+  test('does not add the annotation plugin when only autoWrapExpoRouterErrorBoundary is enabled', () => {
+    process.env[SENTRY_BABEL_TRANSFORMER_OPTIONS] = JSON.stringify({
+      autoWrapExpoRouterErrorBoundary: true,
+    });
+
+    createSentryBabelTransformer().transform?.(createMinimalMockedTransformOptions());
+
+    expect(MockDefaultBabelTransformer.transform).toHaveBeenCalledTimes(1);
+    const calledArgs = MockDefaultBabelTransformer.transform.mock.calls[0][0] as BabelTransformerArgs;
+    expect(calledArgs.plugins).not.toEqual(
+      expect.arrayContaining([[expect.objectContaining({ name: 'componentNameAnnotatePlugin' }), expect.anything()]]),
     );
   });
 

--- a/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
+++ b/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
@@ -112,6 +112,14 @@ describe('sentryExpoRouterAutoWrapBabelPlugin', () => {
     expect(occurrences).toBe(1);
   });
 
+  it("preserves a leading 'use client' directive", () => {
+    // Helper imports must not be hoisted above the directive prologue, or
+    // Expo Web / RSC tooling will stop treating the file as a client module.
+    const src = `'use client';\nexport { ErrorBoundary } from 'expo-router';`;
+    const out = transform(src);
+    expect(out.trimStart()).toMatch(/^['"]use client['"];/);
+  });
+
   it('skips files inside node_modules', () => {
     const out = transform(`export { ErrorBoundary } from 'expo-router';`, '/proj/node_modules/expo-router/build/x.js');
     expect(out).not.toContain('@sentry/react-native');

--- a/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
+++ b/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
@@ -41,6 +41,33 @@ describe('sentryExpoRouterAutoWrapBabelPlugin', () => {
     expect(out).toMatch(/export\s*\{\s*Stack\s*\}\s*from\s*['"]expo-router['"]/);
   });
 
+  it('hoists helper imports to the top of the file, never mid-file', () => {
+    // A common shape: imports + non-import statements + the boundary re-export.
+    // Mid-file `import` declarations are invalid in strict ESM environments
+    // (e.g. Hermes), so the helpers must be pushed up to the imports block.
+    const src = [
+      `import { Stack } from 'expo-router';`,
+      `const greeting = 'hi';`,
+      `export { ErrorBoundary } from 'expo-router';`,
+    ].join('\n');
+    const out = transform(src);
+    const lines = out
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean);
+    const firstNonImport = lines.findIndex(l => !l.startsWith('import'));
+    const helperLineIndexes = lines
+      .map((l, i) =>
+        (l.includes('__sentryOriginalExpoErrorBoundary') || l.includes('__sentryWrapExpoRouterErrorBoundary')) &&
+        l.startsWith('import')
+          ? i
+          : -1,
+      )
+      .filter(i => i !== -1);
+    expect(helperLineIndexes.length).toBe(2);
+    helperLineIndexes.forEach(i => expect(i).toBeLessThan(firstNonImport));
+  });
+
   it('leaves unrelated re-exports alone', () => {
     const src = `export { Stack } from 'expo-router';\nexport { foo } from 'other-pkg';`;
     const out = transform(src);

--- a/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
+++ b/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
@@ -1,0 +1,63 @@
+import { transformSync } from '@babel/core';
+
+import sentryExpoRouterAutoWrapBabelPlugin from '../../src/js/tools/sentryExpoRouterAutoWrapBabelPlugin';
+
+function transform(code: string, filename: string = '/app/(tabs)/index.tsx'): string {
+  const result = transformSync(code, {
+    filename,
+    babelrc: false,
+    configFile: false,
+    plugins: [sentryExpoRouterAutoWrapBabelPlugin],
+  });
+  return result?.code ?? '';
+}
+
+describe('sentryExpoRouterAutoWrapBabelPlugin', () => {
+  it('wraps a plain `export { ErrorBoundary } from "expo-router"` re-export', () => {
+    const out = transform(`export { ErrorBoundary } from 'expo-router';`);
+    expect(out).toMatch(
+      /import\s*\{\s*ErrorBoundary as __sentryOriginalExpoErrorBoundary\s*\}\s*from\s*['"]expo-router['"]/,
+    );
+    expect(out).toMatch(
+      /import\s*\{\s*wrapExpoRouterErrorBoundary as __sentryWrapExpoRouterErrorBoundary\s*\}\s*from\s*['"]@sentry\/react-native['"]/,
+    );
+    expect(out).toContain(
+      `export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary)`,
+    );
+  });
+
+  it('preserves the user-chosen name on aliased re-exports', () => {
+    const out = transform(`export { ErrorBoundary as RouteErrorBoundary } from 'expo-router';`);
+    expect(out).toContain(
+      `export const RouteErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary)`,
+    );
+  });
+
+  it('keeps sibling specifiers untouched on mixed re-exports', () => {
+    const out = transform(`export { ErrorBoundary, Stack } from 'expo-router';`);
+    expect(out).toContain(
+      `export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary)`,
+    );
+    expect(out).toMatch(/export\s*\{\s*Stack\s*\}\s*from\s*['"]expo-router['"]/);
+  });
+
+  it('leaves unrelated re-exports alone', () => {
+    const src = `export { Stack } from 'expo-router';\nexport { foo } from 'other-pkg';`;
+    const out = transform(src);
+    expect(out).not.toContain('__sentryWrapExpoRouterErrorBoundary');
+    expect(out).not.toContain('@sentry/react-native');
+  });
+
+  it('is idempotent — running the plugin twice does not double-wrap', () => {
+    const first = transform(`export { ErrorBoundary } from 'expo-router';`);
+    const second = transform(first);
+    const occurrences = second.match(/__sentryWrapExpoRouterErrorBoundary\(/g)?.length ?? 0;
+    expect(occurrences).toBe(1);
+  });
+
+  it('skips files inside node_modules', () => {
+    const out = transform(`export { ErrorBoundary } from 'expo-router';`, '/proj/node_modules/expo-router/build/x.js');
+    expect(out).not.toContain('@sentry/react-native');
+    expect(out).toMatch(/export\s*\{\s*ErrorBoundary\s*\}\s*from\s*['"]expo-router['"]/);
+  });
+});

--- a/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
+++ b/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
@@ -21,24 +21,37 @@ describe('sentryExpoRouterAutoWrapBabelPlugin', () => {
     expect(out).toMatch(
       /import\s*\{\s*wrapExpoRouterErrorBoundary as __sentryWrapExpoRouterErrorBoundary\s*\}\s*from\s*['"]@sentry\/react-native['"]/,
     );
-    expect(out).toContain(
-      `export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary)`,
+    expect(out).toMatch(
+      /const\s+_wrappedErrorBoundary\w*\s*=\s*__sentryWrapExpoRouterErrorBoundary\(__sentryOriginalExpoErrorBoundary\)/,
     );
+    expect(out).toMatch(/export\s*\{\s*_wrappedErrorBoundary\w*\s+as\s+ErrorBoundary\s*\}/);
   });
 
   it('preserves the user-chosen name on aliased re-exports', () => {
     const out = transform(`export { ErrorBoundary as RouteErrorBoundary } from 'expo-router';`);
-    expect(out).toContain(
-      `export const RouteErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary)`,
-    );
+    expect(out).toMatch(/export\s*\{\s*_wrappedRouteErrorBoundary\w*\s+as\s+RouteErrorBoundary\s*\}/);
   });
 
   it('keeps sibling specifiers untouched on mixed re-exports', () => {
     const out = transform(`export { ErrorBoundary, Stack } from 'expo-router';`);
-    expect(out).toContain(
-      `export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary)`,
-    );
+    expect(out).toMatch(/export\s*\{\s*_wrappedErrorBoundary\w*\s+as\s+ErrorBoundary\s*\}/);
     expect(out).toMatch(/export\s*\{\s*Stack\s*\}\s*from\s*['"]expo-router['"]/);
+  });
+
+  it('does not clash with an existing local `ErrorBoundary` binding in the same file', () => {
+    // The user uses ErrorBoundary locally AND re-exports it for Expo Router.
+    // Declaring `export const ErrorBoundary = ...` would duplicate the binding
+    // introduced by the existing `import { ErrorBoundary }` line and fail to
+    // compile. The wrapped value must use a unique local instead.
+    const src = [
+      `import { ErrorBoundary } from 'expo-router';`,
+      `const Local = ErrorBoundary;`,
+      `export { ErrorBoundary } from 'expo-router';`,
+    ].join('\n');
+    const out = transform(src);
+    // The wrapped value uses a fresh uid — no second `const ErrorBoundary =` is emitted.
+    expect(out).not.toMatch(/const\s+ErrorBoundary\s*=/);
+    expect(out).toMatch(/export\s*\{\s*_wrappedErrorBoundary\w*\s+as\s+ErrorBoundary\s*\}/);
   });
 
   it('hoists helper imports to the top of the file, never mid-file', () => {
@@ -80,8 +93,8 @@ describe('sentryExpoRouterAutoWrapBabelPlugin', () => {
     const out = transform(src);
     const wrapCalls = out.match(/__sentryWrapExpoRouterErrorBoundary\(/g)?.length ?? 0;
     expect(wrapCalls).toBe(2);
-    expect(out).toMatch(/export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary/);
-    expect(out).toMatch(/export const Other = __sentryWrapExpoRouterErrorBoundary/);
+    expect(out).toMatch(/export\s*\{\s*_wrappedErrorBoundary\w*\s+as\s+ErrorBoundary\s*\}/);
+    expect(out).toMatch(/export\s*\{\s*_wrappedOther\w*\s+as\s+Other\s*\}/);
     // Helper imports must be emitted exactly once per file — duplicates are
     // an ES module syntax error.
     const expoImports =

--- a/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
+++ b/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
@@ -51,10 +51,18 @@ describe('sentryExpoRouterAutoWrapBabelPlugin', () => {
   it('wraps every ErrorBoundary re-export when several appear in the same file', () => {
     const src = `export { ErrorBoundary } from 'expo-router';\nexport { ErrorBoundary as Other } from 'expo-router';`;
     const out = transform(src);
-    const occurrences = out.match(/__sentryWrapExpoRouterErrorBoundary\(/g)?.length ?? 0;
-    expect(occurrences).toBe(2);
+    const wrapCalls = out.match(/__sentryWrapExpoRouterErrorBoundary\(/g)?.length ?? 0;
+    expect(wrapCalls).toBe(2);
     expect(out).toMatch(/export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary/);
     expect(out).toMatch(/export const Other = __sentryWrapExpoRouterErrorBoundary/);
+    // Helper imports must be emitted exactly once per file — duplicates are
+    // an ES module syntax error.
+    const expoImports =
+      out.match(/import\s*\{\s*ErrorBoundary as __sentryOriginalExpoErrorBoundary\s*\}/g)?.length ?? 0;
+    const sentryImports =
+      out.match(/import\s*\{\s*wrapExpoRouterErrorBoundary as __sentryWrapExpoRouterErrorBoundary\s*\}/g)?.length ?? 0;
+    expect(expoImports).toBe(1);
+    expect(sentryImports).toBe(1);
   });
 
   it('is idempotent — running the plugin twice does not double-wrap', () => {

--- a/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
+++ b/packages/core/test/tools/sentryExpoRouterAutoWrapBabelPlugin.test.ts
@@ -48,6 +48,15 @@ describe('sentryExpoRouterAutoWrapBabelPlugin', () => {
     expect(out).not.toContain('@sentry/react-native');
   });
 
+  it('wraps every ErrorBoundary re-export when several appear in the same file', () => {
+    const src = `export { ErrorBoundary } from 'expo-router';\nexport { ErrorBoundary as Other } from 'expo-router';`;
+    const out = transform(src);
+    const occurrences = out.match(/__sentryWrapExpoRouterErrorBoundary\(/g)?.length ?? 0;
+    expect(occurrences).toBe(2);
+    expect(out).toMatch(/export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary/);
+    expect(out).toMatch(/export const Other = __sentryWrapExpoRouterErrorBoundary/);
+  });
+
   it('is idempotent — running the plugin twice does not double-wrap', () => {
     const first = transform(`export { ErrorBoundary } from 'expo-router';`);
     const second = transform(first);

--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/react-native';
 import { isRunningInExpoGo } from 'expo';
 import * as ImagePicker from 'expo-image-picker';
-import { ErrorBoundary as ExpoErrorBoundary, SplashScreen, Stack } from 'expo-router';
+import { SplashScreen, Stack } from 'expo-router';
 import { DarkTheme, DefaultTheme, ThemeProvider } from 'expo-router/react-navigation';
 import { useEffect } from 'react';
 import { LogBox } from 'react-native';
@@ -10,9 +10,10 @@ import { useColorScheme } from '@/components/useColorScheme';
 
 import { SENTRY_INTERNAL_DSN } from '../utils/dsn';
 
-// Wrap Expo Router's per-route ErrorBoundary so render-phase errors that hit
-// the fallback UI are captured by Sentry with route context attached.
-export const ErrorBoundary = Sentry.wrapExpoRouterErrorBoundary(ExpoErrorBoundary);
+// Re-export Expo Router's per-route ErrorBoundary. `getSentryExpoConfig` auto
+// wraps it at build time with `Sentry.wrapExpoRouterErrorBoundary` so
+// render-phase errors that hit the fallback are captured with route context.
+export { ErrorBoundary } from 'expo-router';
 
 LogBox.ignoreAllLogs();
 

--- a/samples/expo/app/_layout.tsx
+++ b/samples/expo/app/_layout.tsx
@@ -10,9 +10,10 @@ import { useColorScheme } from '@/components/useColorScheme';
 
 import { SENTRY_INTERNAL_DSN } from '../utils/dsn';
 
-// Re-export Expo Router's per-route ErrorBoundary. `getSentryExpoConfig` auto
-// wraps it at build time with `Sentry.wrapExpoRouterErrorBoundary` so
-// render-phase errors that hit the fallback are captured with route context.
+// Re-export Expo Router's per-route ErrorBoundary. The Sentry Babel plugin
+// (enabled via `autoWrapExpoRouterErrorBoundary: true` in `metro.config.js`)
+// rewrites this at build time into a `Sentry.wrapExpoRouterErrorBoundary`
+// call so render-phase errors that hit the fallback are captured.
 export { ErrorBoundary } from 'expo-router';
 
 LogBox.ignoreAllLogs();

--- a/samples/expo/metro.config.js
+++ b/samples/expo/metro.config.js
@@ -12,6 +12,9 @@ const config = getSentryExpoConfig(__dirname, {
   annotateReactComponents: {
     ignoredComponents: ['BottomTabsNavigator'],
   },
+  // Auto-wrap `export { ErrorBoundary } from 'expo-router'` so the Expo Router
+  // per-route boundary is captured by Sentry without route-file edits.
+  autoWrapExpoRouterErrorBoundary: true,
 });
 
 module.exports = withMonorepo(config);


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Adds a Babel plugin (sentryExpoRouterAutoWrapBabelPlugin) that auto-wraps Expo Router's per-route ErrorBoundary re-exports at build time, removing the manual call-site step introduced in #6318.

 The plugin detects this in user source files:

 ```ts
   export { ErrorBoundary } from 'expo-router';
 ```

and rewrites it to:

 ```ts
   import { ErrorBoundary as __sentryOriginalExpoErrorBoundary } from 'expo-router';
   import { wrapExpoRouterErrorBoundary as __sentryWrapExpoRouterErrorBoundary } from '@sentry/react-native';
   export const ErrorBoundary = __sentryWrapExpoRouterErrorBoundary(__sentryOriginalExpoErrorBoundary);
 ```

 So users get the full ErrorBoundary instrumentation (route context, navigation-span error tagging, breadcrumb) with zero code changes in their route files.

## :bulb: Motivation and Context
#6318 shipped Sentry.wrapExpoRouterErrorBoundary but required users to edit every route file that re-exports ErrorBoundary from expo-router. That edit is trivial & easy to forget on new routes.

## :green_heart: How did you test it?


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
