### PR TITLE
feat(replay): Track mobile replay network capture adoption

### DIFF
--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -7,6 +7,9 @@ import * as React from 'react';
 import type { GlobalErrorEvent } from './integrations/globalErrorBus';
 
 import { subscribeGlobalError } from './integrations/globalErrorBus';
+import { registerFeatureMarker } from './utils/featureMarkers';
+
+export const GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME = 'GlobalErrorBoundary';
 
 /**
  * Props for {@link GlobalErrorBoundary}. Extends the standard `ErrorBoundary`
@@ -74,6 +77,7 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
   private _latched = false;
 
   public componentDidMount(): void {
+    registerFeatureMarker(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME);
     this._subscribe();
   }
 

--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -7,8 +7,12 @@ import type { ResolvedNetworkOptions } from './networkUtils';
 import { isHardCrash } from '../misc';
 import { hasHooks } from '../utils/clientutils';
 import { isExpoGo, notMobileOs } from '../utils/environment';
+import { registerFeatureMarker } from '../utils/featureMarkers';
 import { NATIVE } from '../wrapper';
 import { makeEnrichXhrBreadcrumbsForMobileReplay } from './xhrUtils';
+
+const MOBILE_REPLAY_NETWORK_DETAILS_INTEGRATION_NAME = 'MobileReplayNetworkDetails';
+const MOBILE_REPLAY_NETWORK_BODIES_INTEGRATION_NAME = 'MobileReplayNetworkBodies';
 
 export const MOBILE_REPLAY_INTEGRATION_NAME = 'MobileReplay';
 
@@ -385,6 +389,13 @@ export const mobileReplayIntegration = (initOptions: MobileReplayOptions = defau
   function setup(client: Client): void {
     if (!hasHooks(client)) {
       return;
+    }
+
+    if ((options.networkDetailAllowUrls?.length ?? 0) > 0) {
+      registerFeatureMarker(MOBILE_REPLAY_NETWORK_DETAILS_INTEGRATION_NAME, client);
+      if (options.networkCaptureBodies ?? true) {
+        registerFeatureMarker(MOBILE_REPLAY_NETWORK_BODIES_INTEGRATION_NAME, client);
+      }
     }
 
     // Initialize the cached replay ID on setup

--- a/packages/core/src/js/utils/featureMarkers.ts
+++ b/packages/core/src/js/utils/featureMarkers.ts
@@ -1,0 +1,25 @@
+import type { Client } from '@sentry/core';
+
+import { getClient } from '@sentry/core';
+
+/**
+ * Registers a no-op named integration on the client so the feature name flows
+ * through to `event.sdk.integrations` — the channel Sentry uses to measure
+ * feature adoption across SDKs.
+ *
+ * The registration is idempotent: a second call with the same name is a no-op
+ * because `getIntegrationByName` returns the existing entry.
+ *
+ * Failing quietly is intentional. Feature-adoption telemetry must never break
+ * the host app: if no client is available, or `addIntegration` is unavailable,
+ * the caller keeps working without a marker.
+ *
+ * @param name The name to register.
+ * @param client Optional explicit client. Falls back to `getClient()`.
+ */
+export function registerFeatureMarker(name: string, client: Client | undefined = getClient()): void {
+  if (!client || client.getIntegrationByName?.(name)) {
+    return;
+  }
+  client.addIntegration?.({ name });
+}

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,15 +1,21 @@
 import * as SentryCore from '@sentry/core';
+import { getClient, setCurrentClient } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
 
-import { GlobalErrorBoundary, withGlobalErrorBoundary } from '../src/js/GlobalErrorBoundary';
+import {
+  GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+  GlobalErrorBoundary,
+  withGlobalErrorBoundary,
+} from '../src/js/GlobalErrorBoundary';
 import {
   _resetGlobalErrorBus,
   hasInterestedSubscribers,
   publishGlobalError,
 } from '../src/js/integrations/globalErrorBus';
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
 
 function Fallback({ error, resetError }: { error: unknown; resetError: () => void }): React.ReactElement {
   return (
@@ -311,6 +317,28 @@ describe('GlobalErrorBoundary', () => {
       publishGlobalError({ error: new Error('hoc-boom'), isFatal: true, kind: 'onerror' });
     });
     expect(getByTestId('fallback').props.children.join('')).toBe('fallback:hoc-boom');
+  });
+});
+
+describe('GlobalErrorBoundary feature marker', () => {
+  beforeEach(() => {
+    _resetGlobalErrorBus();
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers the GlobalErrorBoundary marker on mount', () => {
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toBeUndefined();
+
+    render(
+      <GlobalErrorBoundary fallback={() => <Text>fb</Text>}>
+        <Text>x</Text>
+      </GlobalErrorBoundary>,
+    );
+
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toEqual({
+      name: GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+    });
   });
 });
 

--- a/packages/core/test/replay/mobilereplay.test.ts
+++ b/packages/core/test/replay/mobilereplay.test.ts
@@ -534,6 +534,50 @@ describe('Mobile Replay Integration', () => {
     });
   });
 
