### PR TITLE
feat(tracing): Track standalone app start adoption

### DIFF
--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -7,6 +7,9 @@ import * as React from 'react';
 import type { GlobalErrorEvent } from './integrations/globalErrorBus';
 
 import { subscribeGlobalError } from './integrations/globalErrorBus';
+import { registerFeatureMarker } from './utils/featureMarkers';
+
+export const GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME = 'GlobalErrorBoundary';
 
 /**
  * Props for {@link GlobalErrorBoundary}. Extends the standard `ErrorBoundary`
@@ -74,6 +77,7 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
   private _latched = false;
 
   public componentDidMount(): void {
+    registerFeatureMarker(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME);
     this._subscribe();
   }
 

--- a/packages/core/src/js/integrations/default.ts
+++ b/packages/core/src/js/integrations/default.ts
@@ -46,6 +46,8 @@ import {
   viewHierarchyIntegration,
 } from './exports';
 
+const STANDALONE_APP_START_INTEGRATION_NAME = 'StandaloneAppStart';
+
 /**
  * Returns the default ReactNative integrations based on the current environment.
  *
@@ -114,6 +116,9 @@ export function getDefaultIntegrations(options: ReactNativeClientOptions): Integ
   const hasTracingEnabled = typeof options.tracesSampleRate === 'number' || typeof options.tracesSampler === 'function';
   if (hasTracingEnabled && options.enableAppStartTracking && options.enableNative) {
     integrations.push(appStartIntegration({ standalone: !!options._experiments?.enableStandaloneAppStartTracing }));
+    if (options._experiments?.enableStandaloneAppStartTracing) {
+      integrations.push({ name: STANDALONE_APP_START_INTEGRATION_NAME });
+    }
   }
   const nativeFramesIntegrationInstance = createNativeFramesIntegrations(
     hasTracingEnabled && options.enableNativeFramesTracking && options.enableNative,

--- a/packages/core/src/js/integrations/default.ts
+++ b/packages/core/src/js/integrations/default.ts
@@ -116,9 +116,12 @@ export function getDefaultIntegrations(options: ReactNativeClientOptions): Integ
   const hasTracingEnabled = typeof options.tracesSampleRate === 'number' || typeof options.tracesSampler === 'function';
   if (hasTracingEnabled && options.enableAppStartTracking && options.enableNative) {
     integrations.push(appStartIntegration({ standalone: !!options._experiments?.enableStandaloneAppStartTracing }));
-    if (options._experiments?.enableStandaloneAppStartTracing) {
-      integrations.push({ name: STANDALONE_APP_START_INTEGRATION_NAME });
-    }
+  }
+  // Registered outside the tracing/appStart/native gate: this is an adoption
+  // marker for the experiment flag itself, so it must reach errors-only
+  // projects and any config where tracing is disabled.
+  if (options._experiments?.enableStandaloneAppStartTracing) {
+    integrations.push({ name: STANDALONE_APP_START_INTEGRATION_NAME });
   }
   const nativeFramesIntegrationInstance = createNativeFramesIntegrations(
     hasTracingEnabled && options.enableNativeFramesTracking && options.enableNative,

--- a/packages/core/src/js/utils/featureMarkers.ts
+++ b/packages/core/src/js/utils/featureMarkers.ts
@@ -1,0 +1,25 @@
+import type { Client } from '@sentry/core';
+
+import { getClient } from '@sentry/core';
+
+/**
+ * Registers a no-op named integration on the client so the feature name flows
+ * through to `event.sdk.integrations` — the channel Sentry uses to measure
+ * feature adoption across SDKs.
+ *
+ * The registration is idempotent: a second call with the same name is a no-op
+ * because `getIntegrationByName` returns the existing entry.
+ *
+ * Failing quietly is intentional. Feature-adoption telemetry must never break
+ * the host app: if no client is available, or `addIntegration` is unavailable,
+ * the caller keeps working without a marker.
+ *
+ * @param name The name to register.
+ * @param client Optional explicit client. Falls back to `getClient()`.
+ */
+export function registerFeatureMarker(name: string, client: Client | undefined = getClient()): void {
+  if (!client || client.getIntegrationByName?.(name)) {
+    return;
+  }
+  client.addIntegration?.({ name });
+}

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,15 +1,21 @@
 import * as SentryCore from '@sentry/core';
+import { getClient, setCurrentClient } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
 
-import { GlobalErrorBoundary, withGlobalErrorBoundary } from '../src/js/GlobalErrorBoundary';
+import {
+  GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+  GlobalErrorBoundary,
+  withGlobalErrorBoundary,
+} from '../src/js/GlobalErrorBoundary';
 import {
   _resetGlobalErrorBus,
   hasInterestedSubscribers,
   publishGlobalError,
 } from '../src/js/integrations/globalErrorBus';
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
 
 function Fallback({ error, resetError }: { error: unknown; resetError: () => void }): React.ReactElement {
   return (
@@ -311,6 +317,28 @@ describe('GlobalErrorBoundary', () => {
       publishGlobalError({ error: new Error('hoc-boom'), isFatal: true, kind: 'onerror' });
     });
     expect(getByTestId('fallback').props.children.join('')).toBe('fallback:hoc-boom');
+  });
+});
+
+describe('GlobalErrorBoundary feature marker', () => {
+  beforeEach(() => {
+    _resetGlobalErrorBus();
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers the GlobalErrorBoundary marker on mount', () => {
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toBeUndefined();
+
+    render(
+      <GlobalErrorBoundary fallback={() => <Text>fb</Text>}>
+        <Text>x</Text>
+      </GlobalErrorBoundary>,
+    );
+
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toEqual({
+      name: GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+    });
   });
 });
 

