### PR TITLE
fix(ios): Backport #6449 (retain cycle in RNSentryOnDrawReporterView) to 8.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## 8.14.2
+
+### Fixes
+
+- Fix iOS retain cycle in `RNSentryOnDrawReporterView` leaking TTID/TTFD reporter views and their frame-tracker listeners ([#6449](https://github.com/getsentry/sentry-react-native/pull/6449))
+
 ## 8.14.1
 
 ### Fixes

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryOnDrawReporterTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryOnDrawReporterTests.swift
@@ -145,4 +145,22 @@ final class RNSentryOnDrawReporterTests: XCTestCase {
 
         emitNewFrameCallback!(1)
     }
+
+    func testReporterViewIsDeallocatedAfterRelease() {
+        // Guards against the retain cycle described in
+        // https://github.com/getsentry/sentry-react-native/issues/6440 where the
+        // emit-new-frame block captured `self` strongly, keeping the view (and
+        // its frames-tracker listener) alive forever.
+        weak var weakReporter: RNSentryOnDrawReporterView?
+
+        autoreleasepool {
+            let reporter = RNSentryOnDrawReporterView.createWithMockedListener()
+            reporter!.initialDisplay = true
+            reporter!.parentSpanId = spanId
+            reporter!.didSetProps(["initialDisplay", "parentSpanId"])
+            weakReporter = reporter
+        }
+
+        XCTAssertNil(weakReporter, "RNSentryOnDrawReporterView leaked due to a retain cycle")
+    }
 }

--- a/packages/core/ios/RNSentryOnDrawReporter.m
+++ b/packages/core/ios/RNSentryOnDrawReporter.m
@@ -40,23 +40,29 @@ RCT_EXPORT_VIEW_PROPERTY(parentSpanId, NSString)
 
 - (RNSentryEmitNewFrameEvent)createEmitNewFrameEvent
 {
+    __weak __typeof__(self) weakSelf = self;
     return ^(NSNumber *newFrameTimestampInSeconds) {
-        self->isListening = NO;
-
-        if (![_parentSpanId isKindOfClass:[NSString class]]) {
+        __strong __typeof__(weakSelf) strongSelf = weakSelf;
+        if (strongSelf == nil) {
             return;
         }
 
-        if (self->_fullDisplay) {
+        strongSelf->isListening = NO;
+
+        if (![strongSelf->_parentSpanId isKindOfClass:[NSString class]]) {
+            return;
+        }
+
+        if (strongSelf->_fullDisplay) {
             [RNSentryTimeToDisplay
-                putTimeToDisplayFor:[@"ttfd-" stringByAppendingString:self->_parentSpanId]
+                putTimeToDisplayFor:[@"ttfd-" stringByAppendingString:strongSelf->_parentSpanId]
                               value:newFrameTimestampInSeconds];
             return;
         }
 
-        if (self->_initialDisplay) {
+        if (strongSelf->_initialDisplay) {
             [RNSentryTimeToDisplay
-                putTimeToDisplayFor:[@"ttid-" stringByAppendingString:self->_parentSpanId]
+                putTimeToDisplayFor:[@"ttid-" stringByAppendingString:strongSelf->_parentSpanId]
                               value:newFrameTimestampInSeconds];
             return;
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
Backport of #6449 onto `release/8.14` for a 8.14.2 patch release. The iOS file was unchanged between 8.14.1 and main, so the fix cherry-picks cleanly (only CHANGELOG needed resolution).

## :bulb: Motivation and Context
Fixes #6440 on the 8.14 line for users pinned to it.

## :green_heart: How did you test it?
Same test as on main — `testReporterViewIsDeallocatedAfterRelease` in `RNSentryOnDrawReporterTests.swift`.

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] All tests passing.
- [x] No breaking changes.