### PR TITLE
fix(android): Prevent New Arch build break linking libsentry-tm-perf-logger.so + CI ABI/link coverage

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -34,6 +34,28 @@ jobs:
       - name: Test
         run: yarn test
 
+  job_native_link_check:
+    name: Android Native Link Check
+    runs-on: ubuntu-latest
+    needs: [diff_check]
+    if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - run: corepack enable
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          package-manager-cache: false
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
+      - name: Install Dependencies
+        run: yarn install
+      # Guards against regressing the #6398 fix: verifies libsentry-tm-perf-logger.so
+      # still links for armeabi-v7a under --no-undefined when the reactnative prefab
+      # reference is unresolved. Uses the runner's preinstalled NDK (ANDROID_NDK_LATEST_HOME).
+      - name: Check libsentry-tm-perf-logger.so links (armeabi-v7a)
+        run: ./scripts/check-tm-perf-logger-link.sh
+
   job_lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/sample-application-expo.yml
+++ b/.github/workflows/sample-application-expo.yml
@@ -187,7 +187,11 @@ jobs:
         run: |
           [[ "${{ matrix.build-type }}" == "production" ]] && CONFIG='Release' || CONFIG='Debug'
           echo "Building $CONFIG"
-          ./gradlew ":app:assemble$CONFIG" -PreactNativeArchitectures=x86
+          # Build all ABIs (not just x86): the Sentry perf-logger native library is
+          # compiled from source per ABI, and #6398 (armeabi-v7a link failure) was
+          # reported on an Expo build. Keeps ABI coverage consistent with the bare
+          # RN sample.
+          ./gradlew ":app:assemble$CONFIG" -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 
       - name: Export Expo
         working-directory: samples/expo

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -185,7 +185,12 @@ jobs:
           [[ "${{ matrix.build-type }}" == "production" ]] && export CONFIG='release' || export CONFIG='debug'
 
           ./scripts/set-dsn-aos.mjs
-          ./scripts/build-android.sh -PreactNativeArchitectures=x86
+          # Build all ABIs (not just x86) so armeabi-v7a and the 64-bit ABIs are
+          # exercised too. The Sentry perf-logger native library is compiled from
+          # source per ABI, and ABI-specific breakage has shipped before (#6394
+          # 16 KB alignment, #6398 armeabi-v7a link) precisely because CI only
+          # built x86. The 16 KB alignment check below then runs across every ABI.
+          ./scripts/build-android.sh -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 
       - name: Check 16 KB native library alignment
         # Only Sentry-owned libraries are checked: third-party/React Native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Fix Android New Architecture build failing to link `libsentry-tm-perf-logger.so` with an undefined `TurboModulePerfLogger::enableLogging` symbol on some setups (e.g. armeabi-v7a) ([#6398](https://github.com/getsentry/sentry-react-native/issues/6398))
+
 ## 8.17.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Fix Android New Architecture build failing to link `libsentry-tm-perf-logger.so` with an undefined `TurboModulePerfLogger::enableLogging` symbol on some setups (e.g. armeabi-v7a) ([#6398](https://github.com/getsentry/sentry-react-native/issues/6398))
