### PR TITLE
test(android): Guard reactNativeArchitectures fix with a subset-ABI build

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -199,12 +199,24 @@ jobs:
           [[ "${{ matrix.build-type }}" == "production" ]] && export CONFIG='release' || export CONFIG='debug'
 
           ./scripts/set-dsn-aos.mjs
-          # Build all ABIs (not just x86) so armeabi-v7a and the 64-bit ABIs are
-          # exercised too. The Sentry perf-logger native library is compiled from
-          # source per ABI, and ABI-specific breakage has shipped before (#6394
-          # 16 KB alignment, #6398 armeabi-v7a link) precisely because CI only
-          # built x86. The 16 KB alignment check below then runs across every ABI.
-          ./scripts/build-android.sh -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+          # Split ABI coverage across the two matrix entries:
+          #   - `dev`        → subset (arm64-v8a only) so we can assert the module
+          #                    builds only the ABIs the app requested — the root
+          #                    cause of #6398 was hardcoded abiFilters ignoring
+          #                    `reactNativeArchitectures`.
+          #   - `production` → all four ABIs so the 16 KB alignment check below
+          #                    runs across every ABI (guards against #6394).
+          if [[ "${{ matrix.build-type }}" == "production" ]]; then
+            ./scripts/build-android.sh -PreactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+          else
+            ./scripts/build-android.sh -PreactNativeArchitectures=arm64-v8a
+          fi
+
+      - name: Check libsentry-tm-perf-logger.so honors reactNativeArchitectures
+        if: ${{ matrix.build-type == 'dev' }}
+        # Asserts the module packaged our .so for exactly the subset the app
+        # requested — guards against regressing the #6398 root-cause fix.
+        run: ./scripts/check-tm-perf-logger-abi-subset.sh ${{ env.REACT_NATIVE_SAMPLE_PATH }}/app.apk 'arm64-v8a'
 
       - name: Check 16 KB native library alignment
         # Only Sentry-owned libraries are checked: third-party/React Native

--- a/scripts/check-tm-perf-logger-abi-subset.sh
+++ b/scripts/check-tm-perf-logger-abi-subset.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Regression guard for the `reactNativeArchitectures` fix in
+# https://github.com/getsentry/sentry-react-native/issues/6398.
+#
+# `libsentry-tm-perf-logger.so` is compiled from source in the consuming app.
+# `packages/core/android/build.gradle` must honour the host app's
+# `reactNativeArchitectures` property (like react-native-screens / reanimated
+# do) so the module builds only the ABIs the app requested. When it doesn't,
+# the module builds ABIs whose React Native `reactnative` prefab isn't
+# provided → link failure.
+#
+# This check asserts that a built APK contains `libsentry-tm-perf-logger.so`
+# for EXACTLY the ABIs the app requested — no more, no less. Point it at a
+# clean-build APK from a subset-ABI build (e.g. `-PreactNativeArchitectures=arm64-v8a`).
+#
+# Usage: scripts/check-tm-perf-logger-abi-subset.sh <path-to-apk-or-aab> <expected-abis-csv>
+#   e.g. scripts/check-tm-perf-logger-abi-subset.sh app.apk 'arm64-v8a'
+
+set -euo pipefail
+
+apk="${1:-}"
+expected_csv="${2:-}"
+if [[ -z "$apk" || ! -f "$apk" || -z "$expected_csv" ]]; then
+  echo "usage: $0 <path-to-apk-or-aab> <expected-abis-csv>" >&2
+  exit 2
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+# Extract only the native libraries. APK stores them under `lib/`, AAB under `base/lib/`.
+unzip -qq -o "$apk" 'lib/*' 'base/lib/*' -d "$workdir" 2>/dev/null || true
+
+# ABIs where our library was packaged, one per line, sorted, unique.
+actual=$(
+  find "$workdir" -type f -name 'libsentry-tm-perf-logger.so' 2>/dev/null \
+    | sed -E 's|.*/lib/([^/]+)/.*|\1|' \
+    | sort -u
+)
+expected=$(echo "$expected_csv" | tr ',' '\n' | sed '/^$/d' | sort -u)
+
+echo "expected ABIs: $(echo $expected | tr '\n' ' ')"
+echo "actual ABIs:   $(echo $actual   | tr '\n' ' ')"
+
+if [[ -z "$actual" ]]; then
+  echo "✖ libsentry-tm-perf-logger.so not found in $apk" >&2
+  echo "  Expected it packaged for: $(echo $expected | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+if [[ "$actual" != "$expected" ]]; then
+  echo "✖ ABI mismatch — module built ABIs the app did not request (or missed one)." >&2
+  echo "  Root cause of #6398: abiFilters not honoring reactNativeArchitectures." >&2
+  exit 1
+fi
+
+echo "✔ libsentry-tm-perf-logger.so packaged for exactly the requested ABI(s)"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Closes the last CI coverage gap around the app-compiled `libsentry-tm-perf-logger.so` native library. Follow-up to the 8.17.2 fixes (#6406, #6407).

The 8.17.2 root-cause fix for #6398 made `packages/core/android/build.gradle` honour the host app's `reactNativeArchitectures` (`abiFilters(*reactNativeArchitectures())`, matching react-native-screens/reanimated/the RN template). But nothing in CI exercises a **subset-ABI build**, so the existing all-ABI builds pass identically with or without the fix — they cannot catch a regression back to hardcoded `abiFilters`.

This PR splits the bare-RN sample `build-android` matrix so each ABI-coverage concern gets its own entry, and adds a lightweight assertion:

| Matrix entry | ABIs | New guard | Covers |
|---|---|---|---|
| `dev` | `arm64-v8a` only (subset) | `check-tm-perf-logger-abi-subset.sh` asserts the packaged `.so` set matches exactly | Regression of the `reactNativeArchitectures` fix (#6398 root cause) |
| `production` | all four (unchanged) | existing 16 KB alignment check | Cross-ABI alignment (#6394) |

The new script `scripts/check-tm-perf-logger-abi-subset.sh` unzips a built APK/AAB, finds `libsentry-tm-perf-logger.so` per ABI, and asserts the set matches the expected CSV exactly. Same shape as the existing `check-android-16kb-alignment.sh`.

## :bulb: Motivation and Context
Both #6394 and #6398 escaped because CI only built x86; this module is the SDK's only library compiled per-ABI on the user's side. #6406 + #6407 fixed the code paths; this closes the CI side by ensuring a future regression of the `reactNativeArchitectures` fix is caught pre-merge.

Downstream jobs are unaffected: `Archive Android App` / `Upload Android APK` / `test-android` (Maestro E2E) are all gated on `matrix.build-type == 'production'`, which still builds all four ABIs. Build time for the `dev` entry actually drops slightly (1 ABI vs 4).

## :green_heart: How did you test it?
Verified locally against a real subset APK from the RN sample (`./scripts/build-android.sh -PreactNativeArchitectures=arm64-v8a`, `SENTRY_DISABLE_AUTO_UPLOAD=true`):

| Case | Expected | Actual | Guard |
|---|---|---|---|
| Subset APK with fix | `arm64-v8a` | `arm64-v8a` | ✅ pass (exit 0) |
| Simulated regression — unrequested `armeabi-v7a` `.so` leaks in | `arm64-v8a` | `arm64-v8a armeabi-v7a` | ❌ fail with root-cause hint (exit 1) |
| `.so` missing entirely | `arm64-v8a` | (none) | ❌ distinct "not found" error (exit 1) |

Workflow YAML validated with `ruby -e 'YAML.load_file(...)'`; shell script passes `bash -n`.

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
<!-- CI-only change; no user-facing behavior affected. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)