### PR TITLE
chore(deps): add cross-spawn ^7.0.6 resolution (dev-only advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.10",
     "postcss": "^8.5.10",
     "socks": "^2.8.8",
+    "cross-spawn": "^7.0.6",
     "@appium/support@npm:7.0.6/uuid": "^13.0.1",
     "node-simctl@npm:8.1.6/uuid": "^13.0.1",
     "shell-quote": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14400,17 +14400,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
-  dependencies:
-    path-key: "npm:^3.1.0"
-    shebang-command: "npm:^2.0.0"
-    which: "npm:^2.0.1"
-  checksum: 10c0/5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Adds a `cross-spawn: ^7.0.6` resolution, forcing the single `cross-spawn` 7.x copy in the tree to `7.0.6`.

This addresses **GHSA / high-severity advisory**: _"Regular Expression Denial of Service (ReDoS) in cross-spawn"_ (affects `cross-spawn >=7.0.0 <7.0.5`). The vulnerable copy (`7.0.3`) was pulled transitively via `npm-run-all2@6.2.2`. Only 7.x descriptors exist in the tree, so the global resolution is safe.

## :bulb: Motivation and Context
Dependabot flagged this transitive advisory. The affected package is **dev/build tooling only** (`npm-run-all2`, used to run dev scripts) — it is **not** part of the shipped `@sentry/react-native` runtime, whose production dependency tree audits clean.

## :green_heart: How did you test it?
- `yarn install --immutable` passes (lockfile in sync).
- `yarn npm audit --recursive` no longer reports the `cross-spawn` advisory (tree collapses to a single `cross-spawn@7.0.6`).
- CI (build, test, lint, integrity, codegen) runs on this PR.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
Companion PRs bump the other easy dev-only transitive advisories (`js-yaml`, `brace-expansion`, `glob`). The remaining `sigstore` / `@octokit/*` / `uuid` advisories are bundled deep in `lerna` and are best handled by a separate lerna upgrade.
