### PR TITLE
ci: Migrate Cirrus Ubuntu jobs to GitHub-hosted runners

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -17,7 +17,7 @@ jobs:
 
   job_test:
     name: Test
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
@@ -36,7 +36,7 @@ jobs:
 
   job_lint:
     name: Lint
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
@@ -103,7 +103,7 @@ jobs:
 
   job_check_integrity:
     name: Check package integrity
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
@@ -127,7 +127,7 @@ jobs:
 
   job_build:
     name: Build
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
@@ -170,7 +170,7 @@ jobs:
 
   job_validate_tarball:
     name: Validate tarball
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [job_build, diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     timeout-minutes: 5
@@ -251,7 +251,7 @@ jobs:
 
   job_type_check:
     name: Type Check Typescript 3.8
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [job_build, diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     env:
@@ -284,7 +284,7 @@ jobs:
         run: yarn type-check
   job_circular_dep_check:
     name: Circular Dependency Check
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [job_build, diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
@@ -313,7 +313,7 @@ jobs:
 
   job_api_report:
     name: API Report Check
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [job_build, diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     steps:
@@ -338,7 +338,7 @@ jobs:
 
   job_bundle:
     name: Bundle
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [job_test, job_build, diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     strategy:

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -16,7 +16,7 @@ jobs:
     uses: ./.github/workflows/skip-ci.yml
 
   codegen:
-    runs-on: ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-latest
     needs: [diff_check]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
     strategy:


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description

Migrate all 10 Cirrus Ubuntu runner jobs (`ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04`) to GitHub-hosted `ubuntu-latest` runners:

- **`buildandtest.yml`** (9 jobs): Test, Lint, Check package integrity, Build, Validate tarball, Type Check TS 3.8, Circular Dep Check, API Report Check, Bundle
- **`codegen.yml`** (1 job): Codegen (Android + iOS matrix)


## :bulb: Motivation and Context

These jobs don't require the Cirrus runner infrastructure and can run on standard GitHub-hosted Ubuntu runners.


## :green_heart: How did you test it?

CI will validate on this PR.


## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps

#skip-changelog