### PR TITLE
feat(core): Track NavigationContainer adoption

### DIFF
--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -7,6 +7,9 @@ import * as React from 'react';
 import type { GlobalErrorEvent } from './integrations/globalErrorBus';
 
 import { subscribeGlobalError } from './integrations/globalErrorBus';
+import { registerFeatureMarker } from './utils/featureMarkers';
+
+export const GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME = 'GlobalErrorBoundary';
 
 /**
  * Props for {@link GlobalErrorBoundary}. Extends the standard `ErrorBoundary`
@@ -74,6 +77,7 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
   private _latched = false;
 
   public componentDidMount(): void {
+    registerFeatureMarker(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME);
     this._subscribe();
   }
 

--- a/packages/core/src/js/NavigationContainer.tsx
+++ b/packages/core/src/js/NavigationContainer.tsx
@@ -3,6 +3,9 @@ import * as React from 'react';
 
 import { getNavigationContainerComponent } from './reactNavigationImport';
 import { getReactNavigationIntegration } from './tracing/reactnavigation';
+import { registerFeatureMarker } from './utils/featureMarkers';
+
+export const NAVIGATION_CONTAINER_INTEGRATION_NAME = 'NavigationContainer';
 
 export type FontStyle = {
   fontFamily: string;
@@ -123,6 +126,10 @@ export const NavigationContainer = React.forwardRef<unknown, SentryNavigationCon
     },
     [forwardedRef],
   );
+
+  React.useEffect(() => {
+    registerFeatureMarker(NAVIGATION_CONTAINER_INTEGRATION_NAME);
+  }, []);
 
   const onReady = React.useCallback(() => {
     try {

--- a/packages/core/src/js/utils/featureMarkers.ts
+++ b/packages/core/src/js/utils/featureMarkers.ts
@@ -1,0 +1,25 @@
+import type { Client } from '@sentry/core';
+
+import { getClient } from '@sentry/core';
+
+/**
+ * Registers a no-op named integration on the client so the feature name flows
+ * through to `event.sdk.integrations` — the channel Sentry uses to measure
+ * feature adoption across SDKs.
+ *
+ * The registration is idempotent: a second call with the same name is a no-op
+ * because `getIntegrationByName` returns the existing entry.
+ *
+ * Failing quietly is intentional. Feature-adoption telemetry must never break
+ * the host app: if no client is available, or `addIntegration` is unavailable,
+ * the caller keeps working without a marker.
+ *
+ * @param name The name to register.
+ * @param client Optional explicit client. Falls back to `getClient()`.
+ */
+export function registerFeatureMarker(name: string, client: Client | undefined = getClient()): void {
+  if (!client || client.getIntegrationByName?.(name)) {
+    return;
+  }
+  client.addIntegration?.({ name });
+}

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,15 +1,21 @@
 import * as SentryCore from '@sentry/core';
+import { getClient, setCurrentClient } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
 
-import { GlobalErrorBoundary, withGlobalErrorBoundary } from '../src/js/GlobalErrorBoundary';
+import {
+  GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+  GlobalErrorBoundary,
+  withGlobalErrorBoundary,
+} from '../src/js/GlobalErrorBoundary';
 import {
   _resetGlobalErrorBus,
   hasInterestedSubscribers,
   publishGlobalError,
 } from '../src/js/integrations/globalErrorBus';
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
 
 function Fallback({ error, resetError }: { error: unknown; resetError: () => void }): React.ReactElement {
   return (
@@ -311,6 +317,28 @@ describe('GlobalErrorBoundary', () => {
       publishGlobalError({ error: new Error('hoc-boom'), isFatal: true, kind: 'onerror' });
     });
     expect(getByTestId('fallback').props.children.join('')).toBe('fallback:hoc-boom');
+  });
+});
+
+describe('GlobalErrorBoundary feature marker', () => {
+  beforeEach(() => {
+    _resetGlobalErrorBus();
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers the GlobalErrorBoundary marker on mount', () => {
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toBeUndefined();
+
+    render(
+      <GlobalErrorBoundary fallback={() => <Text>fb</Text>}>
+        <Text>x</Text>
+      </GlobalErrorBoundary>,
+    );
+
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toEqual({
+      name: GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+    });
   });
 });
 

