### PR TITLE
fix(ci): Pin Android E2E emulator to build 15679343 (37.1.5.0)

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -439,6 +439,11 @@ jobs:
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # pin@v2.37.0
         with:
           api-level: ${{ env.ANDROID_API_LEVEL }}
+          # Pin the emulator binary: canary 37.1.6.0 (build 15726199) broke emulator
+          # networking (no egress to 10.0.2.2 mock server or external internet), which
+          # makes the whole E2E suite time out. 37.1.5.0 (build 15679343) is the last
+          # known-good build. Remove once a fixed canary emulator ships.
+          emulator-build: 15679343
           force-avd-creation: false
           disable-animations: true
           disable-spellchecker: true


### PR DESCRIPTION
## 📜 Description

The `Test android production REV2` E2E job has been failing on every `main` push since ~2026-06-29. Pin the Android emulator binary to the last known-good build (`15679343` / `37.1.5.0`) via the `emulator-build` input.

## 💡 Motivation and Context

Root cause is an **unpinned canary emulator regression**, not the SDK or the CI runner image. Comparing the last green run (Jun 26) with the failures, the only variable that changed:

| | Last green (Jun 26) | Failing (Jun 29–30) |
|---|---|---|
| Code commit | `57896457` | same (verified via re-run) |
| Runner OS image | `ubuntu-24.04` / `20260622.220` | identical |
| System image | `system-images;android-30;aosp_atd;x86` | identical |
| **Emulator binary** | **37.1.5.0** (build `15679343`) | **37.1.6.0** (build `15726199`) |

`channel: canary` pulls the latest canary emulator fresh each run. Canary `37.1.6.0` breaks emulator networking — both the `10.0.2.2` host-loopback path to the mock Sentry server and external internet (the Spaceflight News fetch) lose egress, so the Spaceflight Maestro flow can't load articles and every envelope-waiting test times out (120–300s). All 5 suites / 20 tests fail with this signature.

Confirmed it is not code: re-running the last-green commit on today's infra reproduces the failure identically. iOS REV2 runs the same JS bundle and passes.

## 💚 How did you test it?

This PR itself is the test — it triggers `build-android` + `Test android production REV2`. Expecting the suite to go green (emulator pinned back to `37.1.5.0`).

## 📝 Checklist

- [x] I added tests / verified via CI to validate the change.
- [ ] No breaking changes to public API.
- [x] CI-only change; no SDK code touched.

## 🔮 Next steps

- https://github.com/getsentry/sentry-react-native/issues/6379