### PR TITLE
fix(ci): Skip Java, Gradle, and replay-stubs for iOS E2E jobs

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -117,13 +117,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
       - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         with:
           java-version: "17"
           distribution: "adopt"
 
       - name: Gradle cache
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Setup asdf Node.js (Bitrise)
@@ -388,13 +388,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
       - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         with:
           java-version: "17"
           distribution: "adopt"
 
       - name: Gradle cache
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Setup Global Tools
@@ -561,13 +561,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
       - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         with:
           java-version: "17"
           distribution: "adopt"
 
       - name: Gradle cache
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Setup KVM

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -170,6 +170,8 @@ jobs:
       - name: Build SDK
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         run: yarn build
+        env:
+          PLATFORM: ${{ matrix.platform }}
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         if: ${{ steps.platform-check.outputs.skip != 'true' }}

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -126,6 +126,13 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
+      - uses: actions/cache@v4
+        name: Cache Gradle Wrapper
+        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        with:
+          path: ~/.gradle/wrapper/dists
+          key: gradle-wrapper-${{ hashFiles('packages/core/android/replay-stubs/gradle/wrapper/gradle-wrapper.properties') }}
+
       - name: Setup asdf Node.js (Bitrise)
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.runner_provider == 'bitrise' }}
         run: |
@@ -397,6 +404,13 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
+      - uses: actions/cache@v4
+        name: Cache Gradle Wrapper
+        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        with:
+          path: ~/.gradle/wrapper/dists
+          key: gradle-wrapper-${{ hashFiles('packages/core/android/replay-stubs/gradle/wrapper/gradle-wrapper.properties') }}
+
       - name: Setup Global Tools
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         run: |
@@ -569,6 +583,13 @@ jobs:
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+
+      - uses: actions/cache@v4
+        name: Cache Gradle Wrapper
+        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        with:
+          path: ~/.gradle/wrapper/dists
+          key: gradle-wrapper-${{ hashFiles('packages/core/android/replay-stubs/gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Setup KVM
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -126,13 +126,6 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
-      - uses: actions/cache@v4
-        name: Cache Gradle Wrapper
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ hashFiles('packages/core/android/replay-stubs/gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Setup asdf Node.js (Bitrise)
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.runner_provider == 'bitrise' }}
         run: |
@@ -404,13 +397,6 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
-      - uses: actions/cache@v4
-        name: Cache Gradle Wrapper
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ hashFiles('packages/core/android/replay-stubs/gradle/wrapper/gradle-wrapper.properties') }}
-
       - name: Setup Global Tools
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         run: |
@@ -583,13 +569,6 @@ jobs:
       - name: Gradle cache
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
-
-      - uses: actions/cache@v4
-        name: Cache Gradle Wrapper
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
-        with:
-          path: ~/.gradle/wrapper/dists
-          key: gradle-wrapper-${{ hashFiles('packages/core/android/replay-stubs/gradle/wrapper/gradle-wrapper.properties') }}
 
       - name: Setup KVM
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}

--- a/dev-packages/e2e-tests/cli.mjs
+++ b/dev-packages/e2e-tests/cli.mjs
@@ -108,7 +108,7 @@ function patchBoostIfNeeded(rnVersion, patchScriptsDir) {
 // Build and publish the SDK - we only need to do this once in CI.
 // Locally, we may want to get updates from the latest build so do it on every app build.
 if (actions.includes('create') || (env.CI === undefined && actions.includes('build'))) {
-  execSync(`yarn build`, { stdio: 'inherit', cwd: workspaceRootDir, env: env });
+  execSync(`yarn build`, { stdio: 'inherit', cwd: workspaceRootDir, env: { ...env, PLATFORM: platform } });
   execSync(`yalc publish --private`, { stdio: 'inherit', cwd: e2eDir, env: env });
   execSync(`yalc publish`, { stdio: 'inherit', cwd: expoUploadSourcemapsPackageDir, env: env });
   execSync(`yalc publish`, { stdio: 'inherit', cwd: corePackageDir, env: env });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,7 @@
     "build:tools": "tsc -p tsconfig.build.tools.json",
     "build:tools:watch": "tsc -p tsconfig.build.tools.json -w --preserveWatchOutput",
     "build:plugin": "EXPO_NONINTERACTIVE=true expo-module build plugin",
-    "build:replay-stubs": "cd android/replay-stubs && ./gradlew jar",
+    "build:replay-stubs": "[ \"$PLATFORM\" = \"ios\" ] && echo 'Skipping replay-stubs for iOS' && exit 0 || cd android/replay-stubs && ./gradlew jar",
     "build:tarball": "bash scripts/build-tarball.sh",
     "downlevel": "downlevel-dts dist ts3.8/dist --to=3.8",
     "clean": "rimraf dist coverage && yarn clean:plugin",


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

- Skips the `build:replay-stubs` Gradle build when `PLATFORM=ios` is set, since the replay-stubs JAR is only needed on Android.
- Passes `PLATFORM` env var from `cli.mjs` into the `yarn build` step so iOS E2E builds avoid invoking Gradle entirely.
- Restricts `setup-java` and `setup-gradle` steps to Android-only (`matrix.platform == 'android'`) across all three E2E jobs (metrics, react-native-build, react-native-test).

#skip-changelog

## :bulb: Motivation and Context

The [Build RN 0.86.0 iOS job on Bitrise](https://github.com/getsentry/sentry-react-native/actions/runs/28171582918/job/83442246522) failed because the Gradle wrapper download timed out (`gradle-8.13-bin.zip` — 10s socket timeout on `services.gradle.org`). This caused the build artifact to never be uploaded, which cascaded into the downstream test job also failing.

iOS builds don't need Java, Gradle, or the replay-stubs JAR at all. Skipping these avoids this class of failure and speeds up iOS E2E builds.


## :green_heart: How did you test it?

- Verified the `build:replay-stubs` skip logic works for all three cases: `PLATFORM=ios` (skips), `PLATFORM=android` (runs), unset (runs).
- All other platform-specific steps (Ruby, CocoaPods, Ninja, xcbeautify, KVM, iDB) were already correctly guarded — no changes needed there.


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps