### PR TITLE
docs(changelog): Add 8.14.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,12 @@
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#351)
   - [diff](https://github.com/getsentry/sentry-cli/compare/3.5.0...3.5.1)
 
+## 8.14.2
+
+### Fixes
+
+- Fix iOS retain cycle in `RNSentryOnDrawReporterView` leaking TTID/TTFD reporter views and their frame-tracker listeners ([#6449](https://github.com/getsentry/sentry-react-native/pull/6449))
+
 ## 8.14.1
 
 ### Fixes


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Refactoring

## :scroll: Description
The 8.14.2 CHANGELOG section lives on `release/8.14` but was never carried over to main. Add it back between 8.14.1 and 8.15.0 so main's history reflects the released hotfix.

## :bulb: Motivation and Context
Keep main's CHANGELOG complete.

## :pencil: Checklist
- [x] No breaking changes.