### PR TITLE
fix(ci): Bump codeql-action/init to v4.36.3 to match analyze/autobuild

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # pin@v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # pin@v4.36.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.


### PR DESCRIPTION
## 📢 Type of change

- [x] Bugfix

## 📜 Description

Bumps `github/codeql-action/init` from `v4.36.2` to `v4.36.3`, aligning it with `analyze` and `autobuild`. All three now pin the same commit `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (upstream `v4.36.3`).

## 💡 Motivation and Context

```
##[error]Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

See the failing run: https://github.com/getsentry/sentry-react-native/actions/runs/28789943042/job/85365787497

## 💚 How did you test it?

CI https://github.com/getsentry/sentry-react-native/actions/runs/28790906713/job/85369051011?pr=6410

## 📝 Checklist

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK API changes.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.

## 🔮 Next steps