### PR TITLE
ci: Disable yarn age gate when bumping first-party @sentry deps

### DIFF
--- a/scripts/update-package-json.sh
+++ b/scripts/update-package-json.sh
@@ -27,17 +27,25 @@ set-version)
     if [[ "$version" == "$tagPrefix"* ]]; then
         version="${version:${#tagPrefix}}"
     fi
+    # Only first-party @sentry/* packages are safe to adopt immediately (see below).
+    allFirstParty=true
     for i in ${!packages[@]}; do
         list+="${packages[$i]}@$version "
+        if [[ "${packages[$i]}" != @sentry/* ]]; then
+            allFirstParty=false
+        fi
     done
     (
         cd "${monorepoRoot}"
-        # These are all first-party @sentry/* packages and the updater's job is to
-        # adopt the just-published version immediately. Yarn 4's npmMinimalAgeGate
-        # (default 1 day, auto-enabled on CI) quarantines a fresh release and fails
-        # `yarn up`. There's no supply-chain risk for our own packages, so disable
-        # the gate for this single command.
-        YARN_NPM_MINIMAL_AGE_GATE=0 yarn up $list
+        # The updater's job is to adopt the just-published version immediately, but
+        # Yarn 4's npmMinimalAgeGate (default 1 day, auto-enabled on CI) quarantines a
+        # fresh release and fails `yarn up`. For first-party @sentry/* packages there's
+        # no supply-chain risk, so disable the gate. Third-party packages (e.g.
+        # react-native via update-rn.sh) keep the gate.
+        if [[ "$allFirstParty" == true ]]; then
+            export YARN_NPM_MINIMAL_AGE_GATE=0
+        fi
+        yarn up $list
     )
     ;;
 *)

--- a/scripts/update-package-json.sh
+++ b/scripts/update-package-json.sh
@@ -32,7 +32,12 @@ set-version)
     done
     (
         cd "${monorepoRoot}"
-        yarn up $list
+        # These are all first-party @sentry/* packages and the updater's job is to
+        # adopt the just-published version immediately. Yarn 4's npmMinimalAgeGate
+        # (default 1 day, auto-enabled on CI) quarantines a fresh release and fails
+        # `yarn up`. There's no supply-chain risk for our own packages, so disable
+        # the gate for this single command.
+        YARN_NPM_MINIMAL_AGE_GATE=0 yarn up $list
     )
     ;;
 *)


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
The dependency updater's `set-version` step (`scripts/update-package-json.sh`, shared by the `javascript`, `cli`, `wizard`, and `bundler-plugins` jobs in `update-deps.yml`) runs `yarn up` on the just-published `@sentry/*` version.

Yarn 4's `npmMinimalAgeGate` (default 1 day, auto-enabled on CI) quarantines any version younger than the threshold and fails the install:

```
@sentry/core@npm:10.68.0: All versions satisfying "10.68.0" are quarantined
```

This makes the updater fail every time it tries to adopt a freshly published release. This PR sets `YARN_NPM_MINIMAL_AGE_GATE=0` for that single `yarn up` command so the gate is disabled only while upgrading first-party packages.

## :bulb: Motivation and Context
The age gate is a supply-chain safeguard against a malicious version being published and quickly yanked. Every package these updaters touch is first-party `@sentry/*` from trusted Sentry repos, so there's no such risk here — and the entire purpose of the updater is to pick up the new version immediately rather than waiting a day for the next cron run.

This matches existing precedent in the repo, where the same gate is already disabled for the same "just-published SDK" reason:
- `dev-packages/type-check/run-type-check.sh`
- `packages/core/dev-packages/e2e-tests/cli.mjs`

The change is scoped inline to the single command, so the gate remains in effect everywhere else.

Failing run: https://github.com/getsentry/sentry-react-native/actions/runs/30092846605/job/89479814118

## :green_heart: How did you test it?
CI-only change to the updater script. Verified the env var is scoped to the single `yarn up` invocation and only ever applies to first-party `@sentry/*` packages.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)