### PR TITLE
chore(ci): Move sample app iOS build jobs to GitHub Actions runners

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -39,8 +39,7 @@ jobs:
     uses: ./.github/workflows/skip-ci-noauth.yml
     secrets: inherit
   metrics:
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:tahoe"]') || matrix.runs-on }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, detect-changes, auth_token_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') }}
     env:
@@ -53,14 +52,9 @@ jobs:
       matrix:
         rn-architecture: ["legacy", "new"]
         platform: ["ios", "android"]
-        runner_provider: ["cirrus", "bitrise"]
         include:
           - platform: ios
-            runs-on:
-              [
-                "ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0",
-                "runner_group_id:10",
-              ]
+            runs-on: macos-26-xlarge
             name: iOS
             appPlain: performance-tests/test-app-plain.ipa
           - platform: android
@@ -71,9 +65,6 @@ jobs:
               ]
             name: Android
             appPlain: performance-tests/TestAppPlain/android/app/build/outputs/apk/release/app-release.apk
-        exclude:
-          - platform: android
-            runner_provider: bitrise
     steps:
       - name: Check if platform is needed
         id: platform-check
@@ -126,36 +117,8 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
-      - name: Setup asdf Node.js (Bitrise)
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.runner_provider == 'bitrise' }}
-        run: |
-          asdf global nodejs system
-          corepack enable
-
-      - uses: actions/cache@v4
-        name: Cache Ruby
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider != 'bitrise' }}
-        with:
-          path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - uses: actions/cache@v4
-        name: Cache Ruby (Bitrise)
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider == 'bitrise' }}
-        with:
-          path: ~/.asdf/installs/ruby
-          key: asdf-ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - name: Install Ruby (Bitrise)
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider == 'bitrise' }}
-        run: |
-          asdf install ruby 3.3.0
-          asdf local ruby 3.3.0
-
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider != 'bitrise' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' }}
         with:
           ruby-version: "3.3.0"
 

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -219,9 +219,8 @@ jobs:
           sauce-key: ${{ secrets.SAUCE_ACCESS_KEY }}
 
   react-native-build:
-    name: Build RN ${{ matrix.rn-version }} ${{ matrix.rn-architecture }} ${{ matrix.engine }} ${{ matrix.platform }} ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }} on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON(format('["bitrise_pool_name:{0}"]', matrix.macos_version)) || matrix.runs-on }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    name: Build RN ${{ matrix.rn-version }} ${{ matrix.rn-architecture }} ${{ matrix.engine }} ${{ matrix.platform }} ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }}
+    runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, detect-changes, auth_token_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.auth_token_check.outputs.skip_ci != 'true' && !startsWith(github.ref, 'refs/heads/release/') }}
     env:
@@ -240,33 +239,21 @@ jobs:
         build-type: ["production"]
         ios-use-frameworks: ["no", "static", "dynamic"]
         engine: ["hermes"]
-        runner_provider: ["cirrus", "bitrise"]
         include:
-          # Use Xcode 16 for older RN versions
+          # Use Xcode 16 (macos-15) for older RN versions
           - platform: ios
             rn-version: "0.71.19"
-            runs-on:
-              [
-                "ghcr.io/cirruslabs/macos-sequoia-xcode:16.4",
-                "runner_group_id:10",
-              ]
-            macos_version: "sequoia"
-          # Use Xcode 26 for newer RN versions
+            runs-on: macos-15-xlarge
+          # Use Xcode 26 (macos-26) for newer RN versions
           - platform: ios
             rn-version: "0.86.0"
-            runs-on:
-              [
-                "ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0",
-                "runner_group_id:10",
-              ]
-            macos_version: tahoe
+            runs-on: macos-26-xlarge
           - platform: android
             runs-on:
               [
                 "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04",
                 "runner_group_id:10",
               ]
-            macos_version: none
         exclude:
           # exclude all rn versions lower than 0.80.0 for new architecture
           - rn-version: "0.71.19"
@@ -286,9 +273,6 @@ jobs:
           # exclude new rn architecture and dynamic frameworks
           - rn-architecture: "new"
             ios-use-frameworks: "dynamic"
-          # only run bitrise for macOS (iOS) jobs
-          - platform: "android"
-            runner_provider: "bitrise"
 
     steps:
       - name: Check if platform is needed
@@ -340,24 +324,18 @@ jobs:
           cache: "yarn"
           cache-dependency-path: yarn.lock
 
-      - name: Setup asdf Node.js (Bitrise)
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.runner_provider == 'bitrise' }}
-        run: |
-          asdf global nodejs system
-          corepack enable
-
       - name: Install Ninja
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         run: sudo apt-get update && sudo apt-get install -y ninja-build
 
       - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         with:
           java-version: "17"
           distribution: "adopt"
 
       - name: Gradle cache
