### PR TITLE
build(craft): Set checkPackageName so 8.14.x publishes under the "old" npm dist-tag

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,6 +3,7 @@ changelogPolicy: auto
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm
+    checkPackageName: '@sentry/react-native'
   - name: github
   - name: registry
     sdks:


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
Set `checkPackageName: '@sentry/react-native'` on the npm target so craft's built-in "publish lower version under `old` tag" path kicks in (see [`getPublishTag()` in `src/targets/npm.ts`](https://github.com/getsentry/craft/blob/master/src/targets/npm.ts)).

Craft doesn't accept a `distTag` field on the npm target — first version of this PR set it and it would have been silently ignored (thanks Cursor bugbot for catching that). With `checkPackageName` set, craft compares the version being published against the registry's `latest`, and if lower publishes `--tag=old`. Both packages currently have `latest = 8.18.0`, so 8.14.2 will land under `old` and `latest` stays put.

## :bulb: Motivation and Context
Unblocks the 8.14.2 release run. See failing publish job: https://github.com/getsentry/publish/actions/runs/29426486747/job/87390105496

`npm error Cannot implicitly apply the "latest" tag because previously published version 8.18.0 is higher than the new version 8.14.2.`

The safeguard is new in npm 11 ([npm/cli#7939](https://github.com/npm/cli/pull/7939)); craft's docker image bumped from Node 22 (npm 10.9) → Node 24 (npm 11.16) on 2026-06-26 ([getsentry/craft#838](https://github.com/getsentry/craft/pull/838)), which is why 8.14.1 got through on 2026-06-24 and 8.14.2 now fails.

Users on the 8.14 line install with `npm i @sentry/react-native@8.14.2` (or `@old`).

## :green_heart: How did you test it?
Config-only change. Verified by re-running the craft publish job after merge.

## :pencil: Checklist
- [x] No breaking changes.