### PR TITLE
chore(ios): Bump iOS binary size limit to 1650 KiB

### DIFF
--- a/performance-tests/metrics-ios.yml
+++ b/performance-tests/metrics-ios.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 600 KiB
-  diffMax: 1600 KiB
+  diffMax: 1650 KiB


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Bump the iOS binary size overhead limit (`binarySizeTest.diffMax`) in `performance-tests/metrics-ios.yml` from `1600 KiB` to `1650 KiB`.


## :bulb: Motivation and Context
The `metrics (legacy, ios)` job has been failing on `main` since #6380 ("refactor(ios): Migrate from PrivateSentrySDKOnly to SentrySDK.internal") merged, which pushed the measured SDK binary overhead over the existing `1600 KiB` cap:

```
BinarySizeTest > app size() FAILED
    java.lang.AssertionError: 1649579 should be < 1638400
```

The migration to the `SentrySDK.internal` API is an expected, legitimate size increase — not a regression. The threshold simply needs re-baselining, and the bump should ideally have ridden along in #6380. The current measured size is ~1,649,579 bytes (~1611 KiB); `1650 KiB` (= 1,689,600 bytes) restores a passing state with ~40 KiB of headroom for normal dependency creep while still catching large jumps.


## :green_heart: How did you test it?
Threshold-only change. The `metrics (legacy, ios)` CI job on this PR verifies the binary size is now under the limit.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