-        if: ${{ steps.platform-check.outputs.skip != 'true' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'android' }}
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Setup Global Tools
@@ -373,30 +351,8 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' }}
         run: yarn install
 
-      - uses: actions/cache@v4
-        name: Cache Ruby
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider != 'bitrise' }}
-        with:
-          path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - uses: actions/cache@v4
-        name: Cache Ruby (Bitrise)
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider == 'bitrise' }}
-        with:
-          path: ~/.asdf/installs/ruby
-          key: asdf-ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - name: Install Ruby (Bitrise)
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider == 'bitrise' }}
-        run: |
-          asdf install ruby 3.3.0
-          asdf local ruby 3.3.0
-
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' && matrix.runner_provider != 'bitrise' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' }}
         with:
           ruby-version: "3.3.0"
 
@@ -412,7 +368,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.build-type == 'production' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-${{ matrix.runner_provider }}-app-package
+          name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-app-package
           path: dev-packages/e2e-tests/RnDiffApp.ap*
           retention-days: 1
 
@@ -420,7 +376,7 @@ jobs:
         if: ${{ always() && steps.platform-check.outputs.skip != 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: rn-build-logs-${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-${{ matrix.runner_provider }}
+          name: rn-build-logs-${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}
           path: dev-packages/e2e-tests/react-native-versions/${{ matrix.rn-version }}/RnDiffApp/ios/*.log
 
   react-native-test:
@@ -498,7 +454,7 @@ jobs:
         if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.build-type == 'production' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-${{ matrix.runner_provider }}-app-package
+          name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-app-package
           path: dev-packages/e2e-tests
 
       - name: Enable Corepack

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -35,9 +35,8 @@ jobs:
       caller_ref: ${{ github.ref }}
 
   build-ios:
-    name: Build ios ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }} on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]') }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    name: Build ios ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }}
+    runs-on: macos-26-xlarge
     needs: [diff_check, detect-changes]
     if: >-
       ${{
@@ -52,7 +51,6 @@ jobs:
       matrix:
         ios-use-frameworks: ["no-frameworks", "dynamic-frameworks"]
         build-type: ["dev", "production"]
-        runner_provider: ["cirrus", "bitrise"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -66,37 +64,7 @@ jobs:
           cache: "yarn"
           cache-dependency-path: yarn.lock
 
-      - name: Setup asdf Node.js (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        run: |
-          asdf global nodejs system
-          corepack enable
-
-      - uses: actions/cache@v4
-        name: Cache Ruby
-        if: matrix.runner_provider != 'bitrise'
-        with:
-          path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - uses: actions/cache@v4
-        name: Cache Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        with:
-          path: ~/.asdf/installs/ruby
-          key: asdf-ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - name: Install Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        working-directory: samples/expo
-        run: |
-          asdf install ruby 3.3.0
-          asdf local ruby 3.3.0
-
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
-        if: matrix.runner_provider != 'bitrise'
         with:
           working-directory: samples/expo
           ruby-version: "3.3.0" # based on what is used in the sample
@@ -161,7 +129,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: build-sample-expo-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-${{ matrix.runner_provider }}-logs
+          name: build-sample-expo-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-logs
           path: samples/expo/ios/*.log
 
   build-android:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -43,9 +43,8 @@ jobs:
       caller_ref: ${{ github.ref }}
 
   build-ios:
-    name: Build ${{ matrix.rn-architecture }} ios ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }} on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]') }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    name: Build ${{ matrix.rn-architecture }} ios ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }}
+    runs-on: macos-26-xlarge
     needs: [diff_check, detect-changes]
     if: >-
       ${{
@@ -61,7 +60,6 @@ jobs:
         rn-architecture: ["new"]
         ios-use-frameworks: ["no-frameworks"]
         build-type: ["dev", "production"]
-        runner_provider: ["cirrus", "bitrise"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -75,38 +73,7 @@ jobs:
           cache: "yarn"
           cache-dependency-path: yarn.lock
 
-      - name: Setup asdf Node.js (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        run: |
-          asdf global nodejs system
-          corepack enable
-
-      - uses: actions/cache@v4
-        name: Cache Ruby
-        if: matrix.runner_provider != 'bitrise'
-        with:
-          path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - uses: actions/cache@v4
-        name: Cache Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        with:
-          path: ~/.asdf/installs/ruby
-          key: asdf-ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - name: Install Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        working-directory: ${{ env.REACT_NATIVE_SAMPLE_PATH }}
-        run: |
-          asdf install ruby 3.3.0
-          asdf local ruby 3.3.0
-          bundle install
-
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
-        if: matrix.runner_provider != 'bitrise'
         with:
           working-directory: ${{ env.REACT_NATIVE_SAMPLE_PATH }}
           ruby-version: "3.3.0" # based on what is used in the sample
@@ -156,7 +123,7 @@ jobs:
         if: ${{ matrix.rn-architecture == 'new' && matrix.build-type == 'production' && matrix.ios-use-frameworks == 'no-frameworks' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: sample-rn-${{ matrix.rn-architecture }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-ios-${{ matrix.runner_provider }}
+          name: sample-rn-${{ matrix.rn-architecture }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-ios
           path: ${{ env.IOS_APP_ARCHIVE_PATH }}
           retention-days: 1
 
@@ -164,7 +131,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: build-sample-${{ matrix.rn-architecture }}-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-${{ matrix.runner_provider }}-logs
+          name: build-sample-${{ matrix.rn-architecture }}-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-logs
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/ios/*.log
 
   build-android:
@@ -244,9 +211,8 @@ jobs:
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/android/*.log
 
   build-macos:
-    name: Build legacy macos ${{ matrix.build-type }} on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:sequoia"]') || fromJSON('["ghcr.io/cirruslabs/macos-sequoia-xcode:16.4", "runner_group_id:10"]') }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    name: Build legacy macos ${{ matrix.build-type }}
+    runs-on: macos-15-xlarge
     needs: [diff_check, detect-changes]
     if: >-
       ${{
@@ -260,7 +226,6 @@ jobs:
       fail-fast: false
       matrix:
         build-type: ["dev", "production"]
-        runner_provider: ["cirrus", "bitrise"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -274,38 +239,7 @@ jobs:
           cache: "yarn"
           cache-dependency-path: yarn.lock
 
-      - name: Setup asdf Node.js (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        run: |
-          asdf global nodejs system
-          corepack enable
-
-      - uses: actions/cache@v4
-        name: Cache Ruby
-        if: matrix.runner_provider != 'bitrise'
-        with:
-          path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - uses: actions/cache@v4
-        name: Cache Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        with:
-          path: ~/.asdf/installs/ruby
-          key: asdf-ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - name: Install Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
-        working-directory: samples/react-native-macos
-        run: |
-          asdf install ruby 3.3.0
-          asdf local ruby 3.3.0
-          bundle install
-
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1
-        if: matrix.runner_provider != 'bitrise'
         with:
           working-directory: samples/react-native-macos
           ruby-version: "3.3.0" # based on what is used in the sample
@@ -351,7 +285,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: build-sample-legacy-macos-${{ matrix.build-type }}-no-frameworks-${{ matrix.runner_provider }}-logs
+          name: build-sample-legacy-macos-${{ matrix.build-type }}-no-frameworks-logs
           path: samples/react-native-macos/macos/*.log
 
   test-ios:
@@ -380,7 +314,7 @@ jobs:
       - name: Download iOS App Archive
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: sample-rn-new-production-no-frameworks-ios-${{ matrix.runner_provider }}
+          name: sample-rn-new-production-no-frameworks-ios
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}
 
       - name: Unzip iOS App Archive


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

Moves build-only iOS jobs from Cirrus/Bitrise to GitHub-hosted runners:
- `sample-application.yml` `build-ios` → `macos-26-xlarge`
- `sample-application.yml` `build-macos` → `macos-15-xlarge` (needs Xcode 16.4)
- `sample-application-expo.yml` `build-ios` → `macos-26-xlarge`

Removes the `runner_provider` matrix and all dead Bitrise-specific steps (asdf, Bitrise Ruby cache/install) from build jobs. Test jobs (`test-ios`) remain on Cirrus/Bitrise as they need simulators.

Artifact names no longer include the runner provider suffix since builds now produce a single artifact.


## :bulb: Motivation and Context

Build-only jobs don't need simulator access — they just compile with Xcode. GitHub-hosted `macos-26-xlarge` runners showed comparable performance to Cirrus in prior testing (size-analysis and testflight PRs) while being simpler to maintain and more stable.

| Workflow | Cirrus | macos-26 | macos-26-xlarge |
|---|---|---|---|
| **iOS Size Analysis** | 6 min | 15 min | 7 min |
| **Testflight** | 7 min | 18 min | 8 min |


## :green_heart: How did you test it?

- Verified all removed steps were behind `runner_provider == 'bitrise'` conditions.
- Confirmed `test-ios` artifact download references match the updated upload names.
- Android and test jobs are unchanged.


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps