### PR TITLE
fix(e2e): Remove dead OSSRH snapshots repo from RN 0.71 Gradle plugin

### DIFF
--- a/dev-packages/e2e-tests/cli.mjs
+++ b/dev-packages/e2e-tests/cli.mjs
@@ -185,6 +185,14 @@ if (actions.includes('create')) {
     env: env,
   });
 
+  // Replace the dead OSSRH snapshots repo hardcoded by older RN Gradle plugins
+  // (oss.sonatype.org is EOL and intermittently 504s, breaking dependency resolution).
+  execSync(`${patchScriptsDir}/rn.patch.gradle.plugin.repo.js --app-dir .`, {
+    stdio: 'inherit',
+    cwd: appDir,
+    env: env,
+  });
+
   // Patch the app
   execSync(`patch --verbose --strip=0 --force --ignore-whitespace --fuzz 4 < ${patchScriptsDir}/rn.patch`, {
     stdio: 'inherit',

--- a/dev-packages/e2e-tests/patch-scripts/rn.patch.gradle.plugin.repo.js
+++ b/dev-packages/e2e-tests/patch-scripts/rn.patch.gradle.plugin.repo.js
@@ -21,10 +21,11 @@ if (!args['app-dir']) {
 // Gradle treats a 5xx from any declared repo as fatal (unlike a 404, which it
 // skips), so a single 504 breaks resolution of ANY dependency (react-android,
 // AGP lint, ...) even though those artifacts live on Maven Central / google().
-// Swapping the dead host for its live replacement makes the repo return clean
-// 404s for release artifacts, so Gradle skips it and resolves as intended.
-const OLD_URL = 'https://oss.sonatype.org/content/repositories/snapshots/';
-const NEW_URL = 'https://central.sonatype.com/repository/maven-snapshots/';
+//
+// We pin a stable RN release, so the snapshots repo is only ever used for
+// nightly (0.0.0-*) builds and serves no purpose here — remove it entirely so
+// nothing in the resolution path depends on a Sonatype snapshots host.
+const SNAPSHOT_REPO_LINE = /^[^\n]*mavenRepoFromUrl\("https:\/\/oss\.sonatype\.org\/content\/repositories\/snapshots\/"\)[^\n]*\n/m;
 
 const dependencyUtilsPath = path.join(
   args['app-dir'],
@@ -40,18 +41,18 @@ const dependencyUtilsPath = path.join(
   'DependencyUtils.kt'
 );
 
-debug.log('Patching React Native Gradle plugin snapshots repo', dependencyUtilsPath);
+debug.log('Removing dead OSSRH snapshots repo from React Native Gradle plugin', dependencyUtilsPath);
 
 if (!fs.existsSync(dependencyUtilsPath)) {
   debug.log('DependencyUtils.kt not found, skipping patch (plugin likely already uses a live repo)');
 } else {
   const source = fs.readFileSync(dependencyUtilsPath, 'utf8');
 
-  if (!source.includes(OLD_URL)) {
+  if (!SNAPSHOT_REPO_LINE.test(source)) {
     debug.log('DependencyUtils.kt does not reference the dead OSSRH host, nothing to patch');
   } else {
-    const patched = source.split(OLD_URL).join(NEW_URL);
+    const patched = source.replace(SNAPSHOT_REPO_LINE, '');
     fs.writeFileSync(dependencyUtilsPath, patched);
-    debug.log('Patched React Native Gradle plugin snapshots repo successfully!');
+    debug.log('Removed dead OSSRH snapshots repo successfully!');
   }
 }

--- a/dev-packages/e2e-tests/patch-scripts/rn.patch.gradle.plugin.repo.js
+++ b/dev-packages/e2e-tests/patch-scripts/rn.patch.gradle.plugin.repo.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { argv } = require('process');
+
+const parseArgs = require('minimist');
+const { debug } = require('@sentry/core');
+debug.enable();
+
+const args = parseArgs(argv.slice(2));
+if (!args['app-dir']) {
+  throw new Error('Missing --app-dir');
+}
+
+// Sonatype's legacy OSSRH host (oss.sonatype.org) reached end-of-life on
+// 2025-06-30 and is now unreliable — it intermittently answers with a
+// `504 Gateway Time-out` instead of a clean `404`. The React Native Gradle
+// plugin bundled with older RN versions (e.g. 0.71) hardcodes this host as a
+// snapshots repository and injects it into every project's repository list.
+// Gradle treats a 5xx from any declared repo as fatal (unlike a 404, which it
+// skips), so a single 504 breaks resolution of ANY dependency (react-android,
+// AGP lint, ...) even though those artifacts live on Maven Central / google().
+// Swapping the dead host for its live replacement makes the repo return clean
+// 404s for release artifacts, so Gradle skips it and resolves as intended.
+const OLD_URL = 'https://oss.sonatype.org/content/repositories/snapshots/';
+const NEW_URL = 'https://central.sonatype.com/repository/maven-snapshots/';
+
+const dependencyUtilsPath = path.join(
+  args['app-dir'],
+  'node_modules',
+  'react-native-gradle-plugin',
+  'src',
+  'main',
+  'kotlin',
+  'com',
+  'facebook',
+  'react',
+  'utils',
+  'DependencyUtils.kt'
+);
+
+debug.log('Patching React Native Gradle plugin snapshots repo', dependencyUtilsPath);
+
+if (!fs.existsSync(dependencyUtilsPath)) {
+  debug.log('DependencyUtils.kt not found, skipping patch (plugin likely already uses a live repo)');
+} else {
+  const source = fs.readFileSync(dependencyUtilsPath, 'utf8');
+
+  if (!source.includes(OLD_URL)) {
+    debug.log('DependencyUtils.kt does not reference the dead OSSRH host, nothing to patch');
+  } else {
+    const patched = source.split(OLD_URL).join(NEW_URL);
+    fs.writeFileSync(dependencyUtilsPath, patched);
+    debug.log('Patched React Native Gradle plugin snapshots repo successfully!');
+  }
+}


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

This adds a create-time patch step to the E2E  to remove the Sonatype's legacy OSSRH host [that reached EOL](https://central.sonatype.org/pages/ossrh-eol/)

## :bulb: Motivation and Context
[This has been failing the `0.71.19` legacy Android E2E leg](https://github.com/getsentry/sentry-react-native/actions/runs/28506394760/job/84520218981?pr=6385), e.g.:

```
> Could not resolve com.android.tools.lint:lint:30.3.1.
   > Could not GET 'https://oss.sonatype.org/content/repositories/snapshots/.../lint-30.3.1.pom'.
     Received status code 504 from server: Gateway Time-out
```

Note that the `0.71.19` is the last 0.71.x release (RN 0.71 is EOL), so there is no fixed upstream version to bump to.

## :green_heart: How did you test it?
CI

## :pencil: Checklist
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] No breaking changes

## :crystal_ball: Next steps

Remove this when we retire 0.71 from the checks