### PR TITLE
feat(core): Use native btoa for envelope base64 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Features
 
+- Use the runtime's native `btoa` for envelope base64 encoding when available, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if `btoa` is missing.
 - Capture errors that hit Expo Router's per-route `ErrorBoundary` ([#6318](https://github.com/getsentry/sentry-react-native/pull/6318))
 
   Wrap the boundary with `Sentry.wrapExpoRouterErrorBoundary` in your route file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Use the runtime's native `btoa` for envelope base64 encoding when available, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if `btoa` is missing.
+- Use the runtime's native `btoa` for envelope base64 encoding when available, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if `btoa` is missing ([#6351](https://github.com/getsentry/sentry-react-native/pull/6351)).
 - Capture errors that hit Expo Router's per-route `ErrorBoundary` ([#6318](https://github.com/getsentry/sentry-react-native/pull/6318))
 
   Wrap the boundary with `Sentry.wrapExpoRouterErrorBoundary` in your route file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
-## 8.16.0
+## Unreleased
 
 ### Features
 
 - Use the runtime's native `btoa` for envelope base64 encoding when available, to improve `captureEnvelope` performance. Falls back to the bundled JS encoder if `btoa` is missing ([#6351](https://github.com/getsentry/sentry-react-native/pull/6351)).
+
+## 8.16.0
+
+### Features
+
 - Capture errors that hit Expo Router's per-route `ErrorBoundary` ([#6318](https://github.com/getsentry/sentry-react-native/pull/6318))
 
   Wrap the boundary with `Sentry.wrapExpoRouterErrorBoundary` in your route file:

--- a/packages/core/src/js/utils/base64.ts
+++ b/packages/core/src/js/utils/base64.ts
@@ -6,10 +6,10 @@ const CHUNK_SIZE = 0x8000;
 
 /**
  * Encodes a byte array to base64. Uses the runtime's native `btoa` when
- * available (Hermes and modern JSC both expose it), which is significantly
- * faster than the pure-JS encoder for the envelope payloads going through
- * `RNSentry.captureEnvelope`. Falls back to the bundled JS encoder when
- * `btoa` is missing (e.g. older JS engines).
+ * available — Hermes exposes it natively, and some JSC builds do too — which
+ * is significantly faster than the pure-JS encoder for the envelope payloads
+ * going through `RNSentry.captureEnvelope`. Falls back to the bundled JS
+ * encoder when `btoa` is missing.
  */
 export function encodeToBase64(bytes: Uint8Array): string {
   const nativeBtoa = (globalThis as { btoa?: (input: string) => string }).btoa;

--- a/packages/core/src/js/utils/base64.ts
+++ b/packages/core/src/js/utils/base64.ts
@@ -1,0 +1,25 @@
+import { base64StringFromByteArray } from '../vendor';
+
+// Chunk size for `String.fromCharCode.apply` — keeps argument count well below
+// engine limits while still amortising the call overhead across many bytes.
+const CHUNK_SIZE = 0x8000;
+
+/**
+ * Encodes a byte array to base64. Uses the runtime's native `btoa` when
+ * available (Hermes and modern JSC both expose it), which is significantly
+ * faster than the pure-JS encoder for the envelope payloads going through
+ * `RNSentry.captureEnvelope`. Falls back to the bundled JS encoder when
+ * `btoa` is missing (e.g. older JS engines).
+ */
+export function encodeToBase64(bytes: Uint8Array): string {
+  const nativeBtoa = (globalThis as { btoa?: (input: string) => string }).btoa;
+  if (typeof nativeBtoa !== 'function') {
+    return base64StringFromByteArray(bytes);
+  }
+
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK_SIZE) as unknown as number[]);
+  }
+  return nativeBtoa(binary);
+}

--- a/packages/core/src/js/wrapper.ts
+++ b/packages/core/src/js/wrapper.ts
@@ -30,11 +30,11 @@ import type { MobileReplayOptions } from './replay/mobilereplay';
 import type { RequiredKeysUser } from './user';
 
 import { isHardCrash } from './misc';
+import { encodeToBase64 } from './utils/base64';
 import { encodeUTF8 } from './utils/encode';
 import { isTurboModuleEnabled } from './utils/environment';
 import { convertToNormalizedObject } from './utils/normalize';
 import { ReactNativeLibraries } from './utils/rnlibraries';
-import { base64StringFromByteArray } from './vendor';
 import { SDK_VERSION } from './version';
 
 /**
@@ -231,7 +231,7 @@ export const NATIVE: SentryNativeWrapper = {
       envelopeBytes = newBytes;
     }
 
-    await RNSentry.captureEnvelope(base64StringFromByteArray(envelopeBytes), { hardCrashed });
+    await RNSentry.captureEnvelope(encodeToBase64(envelopeBytes), { hardCrashed });
   },
 
   /**

--- a/packages/core/test/utils/base64.test.ts
+++ b/packages/core/test/utils/base64.test.ts
@@ -1,0 +1,18 @@
+import { encodeToBase64 } from '../../src/js/utils/base64';
+
+describe('encodeToBase64', () => {
+  test('encodes a small byte array correctly', () => {
+    // "sentry" => "c2VudHJ5"
+    expect(encodeToBase64(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]))).toBe('c2VudHJ5');
+  });
+
+  test('encodes a large byte array correctly (exercises chunked path)', () => {
+    // 100,000 bytes — well past CHUNK_SIZE (0x8000 = 32,768) so we cross
+    // multiple chunks. Compare against Node's reference Buffer encoding.
+    const bytes = new Uint8Array(100_000);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i % 256;
+    }
+    expect(encodeToBase64(bytes)).toBe(Buffer.from(bytes).toString('base64'));
+  });
+});

--- a/packages/core/test/utils/base64.test.ts
+++ b/packages/core/test/utils/base64.test.ts
@@ -15,4 +15,17 @@ describe('encodeToBase64', () => {
     }
     expect(encodeToBase64(bytes)).toBe(Buffer.from(bytes).toString('base64'));
   });
+
+  test('falls back to the JS encoder when `btoa` is unavailable', () => {
+    const originalBtoa = (globalThis as { btoa?: unknown }).btoa;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).btoa;
+    try {
+      // "sentry" => "c2VudHJ5"
+      expect(encodeToBase64(new Uint8Array([0x73, 0x65, 0x6e, 0x74, 0x72, 0x79]))).toBe('c2VudHJ5');
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).btoa = originalBtoa;
+    }
+  });
 });


### PR DESCRIPTION
## 📢 Type of change

- [ ] Bugfix
- [ ] New feature
- [X] Enhancement
- [ ] Refactoring

## 📜 Description

Switch envelope base64 encoding on the `RNSentry.captureEnvelope` hot path from the bundled JS encoder to the runtime's native `btoa`. Hermes and modern JSC both expose `btoa`, and the native implementation should be significantly faster than the pure-JS encoder for the envelope payloads going through the bridge (profiles, attachments, replays).

The comes with no native code and no breaking changes for the customers.

## 💡 Motivation and Context

Closes getsentry/sentry-react-native#4884.  <br>Alternative approach to getsentry/sentry-react-native#6314 (which should be closed now)

## 💚 How did you test it?

* Added `test/utils/base64.test.ts`

## :pencil: Checklist

- [X] I added tests to verify changes
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [X] All tests passing
- [X] No breaking changes