### PR TITLE
chore: Auto-request mobile team review on public API changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 *       @alwx @antonis @lucas-zimerman
+
+# Public API surface — auto-request a mobile SDK team review on API changes
+/packages/core/etc/sentry-react-native.api.md @getsentry/team-mobile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 *       @alwx @antonis @lucas-zimerman
 
-# Public API surface — auto-request a mobile SDK team review on API changes
-/packages/core/etc/sentry-react-native.api.md @getsentry/team-mobile
+# Public API surface — also request a mobile SDK team review on API changes
+/packages/core/etc/sentry-react-native.api.md @alwx @antonis @lucas-zimerman @getsentry/team-mobile


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Enhancement

## :scroll: Description
Adds a CODEOWNERS rule for the committed api-extractor report,
`packages/core/etc/sentry-react-native.api.md`

## :bulb: Motivation and Context
Public API changes in the mobile SDKs should be reviewed by another mobile SDK team
member for cross-SDK consistency.

## :green_heart: How did you test it?
Manually

## :pencil: Checklist
- [ ] I added tests to verify changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing
- [x] No breaking changes

## :crystal_ball: Next steps
