### PR TITLE
docs: Fix stale pod-install script names in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,13 @@ Recommended is to open the native project in `samples/react-native/android` and 
 For android switch `newArchEnabled` to `false` in [android/gradle.properties](https://github.com/getsentry/sentry-react-native/blob/c95aa21497ca93aaaaf0b44d170dc39dc7bcf660/sample-new-architecture/android/gradle.properties#L40). For iOS explicitly disable fabric in `samples/react-native/ios/Podfile` by setting `:fabric_enabled => false` before `pod install`.
 
 ```sh
-yarn pod-install-legacy
+yarn pod-install-debug-static-legacy
 yarn react-native run-ios
 
 yarn react-native run-android
 
 # Release builds
-yarn pod-install-legacy-production
+yarn pod-install-release-static-legacy
 yarn react-native run-ios --mode=Release
 
 yarn react-native run-android --mode=release
@@ -96,17 +96,19 @@ yarn react-native run-android --mode=release
 
 ### Run the emulators (new-architecture):
 ```sh
-yarn pod-install
+yarn pod-install-debug-static
 yarn react-native run-ios
 
 yarn react-native run-android
 
 # Release builds
-yarn pod-install-production
+yarn pod-install-release-static
 yarn react-native run-ios --mode=Release
 
 yarn react-native run-android --mode=Release
 ```
+
+The `pod-install-*` scripts follow the pattern `pod-install-{debug,release}-{static,dynamic}[-legacy]` (dynamic variants build with frameworks as dynamic libraries). Since [#6413](https://github.com/getsentry/sentry-react-native/pull/6413), `pod install` downloads a prebuilt `Sentry.xcframework` from sentry-cocoa's GitHub release and vendors it, instead of building Sentry from source. Set `SENTRY_USE_XCFRAMEWORK=0` before `pod install` to restore the previous source-build behavior (e.g. for offline builds).
 
 ## Running the macOS sample
 


### PR DESCRIPTION
## :loudspeaker: Type of change

- [x] Enhancement

## :scroll: Description

The `yarn pod-install*` commands in `CONTRIBUTING.md`'s two "Run the emulators" sections no longer exist in `samples/react-native/package.json`. The scripts were renamed some time ago to the `pod-install-{debug,release}-{static,dynamic}[-legacy]` pattern (8 variants). This updates the docs to the current names:

| Old (docs) | New |
|---|---|
| `yarn pod-install` | `yarn pod-install-debug-static` |
| `yarn pod-install-production` | `yarn pod-install-release-static` |
| `yarn pod-install-legacy` | `yarn pod-install-debug-static-legacy` |
| `yarn pod-install-legacy-production` | `yarn pod-install-release-static-legacy` |

Also adds a short note describing the naming pattern and the [#6413](https://github.com/getsentry/sentry-react-native/pull/6413) change (`pod install` now vendors a prebuilt `Sentry.xcframework` by default; `SENTRY_USE_XCFRAMEWORK=0` restores the source build).

## :bulb: Motivation and Context

Updates to match the changes in #6413

## :green_heart: How did you test it?

Manual

## :pencil: Checklist

- [x] I updated the docs if needed.
- [x] No breaking changes.

## :crystal_ball: Next steps
