### PR TITLE
feat(tracing): Track appLoaded and extendAppStart adoption

### DIFF
--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -7,6 +7,9 @@ import * as React from 'react';
 import type { GlobalErrorEvent } from './integrations/globalErrorBus';
 
 import { subscribeGlobalError } from './integrations/globalErrorBus';
+import { registerFeatureMarker } from './utils/featureMarkers';
+
+export const GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME = 'GlobalErrorBoundary';
 
 /**
  * Props for {@link GlobalErrorBoundary}. Extends the standard `ErrorBoundary`
@@ -74,6 +77,7 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
   private _latched = false;
 
   public componentDidMount(): void {
+    registerFeatureMarker(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME);
     this._subscribe();
   }
 

--- a/packages/core/src/js/tracing/integrations/appStart.ts
+++ b/packages/core/src/js/tracing/integrations/appStart.ts
@@ -24,6 +24,7 @@ import {
   APP_START_COLD as APP_START_COLD_MEASUREMENT,
   APP_START_WARM as APP_START_WARM_MEASUREMENT,
 } from '../../measurements';
+import { registerFeatureMarker } from '../../utils/featureMarkers';
 import { convertSpanToTransaction, isRootSpan, setEndTimeValue } from '../../utils/span';
 import { NATIVE } from '../../wrapper';
 import { getRootSpanDiscardReason, getTransactionEventDiscardReason } from '../onSpanEndUtils';
@@ -51,6 +52,8 @@ import {
 } from '../utils';
 
 const INTEGRATION_NAME = 'AppStart';
+const APP_LOADED_INTEGRATION_NAME = 'AppLoaded';
+const EXTENDED_APP_START_INTEGRATION_NAME = 'ExtendedAppStart';
 
 export type AppStartIntegration = Integration & {
   captureStandaloneAppStart: () => Promise<void>;
@@ -124,6 +127,7 @@ export async function _appLoaded(): Promise<void> {
     return;
   }
 
+  registerFeatureMarker(APP_LOADED_INTEGRATION_NAME);
   isAppLoadedManuallyInvoked = true;
 
   const timestampMs = timestampInSeconds() * 1000;
@@ -204,6 +208,7 @@ export async function _captureAppStart({ isManual }: { isManual: boolean }): Pro
  * @private
  */
 export function _extendAppStart(): void {
+  registerFeatureMarker(EXTENDED_APP_START_INTEGRATION_NAME);
   getClient()?.getIntegrationByName<AppStartIntegration>(INTEGRATION_NAME)?.extendAppStart();
 }
 
