### PR TITLE
feat(tracing): Track wrapExpoRouterErrorBoundary adoption

### DIFF
--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -7,6 +7,9 @@ import * as React from 'react';
 import type { GlobalErrorEvent } from './integrations/globalErrorBus';
 
 import { subscribeGlobalError } from './integrations/globalErrorBus';
+import { registerFeatureMarker } from './utils/featureMarkers';
+
+export const GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME = 'GlobalErrorBoundary';
 
 /**
  * Props for {@link GlobalErrorBoundary}. Extends the standard `ErrorBoundary`
@@ -74,6 +77,7 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
   private _latched = false;
 
   public componentDidMount(): void {
+    registerFeatureMarker(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME);
     this._subscribe();
   }
 

--- a/packages/core/src/js/tracing/expoRouterErrorBoundary.tsx
+++ b/packages/core/src/js/tracing/expoRouterErrorBoundary.tsx
@@ -67,11 +67,14 @@ export interface ExpoRouterErrorBoundaryProps {
 export function wrapExpoRouterErrorBoundary<P extends ExpoRouterErrorBoundaryProps>(
   OriginalErrorBoundary: React.ComponentType<P>,
 ): React.ComponentType<P> {
-  const Wrapped: React.FC<P> = props => {
-    React.useEffect(() => {
-      registerFeatureMarker(EXPO_ROUTER_ERROR_BOUNDARY_INTEGRATION_NAME);
-    }, []);
+  // Register at wrap-call time (module evaluation) so the marker fires as soon
+  // as the user's route file loads, not only when Expo Router actually renders
+  // the boundary on an error. No-op if `Sentry.init()` has not run yet; route
+  // files load lazily during navigation, so init has typically completed by
+  // then.
+  registerFeatureMarker(EXPO_ROUTER_ERROR_BOUNDARY_INTEGRATION_NAME);
 
+  const Wrapped: React.FC<P> = props => {
     // Reporting is intentionally done in `useEffect` (commit phase) rather than
     // during render: render must be pure, and in Concurrent Mode an in-progress
     // render can be discarded — we only want to report errors that React

--- a/packages/core/src/js/tracing/expoRouterErrorBoundary.tsx
+++ b/packages/core/src/js/tracing/expoRouterErrorBoundary.tsx
@@ -13,7 +13,10 @@ import {
 } from '@sentry/core';
 import * as React from 'react';
 
+import { registerFeatureMarker } from '../utils/featureMarkers';
 import { getCurrentExpoRouterRouteInfo } from './expoRouterStore';
+
+export const EXPO_ROUTER_ERROR_BOUNDARY_INTEGRATION_NAME = 'ExpoRouterErrorBoundary';
 
 /**
  * Errors we have already reported. Module-scoped (rather than a per-instance
@@ -65,6 +68,10 @@ export function wrapExpoRouterErrorBoundary<P extends ExpoRouterErrorBoundaryPro
   OriginalErrorBoundary: React.ComponentType<P>,
 ): React.ComponentType<P> {
   const Wrapped: React.FC<P> = props => {
+    React.useEffect(() => {
+      registerFeatureMarker(EXPO_ROUTER_ERROR_BOUNDARY_INTEGRATION_NAME);
+    }, []);
+
     // Reporting is intentionally done in `useEffect` (commit phase) rather than
     // during render: render must be pure, and in Concurrent Mode an in-progress
     // render can be discarded — we only want to report errors that React

--- a/packages/core/src/js/utils/featureMarkers.ts
+++ b/packages/core/src/js/utils/featureMarkers.ts
@@ -1,0 +1,25 @@
+import type { Client } from '@sentry/core';
+
+import { getClient } from '@sentry/core';
+
+/**
+ * Registers a no-op named integration on the client so the feature name flows
+ * through to `event.sdk.integrations` — the channel Sentry uses to measure
+ * feature adoption across SDKs.
+ *
+ * The registration is idempotent: a second call with the same name is a no-op
+ * because `getIntegrationByName` returns the existing entry.
+ *
+ * Failing quietly is intentional. Feature-adoption telemetry must never break
+ * the host app: if no client is available, or `addIntegration` is unavailable,
+ * the caller keeps working without a marker.
+ *
+ * @param name The name to register.
+ * @param client Optional explicit client. Falls back to `getClient()`.
+ */
+export function registerFeatureMarker(name: string, client: Client | undefined = getClient()): void {
+  if (!client || client.getIntegrationByName?.(name)) {
+    return;
+  }
+  client.addIntegration?.({ name });
+}

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,15 +1,21 @@
 import * as SentryCore from '@sentry/core';
