### PR TITLE
fix(core): Fix stale route when reactNavigationIntegration uses a route override provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fix `TypeError` when `showFeedbackForm`/`showFeedbackButton`/`showScreenshotButton` is called before `FeedbackFormProvider` mounts ([#6435](https://github.com/getsentry/sentry-react-native/pull/6435))
 - Fix orphaned TTID/TTFD spans in the trace view ([#6437](https://github.com/getsentry/sentry-react-native/pull/6437))
 - Fix iOS retain cycle in `RNSentryOnDrawReporterView` leaking TTID/TTFD reporter views and their frame-tracker listeners ([#6449](https://github.com/getsentry/sentry-react-native/pull/6449))
-- Fix `reactNavigationIntegration` reading a stale route from an override provider (e.g. `expoRouterIntegration`), causing navigation transactions to be named/attributed for the previous route ([#6436](https://github.com/getsentry/sentry-react-native/issues/6436))
+- Fix `reactNavigationIntegration` reading a stale route from an override provider (e.g. `expoRouterIntegration`), causing navigation transactions to be named/attributed for the previous route ([#6458](https://github.com/getsentry/sentry-react-native/pull/6458))
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix `TypeError` when `showFeedbackForm`/`showFeedbackButton`/`showScreenshotButton` is called before `FeedbackFormProvider` mounts ([#6435](https://github.com/getsentry/sentry-react-native/pull/6435))
 - Fix orphaned TTID/TTFD spans in the trace view ([#6437](https://github.com/getsentry/sentry-react-native/pull/6437))
 - Fix iOS retain cycle in `RNSentryOnDrawReporterView` leaking TTID/TTFD reporter views and their frame-tracker listeners ([#6449](https://github.com/getsentry/sentry-react-native/pull/6449))
+- Fix `reactNavigationIntegration` reading a stale route from an override provider (e.g. `expoRouterIntegration`), causing navigation transactions to be named/attributed for the previous route ([#6436](https://github.com/getsentry/sentry-react-native/issues/6436))
 
 ### Internal
 

--- a/packages/core/src/js/tracing/reactnavigation.ts
+++ b/packages/core/src/js/tracing/reactnavigation.ts
@@ -411,7 +411,14 @@ export const reactNavigationIntegration = ({
 
     // This action is emitted on every dispatch
     navigationContainer.addListener('__unsafe_action__', startIdleNavigationSpan);
-    navigationContainer.addListener('state', updateLatestNavigationSpanWithCurrentRoute);
+    // React Navigation fires `emit('state')` synchronously BEFORE the
+    // `onStateChange` prop callback. Integrations like Expo Router refresh
+    // their route cache (which our route override provider reads) inside that
+    // `onStateChange`, so reading the override synchronously here would return
+    // the previous route for the current transition. Defer with a microtask
+    // so the read happens after the synchronous state-change chain completes
+    // and downstream caches have caught up. See #6436.
+    navigationContainer.addListener('state', scheduleUpdateLatestNavigationSpanWithCurrentRoute);
     RN_GLOBAL_OBJ.__sentry_rn_v5_registered = true;
 
     if (initialStateHandled) {
@@ -595,6 +602,27 @@ export const reactNavigationIntegration = ({
     }
 
     stateChangeTimeout = setTimeout(_discardLatestTransaction, routeChangeTimeoutMs);
+  };
+
+  /**
+   * Defer {@link updateLatestNavigationSpanWithCurrentRoute} until the current
+   * synchronous state-change chain unwinds so route override providers backed
+   * by a downstream cache (e.g. Expo Router's router-store, which is refreshed
+   * via `NavigationContainer.onStateChange`) have picked up the new route. See
+   * #6436.
+   */
+  const scheduleUpdateLatestNavigationSpanWithCurrentRoute = (): void => {
+    const g = globalThis as unknown as { queueMicrotask?: (cb: () => void) => void };
+    if (typeof g.queueMicrotask === 'function') {
+      g.queueMicrotask(updateLatestNavigationSpanWithCurrentRoute);
+      return;
+    }
+    // Fallback for runtimes without `queueMicrotask`. `.catch()` handler is
+    // there only to satisfy the `no-floating-promises` lint — the update
+    // function does not throw.
+    Promise.resolve()
+      .then(updateLatestNavigationSpanWithCurrentRoute)
+      .catch(() => {});
   };
 
   /**

--- a/packages/core/test/tracing/reactnavigation.test.ts
+++ b/packages/core/test/tracing/reactnavigation.test.ts
@@ -2007,6 +2007,45 @@ describe('ReactNavigationInstrumentation', () => {
       expect(traceData[SEMANTIC_ATTRIBUTE_ROUTE_NAME]).toBe('/posts/[...slug]');
       expect(traceData[SEMANTIC_ATTRIBUTE_PREVIOUS_ROUTE_NAME]).toBe('/profile/[id]');
     });
+
+    // Regression test for #6436. React Navigation's BaseNavigationContainer
+    // fires `emit('state')` synchronously BEFORE the `onStateChange` prop
+    // callback, and Expo Router refreshes its router-store cache from that
+    // prop. Reading the override synchronously in the `state` listener would
+    // return the previous route for the current transition. The integration
+    // must defer the read until after the synchronous state-change chain has
+    // unwound.
+    it('reads the route override after the synchronous state-change chain (Expo Router ordering)', async () => {
+      const rNavigation = setupWithOverride();
+      jest.runOnlyPendingTimers();
+
+      // First navigation: settle on '/A' so the provider has a "previous" value.
+      let latestOverride: { templatedPath: string; params?: Record<string, unknown> } = {
+        templatedPath: '/A',
+      };
+      rNavigation._setRouteOverrideProvider(() => latestOverride);
+
+      mockNavigation.navigateToDynamicRoute();
+      jest.runOnlyPendingTimers();
+      await client.flush();
+
+      // Second navigation: simulate the Expo Router ordering. When the `state`
+      // event fires the override provider still returns '/A' (Expo Router has
+      // not yet run its own `onStateChange` prop callback). Flip the provider
+      // to '/B' AFTER `navigateToCatchAllRoute()` returns but BEFORE the
+      // pending microtask flushes — this mimics `onStateChange` refreshing
+      // the store cache right after `emit('state')` returns.
+      mockNavigation.navigateToCatchAllRoute();
+      latestOverride = { templatedPath: '/B' };
+      jest.runOnlyPendingTimers();
+      await client.flush();
+
+      const traceData = client.event?.contexts?.trace?.data as Record<string, unknown>;
+      expect(client.event?.transaction).toBe('/B');
+      expect(traceData[SEMANTIC_ATTRIBUTE_ROUTE_NAME]).toBe('/B');
+      expect(traceData['route.path']).toBe('/B');
+      expect(traceData[SEMANTIC_ATTRIBUTE_PREVIOUS_ROUTE_NAME]).toBe('/A');
+    });
   });
 
   describe('dispatch breadcrumbs', () => {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
`reactNavigationIntegration` subscribes to route changes via `navigationContainer.addListener('state', ...)`. In React Navigation's `BaseNavigationContainer`, on every state change these fire back-to-back in this order:

```js
emitter.emit({ type: 'state', data: { state } });   // → our listener
if (!isFirstMountRef.current && onStateChangeRef.current) {
  onStateChangeRef.current(hydratedState);          // → Expo Router refreshes its store here
}
```

Integrations like `expoRouterIntegration` supply a `RouteOverrideProvider` that reads Expo Router's `store.getRouteInfo()`, and that store is refreshed via the `onStateChange` prop — which runs *after* our listener. So we were reading the override for the previous route on every transition. Since `updateLatestNavigationSpanWithCurrentRoute` clears its span reference after one call, there was no second chance to correct it.

Fix: schedule the update as a microtask so the read happens after the synchronous state-change chain unwinds and downstream caches (Expo Router's store) have been refreshed.

## :bulb: Motivation and Context
Fixes #6436.

## :green_heart: How did you test it?
- Tests are added

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps