### PR TITLE
fix(ios): Break RNSentryOnDrawReporterView retain cycle in emit-new-frame block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix iOS time-to-initial-display fallback spans reporting a spurious `deadline_exceeded` status and inflated duration ([#6438](https://github.com/getsentry/sentry-react-native/pull/6438))
 - Fix `TypeError` when `showFeedbackForm`/`showFeedbackButton`/`showScreenshotButton` is called before `FeedbackFormProvider` mounts ([#6435](https://github.com/getsentry/sentry-react-native/pull/6435))
 - Fix orphaned TTID/TTFD spans in the trace view ([#6437](https://github.com/getsentry/sentry-react-native/pull/6437))
+- Fix iOS retain cycle in `RNSentryOnDrawReporterView` leaking TTID/TTFD reporter views and their frame-tracker listeners ([#6449](https://github.com/getsentry/sentry-react-native/pull/6449))
 
 ### Internal
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryOnDrawReporterTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryOnDrawReporterTests.swift
@@ -145,4 +145,22 @@ final class RNSentryOnDrawReporterTests: XCTestCase {
 
         emitNewFrameCallback!(1)
     }
+
+    func testReporterViewIsDeallocatedAfterRelease() {
+        // Guards against the retain cycle described in
+        // https://github.com/getsentry/sentry-react-native/issues/6440 where the
+        // emit-new-frame block captured `self` strongly, keeping the view (and
+        // its frames-tracker listener) alive forever.
+        weak var weakReporter: RNSentryOnDrawReporterView?
+
+        autoreleasepool {
+            let reporter = RNSentryOnDrawReporterView.createWithMockedListener()
+            reporter!.initialDisplay = true
+            reporter!.parentSpanId = spanId
+            reporter!.didSetProps(["initialDisplay", "parentSpanId"])
+            weakReporter = reporter
+        }
+
+        XCTAssertNil(weakReporter, "RNSentryOnDrawReporterView leaked due to a retain cycle")
+    }
 }

--- a/packages/core/ios/RNSentryOnDrawReporter.m
+++ b/packages/core/ios/RNSentryOnDrawReporter.m
@@ -40,23 +40,29 @@ RCT_EXPORT_VIEW_PROPERTY(parentSpanId, NSString)
 
 - (RNSentryEmitNewFrameEvent)createEmitNewFrameEvent
 {
+    __weak __typeof__(self) weakSelf = self;
     return ^(NSNumber *newFrameTimestampInSeconds) {
-        self->isListening = NO;
-
-        if (![_parentSpanId isKindOfClass:[NSString class]]) {
+        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+        if (strongSelf == nil) {
             return;
         }
 
-        if (self->_fullDisplay) {
+        strongSelf->isListening = NO;
+
+        if (![strongSelf->_parentSpanId isKindOfClass:[NSString class]]) {
+            return;
+        }
+
+        if (strongSelf->_fullDisplay) {
             [RNSentryTimeToDisplay
-                putTimeToDisplayFor:[@"ttfd-" stringByAppendingString:self->_parentSpanId]
+                putTimeToDisplayFor:[@"ttfd-" stringByAppendingString:strongSelf->_parentSpanId]
                               value:newFrameTimestampInSeconds];
             return;
         }
 
-        if (self->_initialDisplay) {
+        if (strongSelf->_initialDisplay) {
             [RNSentryTimeToDisplay
-                putTimeToDisplayFor:[@"ttid-" stringByAppendingString:self->_parentSpanId]
+                putTimeToDisplayFor:[@"ttid-" stringByAppendingString:strongSelf->_parentSpanId]
                               value:newFrameTimestampInSeconds];
             return;
         }


### PR DESCRIPTION
## 📢 Type of change

- [X] Bugfix

## 📜 Description

The block returned from `createEmitNewFrameEvent` captures `self` strongly, and the view owns the listener that owns the block — closed loop, nothing gets freed. Switched to weak capture.

## 💡 Motivation and Context

Fixes getsentry/sentry-react-native#6440. Leaks in Instruments showed a bunch of `RNSentryOnDrawReporterView` / `RNSentryFramesTrackerListener` piling up during scrolling.

## 💚 How did you test it?

Added a test that holds only a weak ref to the view and checks it's gone after the autoreleasepool drains. Fails on main, passes here.

## :pencil: Checklist

- [X] I added tests to verify changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] All tests passing.
- [X] No breaking changes.