+import { getClient, setCurrentClient } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
 
-import { GlobalErrorBoundary, withGlobalErrorBoundary } from '../src/js/GlobalErrorBoundary';
+import {
+  GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+  GlobalErrorBoundary,
+  withGlobalErrorBoundary,
+} from '../src/js/GlobalErrorBoundary';
 import {
   _resetGlobalErrorBus,
   hasInterestedSubscribers,
   publishGlobalError,
 } from '../src/js/integrations/globalErrorBus';
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
 
 function Fallback({ error, resetError }: { error: unknown; resetError: () => void }): React.ReactElement {
   return (
@@ -311,6 +317,28 @@ describe('GlobalErrorBoundary', () => {
       publishGlobalError({ error: new Error('hoc-boom'), isFatal: true, kind: 'onerror' });
     });
     expect(getByTestId('fallback').props.children.join('')).toBe('fallback:hoc-boom');
+  });
+});
+
+describe('GlobalErrorBoundary feature marker', () => {
+  beforeEach(() => {
+    _resetGlobalErrorBus();
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers the GlobalErrorBoundary marker on mount', () => {
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toBeUndefined();
+
+    render(
+      <GlobalErrorBoundary fallback={() => <Text>fb</Text>}>
+        <Text>x</Text>
+      </GlobalErrorBoundary>,
+    );
+
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toEqual({
+      name: GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+    });
   });
 });
 

--- a/packages/core/test/tracing/expoRouterErrorBoundary.test.tsx
+++ b/packages/core/test/tracing/expoRouterErrorBoundary.test.tsx
@@ -3,11 +3,16 @@ import { render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text } from 'react-native';
 
-import { wrapExpoRouterErrorBoundary } from '../../src/js/tracing/expoRouterErrorBoundary';
+import {
+  EXPO_ROUTER_ERROR_BOUNDARY_INTEGRATION_NAME,
+  wrapExpoRouterErrorBoundary,
+} from '../../src/js/tracing/expoRouterErrorBoundary';
 
 const mockCaptureException = jest.fn();
 const mockAddBreadcrumb = jest.fn();
 const mockAddExceptionMechanism = jest.fn();
+const mockAddIntegration = jest.fn();
+const mockGetIntegrationByName = jest.fn().mockReturnValue(undefined);
 let mockSendDefaultPii = false;
 let mockActiveSpan: { setStatus: jest.Mock; __origin?: string } | undefined;
 