+  describe('network detail feature markers', () => {
+    let mockAddIntegration: jest.Mock;
+    let mockGetIntegrationByName: jest.Mock;
+    let markerClient: jest.Mocked<Client>;
+
+    beforeEach(() => {
+      mockAddIntegration = jest.fn();
+      mockGetIntegrationByName = jest.fn().mockReturnValue(undefined);
+      markerClient = {
+        on: jest.fn(),
+        getOptions: jest.fn(() => ({})),
+        getIntegrationByName: mockGetIntegrationByName,
+        addIntegration: mockAddIntegration,
+      } as unknown as jest.Mocked<Client>;
+    });
+
+    it('does not register network markers when networkDetailAllowUrls is empty', () => {
+      const integration = mobileReplayIntegration({ networkDetailAllowUrls: [] });
+      integration.setup?.(markerClient);
+
+      expect(mockAddIntegration).not.toHaveBeenCalledWith({ name: 'MobileReplayNetworkDetails' });
+      expect(mockAddIntegration).not.toHaveBeenCalledWith({ name: 'MobileReplayNetworkBodies' });
+    });
+
+    it('registers both markers when networkDetailAllowUrls is set (bodies default true)', () => {
+      const integration = mobileReplayIntegration({ networkDetailAllowUrls: ['https://api.example.com'] });
+      integration.setup?.(markerClient);
+
+      expect(mockAddIntegration).toHaveBeenCalledWith({ name: 'MobileReplayNetworkDetails' });
+      expect(mockAddIntegration).toHaveBeenCalledWith({ name: 'MobileReplayNetworkBodies' });
+    });
+
+    it('registers only the details marker when bodies are explicitly disabled', () => {
+      const integration = mobileReplayIntegration({
+        networkDetailAllowUrls: ['https://api.example.com'],
+        networkCaptureBodies: false,
+      });
+      integration.setup?.(markerClient);
+
+      expect(mockAddIntegration).toHaveBeenCalledWith({ name: 'MobileReplayNetworkDetails' });
+      expect(mockAddIntegration).not.toHaveBeenCalledWith({ name: 'MobileReplayNetworkBodies' });
+    });
+  });
+
   describe('platform checks', () => {
     it('should return noop integration in Expo Go', () => {
       jest.spyOn(environment, 'isExpoGo').mockReturnValue(true);

--- a/packages/core/test/utils/featureMarkers.test.ts
+++ b/packages/core/test/utils/featureMarkers.test.ts
@@ -1,0 +1,55 @@
+import { captureException, getClient, setCurrentClient } from '@sentry/core';
+
+import { registerFeatureMarker } from '../../src/js/utils/featureMarkers';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('registerFeatureMarker', () => {
+  beforeEach(() => {
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers a no-op named integration on the current client', () => {
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toBeUndefined();
+
+    registerFeatureMarker('SomeFeature');
+
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toEqual({ name: 'SomeFeature' });
+  });
+
+  test('is idempotent — second call with the same name does not overwrite', () => {
+    const first = { name: 'IdempotentFeature', setupOnce: jest.fn() };
+    getClient()?.addIntegration(first);
+
+    registerFeatureMarker('IdempotentFeature');
+
+    expect(getClient()?.getIntegrationByName('IdempotentFeature')).toBe(first);
+  });
+
+  test('is a no-op when no client is available', () => {
+    setCurrentClient(undefined as unknown as TestClient);
+
+    expect(() => registerFeatureMarker('NoClientFeature')).not.toThrow();
+  });
+
+  test('accepts an explicit client argument', () => {
+    const explicitClient = new TestClient(getDefaultTestClientOptions());
+    explicitClient.init();
+
+    registerFeatureMarker('ExplicitClientFeature', explicitClient);
+
+    expect(explicitClient.getIntegrationByName('ExplicitClientFeature')).toEqual({ name: 'ExplicitClientFeature' });
+    expect(getClient()?.getIntegrationByName('ExplicitClientFeature')).toBeUndefined();
+  });
+
+  test('the marker name is attached to `event.sdk.integrations` on captured events', async () => {
+    registerFeatureMarker('AdoptionSignal');
+
+    captureException(new Error('boom'));
+    await getClient()?.flush();
+
+    const client = getClient() as TestClient;
+    const event = client.eventQueue[0];
+    expect(event?.sdk?.integrations).toContain('AdoptionSignal');
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement (feature-adoption telemetry)
- [ ] Refactoring

## Description

Registers no-op `MobileReplayNetworkDetails` and `MobileReplayNetworkBodies` integrations at replay setup when the corresponding options are configured, so the names flow through to `event.sdk.integrations`.

Two markers give a clean funnel:
- Replay on → `MobileReplay` (already tracked)
- Network details on (any `networkDetailAllowUrls`) → `MobileReplayNetworkDetails`
- Bodies on (`networkCaptureBodies`, defaults to `true`) → `MobileReplayNetworkBodies`

Bundled together because both markers live in the same `if (networkDetailAllowUrls)` block in `mobilereplay.ts` — splitting them would mean two PRs editing the same lines.

## Motivation and Context

Part of #6415. The parent `MobileReplay` integration name is already reported, but the sub-options (headers vs. bodies) are not distinguishable from `sdk.integrations` alone. This is the more sensitive/opt-in half of replay and worth tracking separately.

## How did you test it?

- New `describe('network detail feature markers')` block in `test/replay/mobilereplay.test.ts` with three cases: no allow URLs → no markers; allow URLs set (bodies default) → both markers; allow URLs + `networkCaptureBodies: false` → only the details marker.
- Existing mobile replay tests continue to pass.
- Full local suite green.

## Checklist

- [x] I have added tests to validate that my change does not break existing functionality
- [x] I have made corresponding changes to the documentation _(none needed)_
- [ ] I have added a CHANGELOG entry _(intentionally omitted per #6415)_

## Base

Stacked on top of #6421. When #6421 merges, GitHub will automatically retarget this PR to `main`.

Refs: #6415