--- a/packages/core/test/NavigationContainer.test.tsx
+++ b/packages/core/test/NavigationContainer.test.tsx
@@ -2,10 +2,12 @@ import { render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
 
-import { NavigationContainer } from '../src/js/NavigationContainer';
+import { NAVIGATION_CONTAINER_INTEGRATION_NAME, NavigationContainer } from '../src/js/NavigationContainer';
 
 const mockRegisterNavigationContainer = jest.fn();
 const mockGetClient = jest.fn();
+const mockAddIntegration = jest.fn();
+const mockGetIntegrationByName = jest.fn();
 const mockDebugLog = jest.fn();
 const mockDebugWarn = jest.fn();
 
@@ -47,10 +49,23 @@ jest.mock('../src/js/reactNavigationImport', () => ({
 describe('NavigationContainer', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetClient.mockReturnValue({ getIntegrationByName: jest.fn() });
+    mockGetIntegrationByName.mockReturnValue(undefined);
+    mockGetClient.mockReturnValue({
+      getIntegrationByName: mockGetIntegrationByName,
+      addIntegration: mockAddIntegration,
+    });
     mockGetReactNavigationIntegration.mockReturnValue({
       registerNavigationContainer: mockRegisterNavigationContainer,
     });
+  });
+
+  it('registers the NavigationContainer feature marker on mount', () => {
+    render(
+      <NavigationContainer>
+        <Text>App</Text>
+      </NavigationContainer>,
+    );
+    expect(mockAddIntegration).toHaveBeenCalledWith({ name: NAVIGATION_CONTAINER_INTEGRATION_NAME });
   });
 
   it('renders children through to the underlying NavigationContainer', () => {

--- a/packages/core/test/utils/featureMarkers.test.ts
+++ b/packages/core/test/utils/featureMarkers.test.ts
@@ -1,0 +1,55 @@
+import { captureException, getClient, setCurrentClient } from '@sentry/core';
+
+import { registerFeatureMarker } from '../../src/js/utils/featureMarkers';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('registerFeatureMarker', () => {
+  beforeEach(() => {
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers a no-op named integration on the current client', () => {
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toBeUndefined();
+
+    registerFeatureMarker('SomeFeature');
+
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toEqual({ name: 'SomeFeature' });
+  });
+
+  test('is idempotent — second call with the same name does not overwrite', () => {
+    const first = { name: 'IdempotentFeature', setupOnce: jest.fn() };
+    getClient()?.addIntegration(first);
+
+    registerFeatureMarker('IdempotentFeature');
+
+    expect(getClient()?.getIntegrationByName('IdempotentFeature')).toBe(first);
+  });
+
+  test('is a no-op when no client is available', () => {
+    setCurrentClient(undefined as unknown as TestClient);
+
+    expect(() => registerFeatureMarker('NoClientFeature')).not.toThrow();
+  });
+
+  test('accepts an explicit client argument', () => {
+    const explicitClient = new TestClient(getDefaultTestClientOptions());
+    explicitClient.init();
+
+    registerFeatureMarker('ExplicitClientFeature', explicitClient);
+
+    expect(explicitClient.getIntegrationByName('ExplicitClientFeature')).toEqual({ name: 'ExplicitClientFeature' });
+    expect(getClient()?.getIntegrationByName('ExplicitClientFeature')).toBeUndefined();
+  });
+
+  test('the marker name is attached to `event.sdk.integrations` on captured events', async () => {
+    registerFeatureMarker('AdoptionSignal');
+
+    captureException(new Error('boom'));
+    await getClient()?.flush();
+
+    const client = getClient() as TestClient;
+    const event = client.eventQueue[0];
+    expect(event?.sdk?.integrations).toContain('AdoptionSignal');
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement (feature-adoption telemetry)
- [ ] Refactoring

## Description

Registers a no-op `NavigationContainer` integration when the `Sentry.NavigationContainer` component mounts, so the name flows through to `event.sdk.integrations`. Lets us measure adoption of the drop-in wrapper vs. manual `useNavigationContainerRef` wiring.

## Motivation and Context

Part of #6415. `Sentry.NavigationContainer` is opt-in and produces the same telemetry as a hand-wired container today, so we can't tell them apart. Same pattern as `feedback/lazy.ts` and PR #6421.

## How did you test it?

- New test in `test/NavigationContainer.test.tsx` verifying the marker is registered via `client.addIntegration` on mount.
- Existing `NavigationContainer` tests continue to pass.
- Full local suite green.

## Checklist

- [x] I have added tests to validate that my change does not break existing functionality
- [x] I have made corresponding changes to the documentation _(none needed — internal telemetry)_
- [ ] I have added a CHANGELOG entry _(intentionally omitted per #6415)_

## Base

Stacked on top of #6421. When #6421 merges, GitHub will automatically retarget this PR to `main`.

Refs: #6415