### PR TITLE
build(npm): Set publishConfig.tag=v8.14 on 8.14.x packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,8 @@
     "ios"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8.14"
   },
   "author": "Sentry",
   "license": "MIT",

--- a/packages/expo-upload-sourcemaps/package.json
+++ b/packages/expo-upload-sourcemaps/package.json
@@ -45,6 +45,7 @@
     "node": ">=18"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "v8.14"
   }
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
Add `"tag": "v8.14"` under `publishConfig` in both publishable package.json files (`@sentry/react-native`, `@sentry/expo-upload-sourcemaps`). npm reads that at publish time and uses it as the default dist-tag when no `--tag` is passed on the CLI.

## :bulb: Motivation and Context
Prior PR set craft's `checkPackageName` so craft would pass `--tag=old` automatically. That merged, but the retry still failed with the same `Cannot implicitly apply the "latest" tag` error — and craft's expected `Adding tag ...` warn never showed up in the run log. Something in the runtime path is preventing `getPublishTag` from doing its job here.

`publishConfig.tag` is a standard npm feature and bypasses the craft config path entirely, so it unblocks the 8.14.2 publish regardless. `v8.14` reads better than the generic `old` and namespaces future 8.14.x hotfixes to the same tag.

Failing run: https://github.com/getsentry/publish/actions/runs/29435125643/job/87419718179

## :green_heart: How did you test it?
Config-only change. Verified by re-running the craft publish job after merge.

## :pencil: Checklist
- [x] No breaking changes.