### PR TITLE
ci(dependabot): Group github/codeql-action/* bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,7 @@ updates:
     directory: '/'
     schedule:
       interval: weekly
+    groups:
+      codeql-action:
+        patterns:
+          - 'github/codeql-action/*'


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [x] Enhancement

## :scroll: Description
Adds a Dependabot group for `github/codeql-action/*` so `init`, `autobuild`, and `analyze` are bumped together in a single PR.

## :bulb: Motivation and Context
The three CodeQL sub-actions share config and the same CodeQL bundle, so their pins must move in lockstep. Dependabot currently opens a separate PR per sub-action, which repeatedly leaves the workflow in a mismatched state — see #6410 (manual "bump init to match analyze/autobuild") and today's #6445 which only bumps `init` while `autobuild` lags at v4.36.3.

## :green_heart: How did you test it?
Config-only change. Verified by inspection against the Dependabot `groups` schema.

Once merged, comment `@dependabot recreate` on #6445 so it comes back as a grouped PR covering all three sub-actions.

## :pencil: Checklist
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] All tests passing.
- [x] No breaking changes.

## :crystal_ball: Next steps
Recreate #6445 as a grouped bump.

#skip-changelog