### PR TITLE
fix(ios): Skip source maps upload on Debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Skip iOS source maps upload on `Debug` builds ([#6399](https://github.com/getsentry/sentry-react-native/issues/6399))
+
 ## 8.17.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Skip iOS source maps upload on `Debug` builds ([#6399](https://github.com/getsentry/sentry-react-native/issues/6399))
+- Skip iOS source maps upload on `Debug` builds ([#6405](https://github.com/getsentry/sentry-react-native/pull/6405))
 
 ## 8.17.1
 

--- a/packages/core/scripts/sentry-xcode.sh
+++ b/packages/core/scripts/sentry-xcode.sh
@@ -65,7 +65,18 @@ REACT_NATIVE_XCODE_WITH_SENTRY="\"$SENTRY_CLI_EXECUTABLE\" react-native xcode $A
 
 exitCode=0
 
-if [ "$SENTRY_DISABLE_AUTO_UPLOAD" != true ]; then
+if [ "$SENTRY_DISABLE_AUTO_UPLOAD" == true ]; then
+  echo "SENTRY_DISABLE_AUTO_UPLOAD=true, skipping sourcemaps upload"
+  /bin/sh -c "$REACT_NATIVE_XCODE"
+elif echo "$CONFIGURATION" | grep -iq "debug"; then # case insensitive check for "debug"
+  # Skip the source maps upload for *Debug* configuration, matching the behavior of the
+  # native debug files upload (sentry-xcode-debug-files.sh) and the Android Gradle plugin.
+  # Local Debug builds should not require Sentry credentials. Still run the React Native
+  # bundling step so the build itself succeeds.
+  # See: https://github.com/getsentry/sentry-react-native/issues/6399
+  echo "Skipping source maps upload for *Debug* configuration"
+  /bin/sh -c "$REACT_NATIVE_XCODE"
+else
   # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
   set +x +e # disable printing commands otherwise we might print `error:` by accident and allow continuing on error
   SENTRY_XCODE_COMMAND_OUTPUT=$(/bin/sh -c "\"$LOCAL_NODE_BINARY\" $REACT_NATIVE_XCODE_WITH_SENTRY" 2>&1)
@@ -82,9 +93,6 @@ if [ "$SENTRY_DISABLE_AUTO_UPLOAD" != true ]; then
     fi
   fi
   set -x -e # re-enable
-else
-  echo "SENTRY_DISABLE_AUTO_UPLOAD=true, skipping sourcemaps upload"
-  /bin/sh -c "$REACT_NATIVE_XCODE"
 fi
 
 [ -z "$SENTRY_COLLECT_MODULES" ] && SENTRY_RN_PACKAGE_PATH=$("$LOCAL_NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json'))")

--- a/packages/core/test/scripts/sentry-xcode-scripts.test.ts
+++ b/packages/core/test/scripts/sentry-xcode-scripts.test.ts
@@ -455,6 +455,32 @@ describe('sentry-xcode.sh', () => {
     expect(result.stdout).toContain('skipping sourcemaps upload');
   });
 
+  it('skips upload for Debug configuration without invoking sentry-cli', () => {
+    const result = runScript({
+      CONFIGURATION: 'Debug',
+      // A failing sentry-cli would surface here if it were invoked; the Debug skip must run
+      // the React Native bundling step directly instead. See issue #6399.
+      MOCK_CLI_EXIT_CODE: '1',
+      MOCK_CLI_OUTPUT: 'An organization ID or slug is required',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Skipping source maps upload for *Debug* configuration');
+    expect(result.stdout).toContain('Mock React Native bundle');
+    expect(result.stdout).not.toContain('An organization ID or slug is required');
+    expect(result.stdout).not.toContain('error: sentry-cli');
+  });
+
+  it('skips upload for debug configuration (case insensitive)', () => {
+    const result = runScript({
+      CONFIGURATION: 'debug',
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('Skipping source maps upload for *Debug* configuration');
+    expect(result.stdout).toContain('Mock React Native bundle');
+  });
+
   describe('SENTRY_PROJECT_ROOT override', () => {
     it('resolves SOURCEMAP_FILE relative to SENTRY_PROJECT_ROOT instead of PROJECT_DIR/..', () => {
       const customRoot = path.join(tempDir, 'monorepo-package');


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The iOS source-maps upload build phase (`sentry-xcode.sh`) ran `sentry-cli react-native xcode` for **every** configuration, including `Debug`. This adds a `*Debug*` configuration guard so Debug builds skip the upload and run the React Native bundling step directly.

The guard mirrors the two upload paths that already skip Debug:
- Native debug files upload — `sentry-xcode-debug-files.sh` (`grep -iq "debug"`)
- Android Gradle plugin — `sentry.gradle.kts` (`if (vName.contains("debug", ...)) return`)

so all three upload paths now share one convention: no upload on Debug.


## :bulb: Motivation and Context
Fixes #6399.

Since SDK 8 bumped the bundled `sentry-cli` from v2 to v3, `sentry-cli react-native xcode` **hard-fails** when no org/auth token is configured:

```
error: An organization ID or slug is required (provide with --org, set SENTRY_ORG, or use an org-scoped auth token)
```

On 7.x (sentry-cli v2) this warned and continued. Because the source-maps script had no Debug guard, every local Debug build without Sentry credentials now fails until the developer discovers `SENTRY_DISABLE_AUTO_UPLOAD=true`. Skipping upload on Debug restores a working local inner loop while keeping v3's strictness on Release/CI paths (where a silent upload skip would be a real footgun).


## :green_heart: How did you test it?
- Added two unit tests to `sentry-xcode-scripts.test.ts`: Debug skip (asserts a failing `sentry-cli` is **not** invoked and no `error:` is emitted) and case-insensitive `debug`.
- `yarn jest test/scripts/sentry-xcode-scripts.test.ts` — 38/38 pass.
- Manual repro with a v3-style "organization ID required" mock CLI: **Debug** exits `0` (bundles, skips upload); **Release** still exits `1` (hard-fails on missing org).


## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
Minor behavior note: anyone who was relying on iOS source-map upload during *Debug* builds will no longer get it automatically (Release builds and manual `sentry-cli` still work). This matches Android, which already skips Debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)