+- Fix Android New Architecture build failing to link `libsentry-tm-perf-logger.so` with an undefined `TurboModulePerfLogger::enableLogging` symbol on some setups (e.g. armeabi-v7a) ([#6406](https://github.com/getsentry/sentry-react-native/pull/6406))
 
 ## 8.17.1
 

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -6,6 +6,18 @@ def isNewArchitectureEnabled() {
     return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
+// The ABIs the host app is building, from its `reactNativeArchitectures`
+// property (the same knob React Native, react-native-screens and reanimated
+// read). Falls back to all four when unset. We must honour this: when the app
+// builds a subset (e.g. `-PreactNativeArchitectures=arm64-v8a`), React Native
+// only provides its `reactnative` prefab for that subset, so building any other
+// ABI fails to resolve `TurboModulePerfLogger::enableLogging` at link time
+// (#6398). Hardcoding all four ABIs is what caused that failure.
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 // `libsentry-tm-perf-logger.so` links against React Native's `reactnative`
 // prefab target. The merged `libreactnative.so` (exposed as the
 // `ReactAndroid::reactnative` prefab) only ships from RN 0.76 onward; on RN
@@ -135,7 +147,7 @@ android {
         versionCode 1
         versionName "1.0"
         ndk {
-            abiFilters "x86", "armeabi-v7a", "x86_64", "arm64-v8a"
+            abiFilters(*reactNativeArchitectures())
         }
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8

--- a/packages/core/android/src/main/jni/CMakeLists.txt
+++ b/packages/core/android/src/main/jni/CMakeLists.txt
@@ -78,6 +78,32 @@ target_link_options(
         "-Wl,-z,max-page-size=16384"
 )
 
+# Do not fail the link when `facebook::react::TurboModulePerfLogger::enableLogging`
+# (and friends) cannot be resolved at link time. Those symbols live in React
+# Native's `reactnative` prefab, which we link above, and they are present in
+# every ABI's `libreactnative.so`. However, some New Architecture build setups
+# (e.g. Expo builds on certain ABIs such as armeabi-v7a) do not end up
+# satisfying the reference at link time, and the NDK/AGP toolchain links with
+# `-Wl,-z,defs` (a.k.a. `--no-undefined`), which turns that into a fatal
+# `undefined symbol` error and breaks the whole Android build — even for hosts
+# that never opt in to `enableTurboModuleTracking`, since the library is
+# compiled whenever the New Architecture is enabled.
+#
+# `-Wl,-z,undefs` (appended after the toolchain's flags, so it wins) makes
+# undefined symbols non-fatal, leaving them to be resolved at load time against
+# the already-loaded `libreactnative.so`. This is safe: the library is loaded
+# lazily and only when tracking is opted in (see RNSentryTurboModulePerfTracker),
+# and a genuinely unresolvable symbol surfaces as an `UnsatisfiedLinkError` from
+# `System.loadLibrary` that the Java side already swallows, degrading the
+# experimental feature to a no-op rather than crashing. When the prefab does
+# satisfy the reference at link time (the common case) this flag changes nothing.
+# https://github.com/getsentry/sentry-react-native/issues/6398
+target_link_options(
+    sentry-tm-perf-logger
+    PRIVATE
+        "-Wl,-z,undefs"
+)
+
 # Note: we deliberately do NOT pass `-Wl,--strip-all` (or similar) here.
 # Android Gradle Plugin's `StripDebugSymbolsTask` already strips the .so for
 # the packaged APK while preserving the unstripped artefact under

--- a/scripts/check-tm-perf-logger-link.sh
+++ b/scripts/check-tm-perf-logger-link.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Regression guard for https://github.com/getsentry/sentry-react-native/issues/6398
+#
+# `libsentry-tm-perf-logger.so` is compiled from source in the consuming app and
+# references `facebook::react::TurboModulePerfLogger::enableLogging`, which lives
+# in React Native's `reactnative` prefab. On some New Architecture setups (e.g.
+# Expo builds on armeabi-v7a) that reference is not satisfied at link time, and
+# because the NDK/AGP toolchain links with `-Wl,-z,defs` (`--no-undefined`) the
+# unresolved symbol becomes a fatal error that breaks the whole Android build.
+# The fix (see src/main/jni/CMakeLists.txt) appends `-Wl,-z,undefs` so undefined
+# symbols are non-fatal and resolve at load time instead.
+#
+# This check reproduces that exact link condition for armeabi-v7a using the real
+# sources and the real link flags declared in CMakeLists.txt:
+#   1. Control  — link WITHOUT the fix flags: must FAIL (proves the reproduction
+#                 is still valid; if it starts passing the check is stale).
+#   2. Fixed    — link WITH the flags CMakeLists.txt actually declares: must PASS
+#                 (fails if `-Wl,-z,undefs` is ever removed from CMakeLists.txt).
+#
+# Requires an Android NDK (found via $ANDROID_NDK_* / $ANDROID_HOME/ndk) and a
+# React Native install (resolved from packages/core, or $REACT_NATIVE_DIR).
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cmakelists="$repo_root/packages/core/android/src/main/jni/CMakeLists.txt"
+cpp_dir="$repo_root/packages/core/cpp"
+jni_dir="$repo_root/packages/core/android/src/main/jni"
+
+# --- Resolve the React Native source tree (for ReactCommon headers) ----------
+rn_dir="${REACT_NATIVE_DIR:-}"
+if [[ -z "$rn_dir" ]]; then
+  rn_dir="$(cd "$repo_root/packages/core" && node -p "require('path').dirname(require.resolve('react-native/package.json'))" 2>/dev/null || true)"
+fi
+if [[ -z "$rn_dir" || ! -d "$rn_dir/ReactCommon" ]]; then
+  echo "error: could not locate react-native (set \$REACT_NATIVE_DIR to its root)" >&2
+  exit 2
+fi
+
+# --- Locate the NDK clang++ --------------------------------------------------
+find_clang() {
+  local host
+  case "$(uname -s)" in
+    Darwin) host="darwin-x86_64" ;;
+    *) host="linux-x86_64" ;;
+  esac
+  local roots=()
+  [[ -n "${ANDROID_NDK_HOME:-}" ]] && roots+=("$ANDROID_NDK_HOME")
+  [[ -n "${ANDROID_NDK_LATEST_HOME:-}" ]] && roots+=("$ANDROID_NDK_LATEST_HOME")
+  [[ -n "${ANDROID_NDK_ROOT:-}" ]] && roots+=("$ANDROID_NDK_ROOT")
+  for base in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" "$HOME/Library/Android/sdk" "$HOME/Android/Sdk"; do
+    [[ -d "$base/ndk" ]] && while IFS= read -r d; do roots+=("$d"); done < <(find "$base/ndk" -maxdepth 1 -mindepth 1 -type d | sort -r)
+  done
+  for r in "${roots[@]}"; do
+    local c="$r/toolchains/llvm/prebuilt/$host/bin/clang++"
+    [[ -x "$c" ]] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+clang="$(find_clang || true)"
+if [[ -z "$clang" ]]; then
+  echo "error: could not find an Android NDK clang++ (set \$ANDROID_NDK_HOME)" >&2
+  exit 2
+fi
+
+# --- Extract the link flags the CMakeLists.txt actually declares --------------
+# Everything the target passes via target_link_options(... "-Wl,..."), verbatim.
+fix_flags=()
+while IFS= read -r f; do fix_flags+=("$f"); done < <(grep -oE '"-Wl,[^"]+"' "$cmakelists" | tr -d '"')
+if [[ ${#fix_flags[@]} -eq 0 ]]; then
+  echo "error: no -Wl link flags found in $cmakelists (has the target changed?)" >&2
+  exit 2
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+includes=(
+  -I "$cpp_dir"
+  -I "$rn_dir/ReactCommon/react/nativemodule/core"
+  -I "$rn_dir/ReactCommon/reactperflogger"
+  -I "$rn_dir/ReactCommon"
+  -I "$rn_dir/ReactCommon/callinvoker"
+)
+sources=("$cpp_dir/SentryTurboModulePerfLogger.cpp" "$jni_dir/OnLoad.cpp")
+
+# Reproduce the failing condition: armeabi-v7a, -shared, `--no-undefined`, and
+# the `reactnative` prefab NOT linked (so `enableLogging` is unresolved).
+link() {
+  "$clang" --target=armv7-none-linux-androideabi21 -std=c++20 -fPIC -shared \
+    -DRCT_NEW_ARCH_ENABLED=1 "${includes[@]}" "${sources[@]}" \
+    -Wl,--no-undefined "$@" -o "$workdir/out.so" 2>"$workdir/err.txt"
+}
+
+echo "NDK clang: $clang"
+echo "React Native: $rn_dir"
+echo "CMakeLists link flags: ${fix_flags[*]}"
+echo
+
+# --- 1) Control: without the fix flags, the link MUST fail -------------------
+rm -f "$workdir/out.so"
+if link; then
+  echo "✖ CONTROL UNEXPECTEDLY LINKED — the reproduction is stale." >&2
+  echo "  '$0' no longer exercises the #6398 condition (did RN inline the symbol," >&2
+  echo "  or did the toolchain stop passing --no-undefined?). Update this check." >&2
+  exit 1
+fi
+echo "✔ control link fails as expected (undefined symbol without the fix)"
+
+# --- 2) Fixed: with the flags CMakeLists declares, the link MUST succeed ------
+rm -f "$workdir/out.so"
+if ! link "${fix_flags[@]}"; then
+  echo "✖ FIXED LINK FAILED — CMakeLists.txt no longer prevents the #6398 build break." >&2
+  echo "  Ensure the sentry-tm-perf-logger target keeps '-Wl,-z,undefs'." >&2
+  echo "  Linker output:" >&2
+  sed 's/^/    /' "$workdir/err.txt" >&2
+  exit 1
+fi
+echo "✔ fixed link succeeds with CMakeLists flags (${fix_flags[*]})"
+echo
+echo "✔ #6398 link regression guard passed"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Fixes the Android New Architecture build break in #6398, plus CI coverage for the class of failures around this app-compiled library.

### Root-cause fix — honor `reactNativeArchitectures`
`libsentry-tm-perf-logger.so` (added in 8.17.0, #6307) is compiled from source in the consuming app and links React Native's `reactnative` prefab. Our `build.gradle` **hardcoded** `abiFilters` to all four ABIs, ignoring the app's `reactNativeArchitectures` — unlike `react-native-screens`, `reanimated` and the RN app template, which all honor it.

When the app builds a **subset** (e.g. `-PreactNativeArchitectures=arm64-v8a`, common in Expo/dev/CI builds), React Native only provides its `reactnative` prefab for that subset. Our module still tried to build the other three ABIs, which then can't resolve `TurboModulePerfLogger::enableLogging` at link time → build break. (This matches the reporter's clue: the app requested `arm64-v8a` yet `:sentry_react-native:buildCMakeDebug[armeabi-v7a]` ran and failed.)

```groovy
def reactNativeArchitectures() {
    def value = project.getProperties().get("reactNativeArchitectures")
    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
}
// ...
ndk { abiFilters(*reactNativeArchitectures()) }
```

### Defense-in-depth — `-Wl,-z,undefs`
`src/main/jni/CMakeLists.txt` also appends `-Wl,-z,undefs` so that if any built ABI's prefab reference is still unresolved at link time, the build doesn't hard-fail (the NDK/AGP toolchain links with `--no-undefined`). Undefined symbols then resolve at load against `libreactnative.so`; the library is loaded lazily and only when tracking is opted in, and an unresolvable symbol surfaces as an `UnsatisfiedLinkError` the Java side already swallows (`RNSentryTurboModulePerfTracker`) — degrading the experimental feature to a no-op rather than crashing.

### CI coverage
Both #6394 (16 KB alignment) and #6398 escaped because CI only built **x86**, while this is the SDK's only library compiled per-ABI on the user's side:
- **All-ABI sample builds** — the New Architecture sample Android builds (bare React Native and Expo) now build all four ABIs, and the 16 KB alignment check runs across every ABI.
- **`scripts/check-tm-perf-logger-link.sh`** — a lightweight guard (runs on every PR via `buildandtest.yml`) that reproduces the link condition using the real sources and the real `CMakeLists.txt` flags; fails if `-Wl,-z,undefs` is removed.

## :bulb: Motivation and Context
Fixes #6398. Present since 8.17.0 (still in 8.17.1). Hard build failure with no clean workaround, hitting New Architecture apps that build a subset of ABIs — including Expo — regardless of whether the perf-tracking feature is enabled.

## :green_heart: How did you test it?
**Root-cause fix — verified locally against a subset build** (`:sentry_react-native:externalNativeBuildDebug -PreactNativeArchitectures=arm64-v8a`):

| build.gradle | ABIs the module builds |
|---|---|
| hardcoded (before) | arm64-v8a + **armeabi-v7a + x86 + x86_64** (builds unrequested ABIs — the bug) |
| `reactNativeArchitectures()` (after) | **arm64-v8a only** |

**Link flag** — built the real sources with NDK 27 against the RN 0.86 prefab: reproduces `ld.lld: undefined symbol: TurboModulePerfLogger::enableLogging` under `--no-undefined` without the flag; links with it; normal builds keep `libreactnative.so` in `DT_NEEDED`. Verified across all four ABIs, all staying 16 KB aligned. `check-tm-perf-logger-link.sh` passes on the fix and fails when `-Wl,-z,undefs` is removed.

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
- Consider a CI subset-ABI build (e.g. `-PreactNativeArchitectures=arm64-v8a`) to assert the module builds only the requested ABIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)