### PR TITLE
docs: Warn about 16 KB alignment issue in 8.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## 8.17.0
 
+> [!WARNING]
+> ⚠️ **Known Issue (Android):** Apps built with the New Architecture on `sentry-react-native` **8.17.0** bundle a native library (`libsentry-tm-perf-logger.so`) that is not 16 KB page aligned, which breaks [16 KB page size](https://developer.android.com/guide/practices/page-sizes) compatibility on Android 15+ (and fails Google Play's 16 KB requirement). See [#6394](https://github.com/getsentry/sentry-react-native/issues/6394). **Please use [8.17.1](https://github.com/getsentry/sentry-react-native/releases/tag/8.17.1)**.
+
 ### Features
 
 - Add experimental `enableStandaloneAppStartTracing` to send app start as a standalone `app.start` transaction ([#6359](https://github.com/getsentry/sentry-react-native/pull/6359))


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Adds a known-issue warning to the `8.17.0` section of `CHANGELOG.md`, matching the existing 8.11.0 warning format, directing affected users to `8.17.1`:

> ⚠️ **Known Issue (Android):** Apps built with the New Architecture on `sentry-react-native` **8.17.0** bundle a native library (`libsentry-tm-perf-logger.so`) that is not 16 KB page aligned, which breaks 16 KB page size compatibility on Android 15+ (and fails Google Play's 16 KB requirement). See #6394. **Please use 8.17.1**.

## :bulb: Motivation and Context
8.17.0 shipped a New Architecture native library that is only 4 KB aligned, breaking 16 KB page size compatibility on Android 15+ and failing Google Play's 16 KB requirement (#6394). This warns users on the affected version to upgrade. The actual fix lives in #6396.

Related: #6394, #6396.

## :green_heart: How did you test it?
Documentation-only change. Verified the markdown renders as a warning callout and matches the existing 8.11.0 warning style.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
The `8.17.1` release/tag referenced by the warning must be published for the link to resolve. Merge alongside cutting 8.17.1 (which should include #6396).

🤖 Generated with [Claude Code](https://claude.com/claude-code)