### PR TITLE
fix(deps): Bump faraday to 1.10.6

### DIFF
--- a/performance-tests/Gemfile.lock
+++ b/performance-tests/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)

--- a/samples/react-native-macos/Gemfile.lock
+++ b/samples/react-native-macos/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring

## :scroll: Description

Bumps `faraday` from `1.10.5` to `1.10.6` in `performance-tests/Gemfile.lock` and in `samples/react-native-macos/Gemfile.lock`

#skip-changelog

## :bulb: Motivation and Context

Addresses Dependabot alerts.

## :green_heart: How did you test it?

Lockfile-only change. CI runs the performance-tests bundle install/use; no functional behavior in this SDK changes.

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps