### PR TITLE
feat(core): Track CaptureAppStartErrors adoption

### DIFF
--- a/packages/core/src/js/GlobalErrorBoundary.tsx
+++ b/packages/core/src/js/GlobalErrorBoundary.tsx
@@ -7,6 +7,9 @@ import * as React from 'react';
 import type { GlobalErrorEvent } from './integrations/globalErrorBus';
 
 import { subscribeGlobalError } from './integrations/globalErrorBus';
+import { registerFeatureMarker } from './utils/featureMarkers';
+
+export const GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME = 'GlobalErrorBoundary';
 
 /**
  * Props for {@link GlobalErrorBoundary}. Extends the standard `ErrorBoundary`
@@ -74,6 +77,7 @@ export class GlobalErrorBoundary extends React.Component<GlobalErrorBoundaryProp
   private _latched = false;
 
   public componentDidMount(): void {
+    registerFeatureMarker(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME);
     this._subscribe();
   }
 

--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -34,11 +34,14 @@ import {
 import { useEncodePolyfill } from './transports/encodePolyfill';
 import { DEFAULT_BUFFER_SIZE, makeNativeTransportFactory } from './transports/native';
 import { getDefaultEnvironment, isExpoGo, isRunningInMetroDevServer, isWeb } from './utils/environment';
+import { registerFeatureMarker } from './utils/featureMarkers';
 import { getDefaultRelease } from './utils/release';
 import { safeFactory, safeTracesSampler } from './utils/safe';
 import { checkSentryJsSdkVersionMismatch } from './utils/sdkVersionCheck';
 import { RN_GLOBAL_OBJ } from './utils/worldwide';
 import { NATIVE } from './wrapper';
+
+const CAPTURE_APP_START_ERRORS_INTEGRATION_NAME = 'CaptureAppStartErrors';
 
 const DEFAULT_OPTIONS: ReactNativeOptions = {
   enableNativeCrashHandling: true,
@@ -189,6 +192,10 @@ export function init(passedOptions: ReactNativeOptions): void {
 
   if (RN_GLOBAL_OBJ.__SENTRY_OPTIONS__) {
     debug.log('Sentry JS initialized with options from the options file.');
+    // Adoption marker for the "capture app-start errors" feature: shipping
+    // `sentry.options.json` is what opts users in (the Metro serializer bundles
+    // it into JS as `__SENTRY_OPTIONS__`, and native reads it before JS runs).
+    registerFeatureMarker(CAPTURE_APP_START_ERRORS_INTEGRATION_NAME);
   }
 }
 

--- a/packages/core/src/js/utils/featureMarkers.ts
+++ b/packages/core/src/js/utils/featureMarkers.ts
@@ -1,0 +1,25 @@
+import type { Client } from '@sentry/core';
+
+import { getClient } from '@sentry/core';
+
+/**
+ * Registers a no-op named integration on the client so the feature name flows
+ * through to `event.sdk.integrations` — the channel Sentry uses to measure
+ * feature adoption across SDKs.
+ *
+ * The registration is idempotent: a second call with the same name is a no-op
+ * because `getIntegrationByName` returns the existing entry.
+ *
+ * Failing quietly is intentional. Feature-adoption telemetry must never break
+ * the host app: if no client is available, or `addIntegration` is unavailable,
+ * the caller keeps working without a marker.
+ *
+ * @param name The name to register.
+ * @param client Optional explicit client. Falls back to `getClient()`.
+ */
+export function registerFeatureMarker(name: string, client: Client | undefined = getClient()): void {
+  if (!client || client.getIntegrationByName?.(name)) {
+    return;
+  }
+  client.addIntegration?.({ name });
+}

--- a/packages/core/test/GlobalErrorBoundary.test.tsx
+++ b/packages/core/test/GlobalErrorBoundary.test.tsx
@@ -1,15 +1,21 @@
 import * as SentryCore from '@sentry/core';
+import { getClient, setCurrentClient } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 import * as React from 'react';
 import { Text, View } from 'react-native';
 