--- a/packages/core/test/integrations/defaultAppStart.test.ts
+++ b/packages/core/test/integrations/defaultAppStart.test.ts
@@ -56,4 +56,16 @@ describe('getDefaultIntegrations - standalone app start wiring', () => {
 
     expect(integrations.some(i => i.name === 'StandaloneAppStart')).toBe(false);
   });
+
+  it.each([
+    ['tracing disabled', { tracesSampleRate: undefined }],
+    ['app start tracking off', { enableAppStartTracking: false }],
+    ['native off', { enableNative: false }],
+  ])('includes the StandaloneAppStart marker when the flag is on and %s', (_label, overrides) => {
+    const integrations = getDefaultIntegrations(
+      createOptions({ ...overrides, _experiments: { enableStandaloneAppStartTracing: true } }),
+    );
+
+    expect(integrations.some(i => i.name === 'StandaloneAppStart')).toBe(true);
+  });
 });

--- a/packages/core/test/integrations/defaultAppStart.test.ts
+++ b/packages/core/test/integrations/defaultAppStart.test.ts
@@ -42,4 +42,18 @@ describe('getDefaultIntegrations - standalone app start wiring', () => {
 
     expect(appStartIntegration).toHaveBeenCalledWith({ standalone: false });
   });
+
+  it('includes the StandaloneAppStart marker when the experiment flag is enabled', () => {
+    const integrations = getDefaultIntegrations(
+      createOptions({ _experiments: { enableStandaloneAppStartTracing: true } }),
+    );
+
+    expect(integrations.some(i => i.name === 'StandaloneAppStart')).toBe(true);
+  });
+
+  it('does not include the StandaloneAppStart marker when the experiment flag is off', () => {
+    const integrations = getDefaultIntegrations(createOptions({}));
+
+    expect(integrations.some(i => i.name === 'StandaloneAppStart')).toBe(false);
+  });
 });

--- a/packages/core/test/utils/featureMarkers.test.ts
+++ b/packages/core/test/utils/featureMarkers.test.ts
@@ -1,0 +1,55 @@
+import { captureException, getClient, setCurrentClient } from '@sentry/core';
+
+import { registerFeatureMarker } from '../../src/js/utils/featureMarkers';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('registerFeatureMarker', () => {
+  beforeEach(() => {
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers a no-op named integration on the current client', () => {
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toBeUndefined();
+
+    registerFeatureMarker('SomeFeature');
+
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toEqual({ name: 'SomeFeature' });
+  });
+
+  test('is idempotent — second call with the same name does not overwrite', () => {
+    const first = { name: 'IdempotentFeature', setupOnce: jest.fn() };
+    getClient()?.addIntegration(first);
+
+    registerFeatureMarker('IdempotentFeature');
+
+    expect(getClient()?.getIntegrationByName('IdempotentFeature')).toBe(first);
+  });
+
+  test('is a no-op when no client is available', () => {
+    setCurrentClient(undefined as unknown as TestClient);
+
+    expect(() => registerFeatureMarker('NoClientFeature')).not.toThrow();
+  });
+
+  test('accepts an explicit client argument', () => {
+    const explicitClient = new TestClient(getDefaultTestClientOptions());
+    explicitClient.init();
+
+    registerFeatureMarker('ExplicitClientFeature', explicitClient);
+
+    expect(explicitClient.getIntegrationByName('ExplicitClientFeature')).toEqual({ name: 'ExplicitClientFeature' });
+    expect(getClient()?.getIntegrationByName('ExplicitClientFeature')).toBeUndefined();
+  });
+
+  test('the marker name is attached to `event.sdk.integrations` on captured events', async () => {
+    registerFeatureMarker('AdoptionSignal');
+
+    captureException(new Error('boom'));
+    await getClient()?.flush();
+
+    const client = getClient() as TestClient;
+    const event = client.eventQueue[0];
+    expect(event?.sdk?.integrations).toContain('AdoptionSignal');
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement (feature-adoption telemetry)
- [ ] Refactoring

## Description

When `_experiments.enableStandaloneAppStartTracing` is enabled, adds a no-op `StandaloneAppStart` integration to the default integrations list so the name flows through to `event.sdk.integrations` on every event.

## Motivation and Context

Part of #6415. The standalone app start experiment produces a top-level `app.start` transaction (rather than a child span), which is distinguishable in the performance dataset but invisible to projects on errors-only or with low tracing sample rates. The `sdk.integrations` marker gives cross-event adoption.

## How did you test it?

- Two new tests in `test/integrations/defaultAppStart.test.ts` asserting the marker is/isn't included based on the flag.
- Existing default-integration tests continue to pass.
- Full local suite green.

## Checklist

- [x] I have added tests to validate that my change does not break existing functionality
- [x] I have made corresponding changes to the documentation _(none needed)_
- [ ] I have added a CHANGELOG entry _(intentionally omitted per #6415)_

## Base

Stacked on top of #6421. When #6421 merges, GitHub will automatically retarget this PR to `main`.

Refs: #6415