### PR TITLE
chore(deps): bump js-yaml resolution to ^4.3.0 (dev-only advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@yarnpkg/parsers@npm:3.0.0-rc.46/js-yaml": "^3.15.0",
     "cosmiconfig@npm:5.2.1/js-yaml": "^3.15.0",
     "front-matter@npm:4.0.2/js-yaml": "^3.15.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "detox@npm:20.46.0/ajv": "^8.18.0",
     "@expo/fingerprint@npm:0.6.1/minimatch": "^3.1.3",
     "@lerna/create@npm:8.1.8/minimatch": "^3.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20447,14 +20447,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Bumps the `js-yaml` resolution from `^4.2.0` to `^4.3.0`, resolving `js-yaml` to `4.3.0` in the lockfile.

This addresses **GHSA / high-severity advisory**: _"YAML merge-key chains can force quadratic CPU consumption"_ (affects `js-yaml >=4.0.0 <4.3.0`). The vulnerable copy (`4.2.0`) was pulled transitively via `lerna@8.1.8`.

## :bulb: Motivation and Context
Dependabot flagged this transitive advisory. The affected package is **dev/build tooling only** (`lerna`, used for releases) — it is **not** part of the shipped `@sentry/react-native` runtime, whose production dependency tree audits clean. This is a defensive bump to keep the dev toolchain free of known advisories.

## :green_heart: How did you test it?
- `yarn install --immutable` passes (lockfile in sync).
- `yarn npm audit --recursive` no longer reports the `js-yaml` advisory.
- CI (build, test, lint, integrity, codegen) runs on this PR.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
Companion PRs bump the other easy dev-only transitive advisories (`brace-expansion`, `cross-spawn`, `glob`). The remaining `sigstore` / `@octokit/*` / `uuid` advisories are bundled deep in `lerna` and are best handled by a separate lerna upgrade.