-import { GlobalErrorBoundary, withGlobalErrorBoundary } from '../src/js/GlobalErrorBoundary';
+import {
+  GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+  GlobalErrorBoundary,
+  withGlobalErrorBoundary,
+} from '../src/js/GlobalErrorBoundary';
 import {
   _resetGlobalErrorBus,
   hasInterestedSubscribers,
   publishGlobalError,
 } from '../src/js/integrations/globalErrorBus';
+import { getDefaultTestClientOptions, TestClient } from './mocks/client';
 
 function Fallback({ error, resetError }: { error: unknown; resetError: () => void }): React.ReactElement {
   return (
@@ -311,6 +317,28 @@ describe('GlobalErrorBoundary', () => {
       publishGlobalError({ error: new Error('hoc-boom'), isFatal: true, kind: 'onerror' });
     });
     expect(getByTestId('fallback').props.children.join('')).toBe('fallback:hoc-boom');
+  });
+});
+
+describe('GlobalErrorBoundary feature marker', () => {
+  beforeEach(() => {
+    _resetGlobalErrorBus();
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers the GlobalErrorBoundary marker on mount', () => {
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toBeUndefined();
+
+    render(
+      <GlobalErrorBoundary fallback={() => <Text>fb</Text>}>
+        <Text>x</Text>
+      </GlobalErrorBoundary>,
+    );
+
+    expect(getClient()?.getIntegrationByName(GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME)).toEqual({
+      name: GLOBAL_ERROR_BOUNDARY_INTEGRATION_NAME,
+    });
   });
 });
 

--- a/packages/core/test/sdk.test.ts
+++ b/packages/core/test/sdk.test.ts
@@ -11,6 +11,7 @@ import { init, withScope } from '../src/js/sdk';
 import { REACT_NATIVE_TRACING_INTEGRATION_NAME, reactNativeTracingIntegration } from '../src/js/tracing';
 import { makeNativeTransport } from '../src/js/transports/native';
 import { getDefaultEnvironment, isExpoGo, notWeb } from '../src/js/utils/environment';
+import { registerFeatureMarker } from '../src/js/utils/featureMarkers';
 import { RN_GLOBAL_OBJ } from '../src/js/utils/worldwide';
 import { NATIVE } from './mockWrapper';
 import { firstArg, secondArg } from './testutils';
@@ -24,6 +25,9 @@ jest.mock('@sentry/core', () => ({
 }));
 jest.mock('../src/js/integrations/debugsymbolicatorutils', () => ({
   getDevServer: jest.fn(),
+}));
+jest.mock('../src/js/utils/featureMarkers', () => ({
+  registerFeatureMarker: jest.fn(),
 }));
 
 describe('Tests the SDK functionality', () => {
@@ -188,6 +192,18 @@ describe('Tests the SDK functionality', () => {
           autoInitializeNativeSdk: false,
         });
         expect(usedOptions()?.autoInitializeNativeSdk).toBe(false);
+      });
+
+      it('registers the CaptureAppStartErrors marker when __SENTRY_OPTIONS__ is set', () => {
+        RN_GLOBAL_OBJ.__SENTRY_OPTIONS__ = {};
+        init({});
+        expect(registerFeatureMarker).toHaveBeenCalledWith('CaptureAppStartErrors');
+      });
+
+      it('does not register the CaptureAppStartErrors marker without __SENTRY_OPTIONS__', () => {
+        delete RN_GLOBAL_OBJ.__SENTRY_OPTIONS__;
+        init({});
+        expect(registerFeatureMarker).not.toHaveBeenCalledWith('CaptureAppStartErrors');
       });
     });
 

