### PR TITLE
chore(deps): bump postcss to ^8.5.18 (dev-only advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@appium/support@npm:7.0.6/yauzl": "^3.2.1",
     "appium-ios-remotexpc@npm:0.36.0/@xmldom/xmldom": "^0.9.10",
     "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.10",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "socks": "^2.8.8",
     "cross-spawn": "^7.0.6",
     "@appium/support@npm:7.0.6/uuid": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23558,6 +23558,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -25612,14 +25621,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.10":
-  version: 8.5.12
-  resolution: "postcss@npm:8.5.12"
+"postcss@npm:^8.5.18":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
+  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Bumps the `postcss` resolution from `^8.5.10` to `^8.5.18` (resolves to `8.5.23`).

Resolves [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — _PostCSS: Path Traversal in Previous Source Map Auto-Loading (`sourceMappingURL`) leads to Arbitrary `.map` File Disclosure_ (High, affects `<=8.5.17`, patched `8.5.18`).

## :bulb: Motivation and Context
Dependabot alert. `postcss` is **dev/build tooling only** — pulled via `@expo/metro-config` and `detective-postcss`. It is **not** part of the shipped `@sentry/react-native` runtime, whose production dependency tree audits clean.

## :green_heart: How did you test it?
- `yarn install --immutable` passes (lockfile in sync).
- `postcss` now resolves to `8.5.23` (> the `<=8.5.17` vulnerable ceiling).
- CI (build, test, lint, integrity, codegen) runs on this PR.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
