### PR TITLE
ci(e2e): remove obsolete CocoaPods sample build job

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -43,7 +43,7 @@ jobs:
       caller_ref: ${{ github.ref }}
 
   build-ios:
-    name: Build ${{ matrix.rn-architecture }} ios ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }} ${{ matrix.sentry-consumption }}
+    name: Build ${{ matrix.rn-architecture }} ios ${{ matrix.build-type }} ${{ matrix.ios-use-frameworks }}
     runs-on: macos-26-xlarge
     needs: [diff_check, detect-changes]
     if: >-
@@ -60,13 +60,11 @@ jobs:
         rn-architecture: ["new"]
         ios-use-frameworks: ["no-frameworks"]
         build-type: ["dev", "production"]
-        sentry-consumption: ["xcframework"]
-        # `xcframework` is the only supported mode: RNSentry vendors a prebuilt
-        # `Sentry.xcframework` downloaded from sentry-cocoa's release.
-        # There is no CocoaPods job because the source-build fallback
-        # (`SENTRY_USE_XCFRAMEWORK=0`) is gone — sentry-cocoa stopped
-        # publishing to the CocoaPods trunk in 9.20.0, so the podspec raises
-        # when that opt-out is set.
+        # RNSentry vendors a prebuilt `Sentry.xcframework` downloaded from
+        # sentry-cocoa's release. sentry-cocoa dropped CocoaPods (trunk)
+        # support in 9.20.0, so the source-build fallback
+        # (`SENTRY_USE_XCFRAMEWORK=0`) can no longer resolve newer versions
+        # and is not exercised here.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -119,10 +117,7 @@ jobs:
           ./scripts/build-ios.sh
 
       - name: Archive iOS App
-        # Only upload from the xcframework job (the default consumption path)
-        # to avoid duplicate artifact names when the CocoaPods regression job
-        # runs.
-        if: ${{ matrix.rn-architecture == 'new' && matrix.build-type == 'production' && matrix.ios-use-frameworks == 'no-frameworks' && matrix.sentry-consumption == 'xcframework' }}
+        if: ${{ matrix.rn-architecture == 'new' && matrix.build-type == 'production' && matrix.ios-use-frameworks == 'no-frameworks' }}
         working-directory: ${{ env.REACT_NATIVE_SAMPLE_PATH }}
         run: |
           zip -r \
@@ -130,7 +125,7 @@ jobs:
             sentryreactnativesample.app
 
       - name: Upload iOS APP
-        if: ${{ matrix.rn-architecture == 'new' && matrix.build-type == 'production' && matrix.ios-use-frameworks == 'no-frameworks' && matrix.sentry-consumption == 'xcframework' }}
+        if: ${{ matrix.rn-architecture == 'new' && matrix.build-type == 'production' && matrix.ios-use-frameworks == 'no-frameworks' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sample-rn-${{ matrix.rn-architecture }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-ios
@@ -141,7 +136,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: build-sample-${{ matrix.rn-architecture }}-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-${{ matrix.sentry-consumption }}-logs
+          name: build-sample-${{ matrix.rn-architecture }}-ios-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks}}-logs
           path: ${{ env.REACT_NATIVE_SAMPLE_PATH }}/ios/*.log
 
   build-android:


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Removes the dedicated CocoaPods sample build job (`sentry-consumption: cocoapods`) from `sample-application.yml`, along with the now single-valued `sentry-consumption` matrix dimension and its references (job name, `SENTRY_USE_XCFRAMEWORK=0` export, archive/upload/log-artifact conditions and names).

Stacked on top of #6409 (Cocoa bump to 9.22.0).


## :bulb: Motivation and Context
sentry-cocoa dropped CocoaPods (trunk) support after `9.19.1` — `9.20.0`, `9.21.0`, and `9.22.0` are published only as GitHub Release xcframeworks and are **not** on the CocoaPods CDN.

The `cocoapods` job exports `SENTRY_USE_XCFRAMEWORK=0` to exercise the source-build fallback (`s.dependency 'Sentry', sentry_cocoa_version`), which resolves `Sentry` from trunk. On #6409 that job fails because `Sentry (= 9.22.0)` isn't on trunk:

```
None of your spec sources contain a spec satisfying the dependency: `Sentry (= 9.22.0)`.
```

The job only passed on `main` because `main` is still pinned to `9.19.1`. Since the fallback can no longer resolve any Cocoa version past `9.19.1`, the regression job is obsolete and blocks every future Cocoa bump.


## :green_heart: How did you test it?
- Validated the workflow YAML parses cleanly.
- CI on this PR runs the remaining xcframework iOS sample builds.


## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
- The `SENTRY_USE_XCFRAMEWORK=0` fallback path in `RNSentry.podspec` is now effectively dead for versions > 9.19.1. Consider removing it (and the deprecated `SENTRY_USE_SPM` alias) in a follow-up, unless we intend to keep it for offline/proxy builds pinned to old Cocoa versions.
- Merge #6409 first; this PR should be retargeted to `main` once its base lands.