@@ -214,6 +219,7 @@ export function _extendAppStart(): void {
  * @private
  */
 export function _getExtendedAppStartSpan(): Span {
+  registerFeatureMarker(EXTENDED_APP_START_INTEGRATION_NAME);
   return (
     getClient()?.getIntegrationByName<AppStartIntegration>(INTEGRATION_NAME)?.getExtendedAppStartSpan() ??
     new SentryNonRecordingSpan()
@@ -227,6 +233,7 @@ export function _getExtendedAppStartSpan(): Span {
  * @private
  */
 export async function _finishExtendedAppStart(): Promise<void> {
+  registerFeatureMarker(EXTENDED_APP_START_INTEGRATION_NAME);
   await getClient()?.getIntegrationByName<AppStartIntegration>(INTEGRATION_NAME)?.finishExtendedAppStart();
 }
 

--- a/packages/core/src/js/utils/featureMarkers.ts
+++ b/packages/core/src/js/utils/featureMarkers.ts
@@ -1,0 +1,25 @@
+import type { Client } from '@sentry/core';
+
+import { getClient } from '@sentry/core';
+
+/**
+ * Registers a no-op named integration on the client so the feature name flows
+ * through to `event.sdk.integrations` — the channel Sentry uses to measure
+ * feature adoption across SDKs.
+ *
+ * The registration is idempotent: a second call with the same name is a no-op
+ * because `getIntegrationByName` returns the existing entry.
+ *
+ * Failing quietly is intentional. Feature-adoption telemetry must never break
+ * the host app: if no client is available, or `addIntegration` is unavailable,
+ * the caller keeps working without a marker.
+ *
+ * @param name The name to register.
+ * @param client Optional explicit client. Falls back to `getClient()`.
+ */
+export function registerFeatureMarker(name: string, client: Client | undefined = getClient()): void {
+  if (!client || client.getIntegrationByName?.(name)) {
+    return;
+  }
+  client.addIntegration?.({ name });
+}

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,15 +1,21 @@
 import * as SentryCore from '@sentry/core';
+import { getClient, setCurrentClient } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
 
-import { GlobalErrorBoundary, withGlobalErrorBoundary } from '../src/js/GlobalErrorBoundary';
+import {
+  GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+  GlobalErrorBoundary,
+  withGlobalErrorBoundary,
+} from '../src/js/GlobalErrorBoundary';
 import {
   _resetGlobalErrorBus,
   hasInterestedSubscribers,
   publishGlobalError,
 } from '../src/js/integrations/globalErrorBus';
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
 
 function Fallback({ error, resetError }: { error: unknown; resetError: () => void }): React.ReactElement {
   return (
@@ -311,6 +317,28 @@ describe('GlobalErrorBoundary', () => {
       publishGlobalError({ error: new Error('hoc-boom'), isFatal: true, kind: 'onerror' });
     });
     expect(getByTestId('fallback').props.children.join('')).toBe('fallback:hoc-boom');
+  });
+});
+
+describe('GlobalErrorBoundary feature marker', () => {
+  beforeEach(() => {
+    _resetGlobalErrorBus();
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers the GlobalErrorBoundary marker on mount', () => {
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toBeUndefined();
+
+    render(
+      <GlobalErrorBoundary fallback={() => <Text>fb</Text>}>
+        <Text>x</Text>
+      </GlobalErrorBoundary>,
+    );
+
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toEqual({
+      name: GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+    });
   });
 });
 

--- a/packages/core/test/tracing/integrations/appStart.test.ts
+++ b/packages/core/test/tracing/integrations/appStart.test.ts
@@ -32,6 +32,9 @@ import {
   _captureAppStart,
   _clearAppStartEndData,
   _clearRootComponentCreationTimestampMs,
+  _extendAppStart,
+  _finishExtendedAppStart,
+  _getExtendedAppStartSpan,
   _setAppStartEndData,
   _setRootComponentCreationTimestampMs,
   appStartIntegration,
@@ -1219,6 +1222,19 @@ describe('Extended App Start', () => {
     return { integration, client };
   };
 
+  it.each([
+    ['_extendAppStart', (): void => _extendAppStart()],
+    ['_getExtendedAppStartSpan', (): void => void _getExtendedAppStartSpan()],
+    ['_finishExtendedAppStart', async (): Promise<void> => _finishExtendedAppStart()],
+  ])('registers the ExtendedAppStart feature marker via %s', async (_name, call) => {
+    const { client } = setupStandaloneIntegration();
+    expect(client.getIntegrationByName('ExtendedAppStart')).toBeUndefined();
+
+    await call();
+
+    expect(client.getIntegrationByName('ExtendedAppStart')).toEqual({ name: 'ExtendedAppStart' });
+  });
+
   it('creates an extended app start span and finalizes it with a measurement on finish', async () => {
     mockAppStart({ cold: true });
     const { integration, client } = setupStandaloneIntegration();
@@ -1572,6 +1588,14 @@ describe('appLoaded() API', () => {
     integration.afterAllSetup(client);
     return integration;
   }
+
+  it('registers the AppLoaded feature marker on first call', async () => {
+    expect(client.getIntegrationByName('AppLoaded')).toBeUndefined();
+
+    await _appLoaded();
+
+    expect(client.getIntegrationByName('AppLoaded')).toEqual({ name: 'AppLoaded' });
+  });
 
   it('sets the app start end timestamp and marks it as manual', async () => {
     const appLoadedTimeSeconds = Date.now() / 1000;

--- a/packages/core/test/utils/featureMarkers.test.ts
+++ b/packages/core/test/utils/featureMarkers.test.ts
@@ -1,0 +1,55 @@
+import { captureException, getClient, setCurrentClient } from '@sentry/core';
+
+import { registerFeatureMarker } from '../../src/js/utils/featureMarkers';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('registerFeatureMarker', () => {
+  beforeEach(() => {
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers a no-op named integration on the current client', () => {
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toBeUndefined();
+
+    registerFeatureMarker('SomeFeature');
+
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toEqual({ name: 'SomeFeature' });
+  });
+
+  test('is idempotent — second call with the same name does not overwrite', () => {
+    const first = { name: 'IdempotentFeature', setupOnce: jest.fn() };
+    getClient()?.addIntegration(first);
+
+    registerFeatureMarker('IdempotentFeature');
+
+    expect(getClient()?.getIntegrationByName('IdempotentFeature')).toBe(first);
+  });
+
+  test('is a no-op when no client is available', () => {
+    setCurrentClient(undefined as unknown as TestClient);
+
+    expect(() => registerFeatureMarker('NoClientFeature')).not.toThrow();
+  });
+
+  test('accepts an explicit client argument', () => {
+    const explicitClient = new TestClient(getDefaultTestClientOptions());
+    explicitClient.init();
+
+    registerFeatureMarker('ExplicitClientFeature', explicitClient);
+
+    expect(explicitClient.getIntegrationByName('ExplicitClientFeature')).toEqual({ name: 'ExplicitClientFeature' });
+    expect(getClient()?.getIntegrationByName('ExplicitClientFeature')).toBeUndefined();
+  });
+
+  test('the marker name is attached to `event.sdk.integrations` on captured events', async () => {
+    registerFeatureMarker('AdoptionSignal');
+
+    captureException(new Error('boom'));
+    await getClient()?.flush();
+
+    const client = getClient() as TestClient;
+    const event = client.eventQueue[0];
+    expect(event?.sdk?.integrations).toContain('AdoptionSignal');
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement (feature-adoption telemetry)
- [ ] Refactoring

## Description

Registers no-op `AppLoaded` and `ExtendedAppStart` integrations on first call so the names flow through to `event.sdk.integrations`. `ExtendedAppStart` covers all three extend API entry points: `extendAppStart`, `getExtendedAppStartSpan`, and `finishExtendedAppStart`.

Bundled together because both markers live in `packages/core/src/js/tracing/integrations/appStart.ts` — splitting them into separate PRs would produce mechanical merge conflicts on the shared imports.

## Motivation and Context

Part of #6415.
- `Sentry.appLoaded()` explicitly signals app-start end but leaves no distinctive event fingerprint today.
- `Sentry.extendAppStart()` / `getExtendedAppStartSpan()` / `finishExtendedAppStart()` are new experimental APIs that produce standalone app-start transactions indistinguishable from auto-captured ones.

## How did you test it?

- New tests in `test/tracing/integrations/appStart.test.ts`: an `AppLoaded` marker test in the existing `appLoaded() API` describe block and a parameterized `it.each` for the three `ExtendedAppStart` entry points.
- Existing app-start tests continue to pass.
- Full local suite green.

## Note on semantics

`ExtendedAppStart` fires even if the underlying integration no-ops (e.g., user called `extendAppStart` without enabling `_experiments.enableStandaloneAppStartTracing`). This is intentional — measures API adoption, not just successful use.

## Checklist

- [x] I have added tests to validate that my change does not break existing functionality
- [x] I have made corresponding changes to the documentation _(none needed)_
- [ ] I have added a CHANGELOG entry _(intentionally omitted per #6415)_

## Base

Stacked on top of #6421. When #6421 merges, GitHub will automatically retarget this PR to `main`.

Refs: #6415