--- a/packages/core/test/utils/featureMarkers.test.ts
+++ b/packages/core/test/utils/featureMarkers.test.ts
@@ -1,0 +1,55 @@
+import { captureException, getClient, setCurrentClient } from '@sentry/core';
+
+import { registerFeatureMarker } from '../../src/js/utils/featureMarkers';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('registerFeatureMarker', () => {
+  beforeEach(() => {
+    setCurrentClient(new TestClient(getDefaultTestClientOptions()));
+    getClient()?.init();
+  });
+
+  test('registers a no-op named integration on the current client', () => {
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toBeUndefined();
+
+    registerFeatureMarker('SomeFeature');
+
+    expect(getClient()?.getIntegrationByName('SomeFeature')).toEqual({ name: 'SomeFeature' });
+  });
+
+  test('is idempotent — second call with the same name does not overwrite', () => {
+    const first = { name: 'IdempotentFeature', setupOnce: jest.fn() };
+    getClient()?.addIntegration(first);
+
+    registerFeatureMarker('IdempotentFeature');
+
+    expect(getClient()?.getIntegrationByName('IdempotentFeature')).toBe(first);
+  });
+
+  test('is a no-op when no client is available', () => {
+    setCurrentClient(undefined as unknown as TestClient);
+
+    expect(() => registerFeatureMarker('NoClientFeature')).not.toThrow();
+  });
+
+  test('accepts an explicit client argument', () => {
+    const explicitClient = new TestClient(getDefaultTestClientOptions());
+    explicitClient.init();
+
+    registerFeatureMarker('ExplicitClientFeature', explicitClient);
+
+    expect(explicitClient.getIntegrationByName('ExplicitClientFeature')).toEqual({ name: 'ExplicitClientFeature' });
+    expect(getClient()?.getIntegrationByName('ExplicitClientFeature')).toBeUndefined();
+  });
+
+  test('the marker name is attached to `event.sdk.integrations` on captured events', async () => {
+    registerFeatureMarker('AdoptionSignal');
+
+    captureException(new Error('boom'));
+    await getClient()?.flush();
+
+    const client = getClient() as TestClient;
+    const event = client.eventQueue[0];
+    expect(event?.sdk?.integrations).toContain('AdoptionSignal');
+  });
+});


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement (feature-adoption telemetry)
- [ ] Refactoring

## Description

Registers a no-op `CaptureAppStartErrors` integration when the JS runtime detects that `sentry.options.json` is present, so the name flows through to `event.sdk.integrations`.

Detection is entirely on the JS side: the Metro serializer (`sentryOptionsSerializer.ts`) already bundles `sentry.options.json` into the JS bundle as `RN_GLOBAL_OBJ.__SENTRY_OPTIONS__` at build time — shipping that config file is what opts users into the pre-JS crash capture feature. No native or bridge changes are required.

## Motivation and Context

Part of #6415. This was the flagship 8.0 feature and the largest telemetry gap: `sentry.options.json` runs before the JS bundle loads, so today only rare pre-JS crashes signal adoption (and even those look like plain native crashes). The marker lets us see adoption directly in `sdk_integration_array`.

Initial plan called for a native flag + bridge round-trip on iOS and Android. That turned out to be unnecessary: `sdk.tsx` already reads `__SENTRY_OPTIONS__` at init to gate `autoInitializeNativeSdk` (see the existing checks at `sdk.tsx:71,156,190`), so the JS side already has the signal we need.

## Behavior

- Fires in both `__DEV__` and release builds, whenever `__SENTRY_OPTIONS__` is bundled. This measures user *intent* to adopt the feature (matches the choice made for `StandaloneAppStart` in #6427).
- Does not fire when the app has no `sentry.options.json` at all.
- No-ops silently if `Sentry.init()` was somehow called before `initAndBind` — the marker registration runs after the client is bound, so this is essentially guaranteed.

## How did you test it?

Two new tests in `test/sdk.test.ts` under `initialization from sentry.options.json`:
- Asserts the marker is registered when `RN_GLOBAL_OBJ.__SENTRY_OPTIONS__` is set.
- Asserts the marker is NOT registered when `__SENTRY_OPTIONS__` is deleted.

Full local suite green (118/118 in `sdk.test.ts`, 1676/1676 across all suites for this branch), lint clean, `tsc` clean.

## Checklist

- [x] I have added tests to validate that my change does not break existing functionality
- [x] I have made corresponding changes to the documentation _(none needed — internal telemetry, no user-facing API)_
- [ ] I have added a CHANGELOG entry _(intentionally omitted per #6415)_

## Base

Stacked on top of #6421. When #6421 merges, GitHub will automatically retarget this PR to `main`.

Refs: #6415