### PR TITLE
fix(core): Strip empty TurboModule sentinel tags in processEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Strip empty `turbo_module.name` / `turbo_module.method` tags in `turboModuleContextIntegration` so events captured outside an active TurboModule call no longer carry an ingestion "Processing Error" ([#6502](https://github.com/getsentry/sentry-react-native/issues/6502))
+- Strip empty `turbo_module.name` / `turbo_module.method` tags in `turboModuleContextIntegration` so events captured outside an active TurboModule call no longer carry an ingestion "Processing Error" ([#6506](https://github.com/getsentry/sentry-react-native/pull/6506))
 
 - Make `copySentryJsonConfiguration` and the `*_SentryUpload` Gradle tasks compatible with the Gradle Configuration Cache ([#6469](https://github.com/getsentry/sentry-react-native/pull/6469))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixes
 
+- Strip empty `turbo_module.name` / `turbo_module.method` tags in `turboModuleContextIntegration` so events captured outside an active TurboModule call no longer carry an ingestion "Processing Error" ([#6502](https://github.com/getsentry/sentry-react-native/issues/6502))
+
 - Make `copySentryJsonConfiguration` and the `*_SentryUpload` Gradle tasks compatible with the Gradle Configuration Cache ([#6469](https://github.com/getsentry/sentry-react-native/pull/6469))
 
   These tasks previously read `project` state at execution time — `onlyIf` predicates resolving closures from `project.extra`, plus `project.rootDir`, `project.copy`, `project.logger`, and `Project.file` inside task actions — which fails the build with `Could not evaluate onlyIf predicate` when `org.gradle.configuration-cache=true` (Gradle 9 defaults to recommending it). Environment reads are now captured at configuration time, file copies use an injected `FileSystemOperations`, and task actions use the task's own `logger`. No behaviour change. Interim step ahead of the full SAGP migration (getsentry/sentry-android-gradle-plugin#796).

--- a/packages/core/src/js/integrations/turboModuleContext.ts
+++ b/packages/core/src/js/integrations/turboModuleContext.ts
@@ -190,6 +190,11 @@ export const turboModuleContextIntegration = (options: TurboModuleContextOptions
       });
     },
     processEvent(event: Event): Event {
+      // Drop the empty-string sentinel tags written by `clearScope` when no
+      // TurboModule call is active. Sentry ingestion rejects empty tag values
+      // and flags the event with a Processing Error. See #6502.
+      stripEmptySentinelTags(event);
+
       if (!enableAggregate || event.type !== 'transaction') {
         return event;
       }
@@ -201,6 +206,19 @@ export const turboModuleContextIntegration = (options: TurboModuleContextOptions
     },
   };
 };
+
+function stripEmptySentinelTags(event: Event): void {
+  const tags = event.tags;
+  if (!tags) {
+    return;
+  }
+  if (tags['turbo_module.name'] === '') {
+    delete tags['turbo_module.name'];
+  }
+  if (tags['turbo_module.method'] === '') {
+    delete tags['turbo_module.method'];
+  }
+}
 
 /**
  * Mutates a transaction event in place to add the aggregate breakdown as a

--- a/packages/core/test/integrations/turboModuleContext.test.ts
+++ b/packages/core/test/integrations/turboModuleContext.test.ts
@@ -1,4 +1,4 @@
-import type { Client, TransactionEvent } from '@sentry/core';
+import type { Client, Event, TransactionEvent } from '@sentry/core';
 
 import { Scope } from '@sentry/core';
 import * as SentryCore from '@sentry/core';
@@ -141,6 +141,57 @@ describe('turboModuleContextIntegration', () => {
     jest.spyOn(wrapper, 'getRNSentryModule').mockReturnValue(undefined);
 
     expect(() => turboModuleContextIntegration().setupOnce!()).not.toThrow();
+  });
+
+  describe('empty-sentinel tag stripping', () => {
+    beforeEach(() => {
+      jest.spyOn(wrapper, 'getRNSentryModule').mockReturnValue(undefined);
+    });
+
+    it('strips empty turbo_module.name / turbo_module.method tags on any event', () => {
+      const integration = turboModuleContextIntegration({ enableAggregateStats: false });
+      integration.setupOnce?.();
+      integration.setup?.(makeMockClient());
+
+      const event: Event = {
+        tags: {
+          'turbo_module.name': '',
+          'turbo_module.method': '',
+          other: 'kept',
+        },
+      };
+      const out = integration.processEvent?.(event, {}, makeMockClient()) as Event;
+
+      expect(out.tags).toEqual({ other: 'kept' });
+    });
+
+    it('keeps non-empty turbo_module.* tag values untouched', () => {
+      const integration = turboModuleContextIntegration({ enableAggregateStats: false });
+      integration.setupOnce?.();
+      integration.setup?.(makeMockClient());
+
+      const event: Event = {
+        tags: {
+          'turbo_module.name': 'RNSentry',
+          'turbo_module.method': 'captureEnvelope',
+        },
+      };
+      const out = integration.processEvent?.(event, {}, makeMockClient()) as Event;
+
+      expect(out.tags).toEqual({
+        'turbo_module.name': 'RNSentry',
+        'turbo_module.method': 'captureEnvelope',
+      });
+    });
+
+    it('handles events without a tags object', () => {
+      const integration = turboModuleContextIntegration({ enableAggregateStats: false });
+      integration.setupOnce?.();
+      integration.setup?.(makeMockClient());
+
+      const event: Event = {};
+      expect(() => integration.processEvent?.(event, {}, makeMockClient())).not.toThrow();
+    });
   });
 
   describe('aggregate stats', () => {


### PR DESCRIPTION
## 📢 Type of change

- [X] Bugfix

## 📜 Description

`turboModuleContextIntegration.processEvent` now drops `turbo_module.name` / `turbo_module.method` tags when they hold the empty-string sentinel written by `clearScope` (no active TurboModule call). Real values are preserved as before, and `contexts.turbo_module` is unaffected.

## 💡 Motivation and Context

Fixes getsentry/sentry-react-native#6502. Sentry ingestion rejects empty tag values, so every event captured outside an active TurboModule call was flagged with a "Processing Error" (`tags.N.1 — expected a non-empty value`). Since most captures happen outside a call, effectively every JS-captured event was affected.

Fix applied per the reporter's suggestion — same integration, same `processEvent`, minimal surface.

Known limitation (out of scope): native fatal-crash events skip JS `processEvent`, so a crash outside a TurboModule call can still carry the empty tags. A complete fix needs `sentry-cocoa`/`sentry-java` to drop empty tag values on their end.

## 💚 How did you test it?

* Added three unit tests (`packages/core/test/integrations/turboModuleContext.test.ts`) covering strip / keep-real-values / no-tags cases.
* `yarn jest` — all 53 turbomodule + integration tests pass.
* `yarn build:sdk`, `yarn lint`, `yarn circularDepCheck`, `api-report:check` — all clean.

## :pencil: Checklist

- [X] I added tests to verify changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [X] All tests passing.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] No breaking changes.

## 🔮 Next steps