### PR TITLE
fix(android): Correct New Architecture native-build gate to RN 0.76+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Fix Android New Architecture build failing at CMake configure on React Native 0.75 by gating the `libsentry-tm-perf-logger.so` native build to RN 0.76+ ([#6407](https://github.com/getsentry/sentry-react-native/pull/6407))
+
 ## 8.17.1
 
 ### Fixes

--- a/packages/core/android/build.gradle
+++ b/packages/core/android/build.gradle
@@ -7,11 +7,13 @@ def isNewArchitectureEnabled() {
 }
 
 // `libsentry-tm-perf-logger.so` links against React Native's `reactnative`
-// prefab target, which only ships in the `ReactAndroid` prefab AAR shipped
-// with RN 0.75 and newer. On older RN releases the target does not exist
-// and a `find_package(ReactAndroid)` call would fail the CMake configure
-// step before we ever get to the build. Gate the native build on the host
-// app's `react-native` version so older legacy-arch matrix entries that
+// prefab target. The merged `libreactnative.so` (exposed as the
+// `ReactAndroid::reactnative` prefab) only ships from RN 0.76 onward; on RN
+// 0.75 and earlier the native code is split across separate prefab modules
+// and `ReactAndroid::reactnative` does not exist, so `find_package(ReactAndroid)`
+// / `target_link_libraries(... ReactAndroid::reactnative)` would fail the CMake
+// configure step before we ever get to the build. Gate the native build on the
+// host app's `react-native` version so older legacy-arch matrix entries that
 // (intentionally or not) end up with `newArchEnabled=true` do not pull in
 // our CMake target.
 def isReactNativePrefabAvailable() {
@@ -31,10 +33,11 @@ def isReactNativePrefabAvailable() {
         }
         def major = parts[0].toInteger()
         def minor = parts[1].toInteger()
-        // RN 0.75+ ships the `ReactAndroid::reactnative` prefab. Anything
-        // earlier is a legacy-only target as far as our native code is
-        // concerned.
-        return major > 0 || minor >= 75
+        // RN 0.76+ ships the merged `ReactAndroid::reactnative` prefab.
+        // Anything earlier (incl. 0.75, which still splits the native code
+        // across separate prefab modules) has no such target as far as our
+        // native code is concerned.
+        return major > 0 || minor >= 76
     } catch (Exception ignored) {
         return false
     }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
The `libsentry-tm-perf-logger.so` native build (added in 8.17.0, #6307) is gated on the host app's React Native version because it links the `ReactAndroid::reactnative` prefab. That gate was off by one:

```groovy
// before
return major > 0 || minor >= 75
// after
return major > 0 || minor >= 76
```

The **merged `libreactnative.so`** — exposed as the `ReactAndroid::reactnative` prefab selector — was introduced in **React Native 0.76**. On RN **0.75 and earlier**, the native code is split across separate prefab modules (`react_nativemodule_core`, etc.) and `ReactAndroid::reactnative` does not exist. With the old `minor >= 75` gate, an app on **RN 0.75.x with `newArchEnabled=true`** would run our CMake build, which calls `find_package(ReactAndroid REQUIRED CONFIG)` + `target_link_libraries(... ReactAndroid::reactnative)` against a target that isn't there — failing at the **CMake configure step**, before any linking.

## :bulb: Motivation and Context
Found while investigating the class of build failures around this app-compiled library (#6394, #6398). Unlike the armeabi-v7a link failure (#6406), this one fails at *configure* time, so a linker flag can't rescue it — the gate itself must be correct.

Verified the version boundary directly:
- RN 0.72 AAR: no unified `reactnative` prefab (split modules only)
- RN 0.85.1 / 0.86.0 AARs: `reactnative` prefab present, `TurboModulePerfLogger::enableLogging` exported
- RN docs confirm the merged `libreactnative.so` shipped in 0.76 ([release notes](https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture), [RFC #816](https://github.com/react-native-community/discussions-and-proposals/discussions/816))

With the fix, RN 0.75.x New Arch builds simply skip the native target (TurboModule perf tracking degrades to a no-op when the library is absent), instead of breaking the build.

## :green_heart: How did you test it?
Confirmed the prefab-availability boundary against cached RN AARs (0.72 vs 0.85/0.86) and RN's own release documentation. The change is a one-line version-gate correction with updated explanatory comments; RN 0.76+ New Arch behaviour is unchanged (still builds the native target).

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
