### PR TITLE
fix(ios): Restore ObjC SentrySwizzle for RNSScreen to link against xcframework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 > make sure you follow our [migration guide](https://docs.sentry.io/platforms/react-native/migration/) first.
 <!-- prettier-ignore-end -->
 
+## Unreleased
+
+### Fixes
+
+- Fix iOS link failure `Undefined symbols: SentryInternalSwizzleApi.Mode.oncePerClass` when consuming the default prebuilt `Sentry.xcframework` ([#6465](https://github.com/getsentry/sentry-react-native/issues/6465))
+
 ## 8.19.0
 
 ### Features

--- a/packages/core/ios/RNSentryInternal.swift
+++ b/packages/core/ios/RNSentryInternal.swift
@@ -182,52 +182,6 @@ import Foundation
     ) {}
     #endif
 
-    // MARK: - Swizzle
-
-    // `SentryInternalSwizzleApi` in sentry-cocoa has no platform gating.
-    // We enable the wrapper on every UIKit-capable platform (iOS/tvOS/visionOS
-    // — matching `SENTRY_UIKIT_AVAILABLE`, which is what `SENTRY_HAS_UIKIT`
-    // resolves to in the RNSentry.mm caller). `os(iOS)` in Swift already
-    // covers Mac Catalyst, so no separate `targetEnvironment(macCatalyst)` is
-    // needed.
-    #if os(iOS) || os(tvOS) || os(visionOS)
-    /// Stable identity for the `RNSScreen.viewDidAppear:` swizzle so the underlying
-    /// `oncePerClass` bookkeeping in sentry-cocoa can dedupe re-entries.
-    private static var rnsScreenViewDidAppearKey: UInt8 = 0
-
-    /// Swizzles `-[RNSScreen viewDidAppear:]`, invoking `hook` before the original
-    /// implementation on every call. No-op when RNSScreen is unavailable.
-    @_spi(Private) @objc public static func swizzleRNSScreenViewDidAppear(hook: @escaping () -> Void) {
-        guard let cls = NSClassFromString("RNSScreen") else { return }
-        let selector = NSSelectorFromString("viewDidAppear:")
-
-        // `withUnsafePointer(to:)` scopes the pointer's validity to the closure
-        // body. Perform the entire swizzle call inside so we never rely on the
-        // pointer surviving beyond the closure. The backing storage is a
-        // `static var`, so the address itself stays stable across calls —
-        // sentry-cocoa's `oncePerClass` bookkeeping continues to dedupe.
-        withUnsafePointer(to: &rnsScreenViewDidAppearKey) { keyPtr in
-            _ = SentrySDK.internal.swizzle.instanceMethod(
-                selector,
-                in: cls,
-                mode: .oncePerClass,
-                key: UnsafeRawPointer(keyPtr),
-                factory: { getOriginal in
-                    let block: @convention(block) (AnyObject, ObjCBool) -> Void = { receiver, animated in
-                        hook()
-                        typealias OriginalIMP = @convention(c) (AnyObject, Selector, ObjCBool) -> Void
-                        let original = unsafeBitCast(getOriginal(), to: OriginalIMP.self)
-                        original(receiver, selector, animated)
-                    }
-                    return block as AnyObject
-                }
-            )
-        }
-    }
-    #else
-    @_spi(Private) @objc public static func swizzleRNSScreenViewDidAppear(hook: @escaping () -> Void) {}
-    #endif
-
     // MARK: - Profiling
 
     #if !(os(watchOS) || os(tvOS) || os(visionOS))

--- a/packages/core/ios/RNSentryRNSScreen.m
+++ b/packages/core/ios/RNSentryRNSScreen.m
@@ -2,21 +2,41 @@
 
 #if SENTRY_HAS_UIKIT
 
-#    if __has_include(<RNSentry/RNSentry-Swift.h>)
-#        import <RNSentry/RNSentry-Swift.h>
-#    else
-#        import "RNSentry-Swift.h"
-#    endif
 #    import "RNSentryDependencyContainer.h"
 #    import "RNSentryFramesTrackerListener.h"
+// `SentrySwizzle.h` is a private header of `Sentry.framework`. We deliberately
+// keep using the ObjC swizzle API here instead of routing through
+// `SentrySDK.internal.swizzle` (the Swift `@_spi(Private)` equivalent):
+// the Swift SPI enum case `SentryInternalSwizzleApi.Mode.oncePerClass` is not
+// exported as a linkable symbol from sentry-cocoa's prebuilt static
+// xcframework, so consumers on the default (`SENTRY_USE_XCFRAMEWORK` unset)
+// path fail to link with `Undefined symbols: enum case for
+// SentryInternalSwizzleApi.Mode.oncePerClass`. The ObjC `SentrySwizzle`
+// class + `SentrySwizzleMode` enum have proper external symbols in the
+// xcframework slice, so this path links cleanly for both the xcframework
+// and source-built (`SENTRY_USE_XCFRAMEWORK=0`) configurations. See #6465.
+#    if __has_include(<Sentry/SentrySwizzle.h>)
+#        import <Sentry/SentrySwizzle.h>
+#    else
+#        import "SentrySwizzle.h"
+#    endif
 
 @implementation RNSentryRNSScreen
 
 + (void)swizzleViewDidAppear
 {
-    [RNSentryInternal swizzleRNSScreenViewDidAppearWithHook:^{
-        [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
-    }];
+    Class rnsscreenclass = NSClassFromString(@"RNSScreen");
+    if (rnsscreenclass == nil) {
+        return;
+    }
+
+    SEL selector = NSSelectorFromString(@"viewDidAppear:");
+    SentrySwizzleInstanceMethod(rnsscreenclass, selector, SentrySWReturnType(void),
+        SentrySWArguments(BOOL animated), SentrySWReplacement({
+            [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
+            SentrySWCallOriginal(animated);
+        }),
+        SentrySwizzleModeOncePerClass, (void *)selector);
 }
 
 @end


### PR DESCRIPTION
## 📢 Type of change

- [X] Bugfix

## 📜 Description

Restore the `SentrySwizzle` ObjC path for the `RNSScreen viewDidAppear:` swizzle. The Swift `SentrySDK.internal.swizzle` API introduced in getsentry/sentry-react-native#6380 references `SentryInternalSwizzleApi.Mode.oncePerClass`, an `@_spi(Private)` enum case whose metadata symbol is not exported from sentry-cocoa's prebuilt static xcframework — compile succeeds via `.private.swiftinterface`, but link fails on arm64.

The ObjC `SentrySwizzle` class + `SentrySwizzleMode` enum export normally (`_OBJC_CLASS_$_SentrySwizzle` verified in the arm64 slice), so this call site links cleanly for both the xcframework default and the source-built `SENTRY_USE_XCFRAMEWORK=0` fallback. The rest of the `SentrySDK.internal` migration in getsentry/sentry-react-native#6380 keeps using the Swift bridge.

## 💡 Motivation and Context

Fixes getsentry/sentry-react-native#6465.

## 💚 How did you test it?

## :pencil: Checklist

- [ ] I added tests to verify changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [ ] All tests passing.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] No breaking changes.

## 🔮 Next steps