@@ -18,7 +23,11 @@ jest.mock('@sentry/core', () => {
     captureException: (...args: unknown[]) => mockCaptureException(...args),
     addBreadcrumb: (...args: unknown[]) => mockAddBreadcrumb(...args),
     addExceptionMechanism: (...args: unknown[]) => mockAddExceptionMechanism(...args),
-    getClient: () => ({ getOptions: () => ({ sendDefaultPii: mockSendDefaultPii }) }),
+    getClient: () => ({
+      getOptions: () => ({ sendDefaultPii: mockSendDefaultPii }),
+      getIntegrationByName: mockGetIntegrationByName,
+      addIntegration: mockAddIntegration,
+    }),
     getActiveSpan: () => mockActiveSpan,
     getRootSpan: (span: unknown) => span,
     spanToJSON: (span: { __origin?: string } | undefined) => ({ origin: span?.__origin }),
@@ -78,6 +87,12 @@ describe('wrapExpoRouterErrorBoundary', () => {
     const Wrapped = wrapExpoRouterErrorBoundary(OriginalErrorBoundary);
     const { getByTestId } = render(<Wrapped error={new Error('boom')} retry={jest.fn()} />);
     expect(getByTestId('fallback').props.children).toBe('boom');
+  });
+
+  it('registers the ExpoRouterErrorBoundary marker on mount', () => {
+    const Wrapped = wrapExpoRouterErrorBoundary(OriginalErrorBoundary);
+    render(<Wrapped error={new Error('boom')} retry={jest.fn()} />);
+    expect(mockAddIntegration).toHaveBeenCalledWith({ name: EXPO_ROUTER_ERROR_BOUNDARY_INTEGRATION_NAME });
   });
 
   it('captures the error to Sentry once per error instance', () => {

--- a/packages/core/test/tracing/expoRouterErrorBoundary.test.tsx
+++ b/packages/core/test/tracing/expoRouterErrorBoundary.test.tsx
@@ -89,9 +89,8 @@ describe('wrapExpoRouterErrorBoundary', () => {
     expect(getByTestId('fallback').props.children).toBe('boom');
   });
 
-  it('registers the ExpoRouterErrorBoundary marker on mount', () => {
-    const Wrapped = wrapExpoRouterErrorBoundary(OriginalErrorBoundary);
-    render(<Wrapped error={new Error('boom')} retry={jest.fn()} />);
+  it('registers the ExpoRouterErrorBoundary marker at wrap-call time (before any mount)', () => {
+    wrapExpoRouterErrorBoundary(OriginalErrorBoundary);
     expect(mockAddIntegration).toHaveBeenCalledWith({ name: EXPO_ROUTER_ERROR_BOUNDARY_INTEGRATION_NAME });
   });
 

--- a/packages/core/test/utils/featureMarkers.test.ts
+++ b/packages/core/test/utils/featureMarkers.test.ts
@@ -1,0 +1,55 @@
+import { captureException, getClient, setCurrentClient } from '@sentry/core';
+
+import { registerFeatureMarker } from '../../src/js/utils/featureMarkers';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('registerFeatureMarker', () => {
+  beforeEach(() => {
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers a no-op named integration on the current client', () => {
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toBeUndefined();
+
+    registerFeatureMarker('SomeFeature');
+
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toEqual({ name: 'SomeFeature' });
+  });
+
+  test('is idempotent — second call with the same name does not overwrite', () => {
+    const first = { name: 'IdempotentFeature', setupOnce: jest.fn() };
+    getClient()?.addIntegration(first);
+
+    registerFeatureMarker('IdempotentFeature');
+
+    expect(getClient()?.getIntegrationByName('IdempotentFeature')).toBe(first);
+  });
+
+  test('is a no-op when no client is available', () => {
+    setCurrentClient(undefined as unknown as TestClient);
+
+    expect(() => registerFeatureMarker('NoClientFeature')).not.toThrow();
+  });
+
+  test('accepts an explicit client argument', () => {
+    const explicitClient = new TestClient(getDefaultTestClientOptions());
+    explicitClient.init();
+
+    registerFeatureMarker('ExplicitClientFeature', explicitClient);
+
+    expect(explicitClient.getIntegrationByName('ExplicitClientFeature')).toEqual({ name: 'ExplicitClientFeature' });
+    expect(getClient()?.getIntegrationByName('ExplicitClientFeature')).toBeUndefined();
+  });
+
+  test('the marker name is attached to `event.sdk.integrations` on captured events', async () => {
+    registerFeatureMarker('AdoptionSignal');
+
+    captureException(new Error('boom'));
+    await getClient()?.flush();
+
+    const client = getClient() as TestClient;
+    const event = client.eventQueue[0];
+    expect(event?.sdk?.integrations).toContain('AdoptionSignal');
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement (feature-adoption telemetry)
- [ ] Refactoring

## Description

Registers a no-op `ExpoRouterErrorBoundary` integration when the user calls `Sentry.wrapExpoRouterErrorBoundary(...)` (i.e., at module-evaluation time of the route file that uses the wrap), so the name flows through to `event.sdk.integrations`. Covers both manual usage and code emitted by the Babel auto-wrap plugin — both paths ultimately call `wrapExpoRouterErrorBoundary` and share this marker.

## Motivation and Context

Part of #6415. The wrap adds route-scoped context to boundary errors, but nothing about the emitted event distinguishes "wrap installed" from "user's global handler caught it" today. Same pattern as `feedback/lazy.ts` and PR #6421.

The registration fires at wrap-call time rather than on the mount of the wrapped boundary, so we count "wrap installed" (not just "wrap engaged with an error"). Expo Router lazy-loads route files during navigation, so `Sentry.init()` has typically completed by the time the wrap runs — if not, `registerFeatureMarker` silently no-ops.

## How did you test it?

- New test in `test/tracing/expoRouterErrorBoundary.test.tsx` asserting the marker is registered synchronously at wrap-call time (before any component mount).
- Existing boundary tests continue to pass.
- Full local suite green.

## Checklist

- [x] I have added tests to validate that my change does not break existing functionality
- [x] I have made corresponding changes to the documentation _(none needed)_
- [ ] I have added a CHANGELOG entry _(intentionally omitted per #6415)_

## Base

Stacked on top of #6421. When #6421 merges, GitHub will automatically retarget this PR to `main`.

Refs: #6415