### PR TITLE
feat(core): Export instrumentStateGraph and deprecate instrumentLangGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Export `instrumentStateGraph` for manual LangGraph instrumentation ([#PR_NUMBER](https://github.com/getsentry/sentry-react-native/pull/PR_NUMBER))
+- Export `instrumentStateGraph` for manual LangGraph instrumentation ([#6520](https://github.com/getsentry/sentry-react-native/pull/6520))
 
   `instrumentLangGraph` was renamed to `instrumentStateGraph` in the JavaScript SDK and is now deprecated. It remains exported for backwards compatibility and will be removed in the next major version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,10 @@
 
 ## Unreleased
 
-### Features
+### Changes
 
-- Export `instrumentStateGraph` for manual LangGraph instrumentation ([#6520](https://github.com/getsentry/sentry-react-native/pull/6520))
-
-  `instrumentLangGraph` was renamed to `instrumentStateGraph` in the JavaScript SDK and is now deprecated. It remains exported for backwards compatibility and will be removed in the next major version.
-
-  ```js
-  import * as Sentry from '@sentry/react-native';
-
-  const graph = Sentry.instrumentStateGraph(new StateGraph(...));
-  ```
+- Expose `instrumentStateGraph` for manual LangGraph instrumentation ([#6520](https://github.com/getsentry/sentry-react-native/pull/6520))
+  - `instrumentLangGraph` was renamed to `instrumentStateGraph` in the JavaScript SDK and is now deprecated. It stays exported for backwards compatibility and will be removed in the next major version.
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 
 ## Unreleased
 
+### Features
+
+- Export `instrumentStateGraph` for manual LangGraph instrumentation ([#PR_NUMBER](https://github.com/getsentry/sentry-react-native/pull/PR_NUMBER))
+
+  `instrumentLangGraph` was renamed to `instrumentStateGraph` in the JavaScript SDK and is now deprecated. It remains exported for backwards compatibility and will be removed in the next major version.
+
+  ```js
+  import * as Sentry from '@sentry/react-native';
+
+  const graph = Sentry.instrumentStateGraph(new StateGraph(...));
+  ```
+
 ### Internal
 
 - Migrate from `@sentry/babel-plugin-component-annotate` to `@sentry/bundler-plugins/babel-plugin` ([#6501](https://github.com/getsentry/sentry-react-native/pull/6501))

--- a/packages/core/etc/sentry-react-native.api.md
+++ b/packages/core/etc/sentry-react-native.api.md
@@ -59,6 +59,7 @@ import { InstrumentedMethod } from '@sentry/core';
 import { instrumentGoogleGenAIClient } from '@sentry/core';
 import { instrumentLangGraph } from '@sentry/core';
 import { instrumentOpenAiClient } from '@sentry/core';
+import { instrumentStateGraph } from '@sentry/core';
 import { instrumentStateGraphCompile } from '@sentry/core';
 import { Integration } from '@sentry/core';
 import { LangChainIntegration } from '@sentry/core';
@@ -464,6 +465,8 @@ export { instrumentGoogleGenAIClient }
 export { instrumentLangGraph }
 
 export { instrumentOpenAiClient }
+
+export { instrumentStateGraph }
 
 export { instrumentStateGraphCompile }
 

--- a/packages/core/src/js/index.ts
+++ b/packages/core/src/js/index.ts
@@ -54,10 +54,13 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   createLangChainCallbackHandler,
-  instrumentLangGraph,
+  instrumentStateGraph,
   instrumentStateGraphCompile,
   addConsoleInstrumentationFilter,
 } from '@sentry/core';
+
+/** @deprecated Use `instrumentStateGraph` instead. `instrumentLangGraph` will be removed in a future major version. */
+export { instrumentLangGraph } from '@sentry/core';
 
 export type {
   OpenAiClient,

--- a/packages/core/test/aiExports.test.ts
+++ b/packages/core/test/aiExports.test.ts
@@ -6,9 +6,14 @@ describe('AI SDK manual instrumentation re-exports', () => {
     'instrumentAnthropicAiClient',
     'instrumentGoogleGenAIClient',
     'createLangChainCallbackHandler',
+    'instrumentStateGraph',
     'instrumentLangGraph',
     'instrumentStateGraphCompile',
   ])('re-exports %s from @sentry/core', name => {
     expect(typeof (Sentry as Record<string, unknown>)[name]).toBe('function');
+  });
+
+  test('deprecated instrumentLangGraph is an alias of instrumentStateGraph', () => {
+    expect(Sentry.instrumentLangGraph).toBe(Sentry.instrumentStateGraph);
   });
 });


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description

Follow-up to #6516 (JavaScript SDK bump to v10.68.0).

- Re-export `instrumentStateGraph` from `@sentry/core`.
- Keep re-exporting `instrumentLangGraph` and mark it `@deprecated` so consumers get IDE strikethrough and a migration hint. The JSDoc tag is preserved in both the emitted `dist` types and the downleveled `ts3.8` types.
- Regenerate the API report (`etc/sentry-react-native.api.md`).
- Changelog entry filed under `### Changes` (matching the `featureFlagsIntegration` / `logger` re-export precedent), not `### Features`.
- Extend `test/aiExports.test.ts` to cover the new export and assert the deprecated name is the same function reference.

No behavior change — `instrumentLangGraph` is an alias of `instrumentStateGraph` upstream, so existing code keeps working unchanged.


## :bulb: Motivation and Context

sentry-javascript v10.68.0 ([#22491](https://github.com/getsentry/sentry-javascript/pull/22491)) renamed `instrumentLangGraph` to `instrumentStateGraph` and deprecated the old name:

```ts
export declare function instrumentStateGraph<T extends ...>
/** @deprecated This function was renamed and will be removed in a future major version.
 *  Use `instrumentStateGraph` instead. */
export declare const instrumentLangGraph: typeof instrumentStateGraph;
```

The RN SDK only re-exported the deprecated name, so React Native users had no way to reach the new API and got no deprecation signal. This aligns the RN public surface with the upstream JavaScript SDK ahead of the next major, where the alias will be dropped.


## :green_heart: How did you test it?

Run locally on this branch:

- `yarn test` — 1718 tests / 127 suites passing, including the extended `test/aiExports.test.ts`.
- `yarn lint:lerna` — 0 errors (1 pre-existing unrelated warning in a sample).
- `yarn circularDepCheck` — no circular dependencies.
- `cd packages/core && yarn api-report:check` — API report up to date.
- Verified the `@deprecated` tag survives into `packages/core/dist/js/index.d.ts` and `packages/core/ts3.8/dist/js/index.d.ts`.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

- Remove the `instrumentLangGraph` alias in the next major version.
- Consider also re-exporting `instrumentCreateReactAgent` and `instrumentLangChainEmbeddings`, which are available in the browser build but not currently surfaced by the RN SDK (pre-existing gap, not introduced by v10.68.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
