### PR TITLE
chore(deps): add morgan ^1.11.0 resolution (dev-only advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "appium-ios-simulator@npm:8.0.12/@xmldom/xmldom": "^0.9.10",
     "postcss": "^8.5.10",
     "socks": "^2.8.8",
+    "morgan": "^1.11.0",
     "cross-spawn": "^7.0.6",
     "@appium/support@npm:7.0.6/uuid": "^13.0.1",
     "node-simctl@npm:8.1.6/uuid": "^13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23437,16 +23437,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"morgan@npm:1.10.1":
-  version: 1.10.1
-  resolution: "morgan@npm:1.10.1"
+"morgan@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "morgan@npm:1.11.0"
   dependencies:
     basic-auth: "npm:~2.0.1"
     debug: "npm:2.6.9"
     depd: "npm:~2.0.0"
-    on-finished: "npm:~2.3.0"
+    on-finished: "npm:~2.4.1"
     on-headers: "npm:~1.1.0"
-  checksum: 10c0/2ecd68504d29151b516a6233839e4f27ae0312acc4dbcb1fe84ff9b5db0eb9b25f31258a931dcf689184b4858839572095fcc62eef3cbd7339287d59f1424346
+  checksum: 10c0/1d8c67bdeb34dc4112f5b6cbff0d5b4ef14bfdcb9f67a7ae67fc7a77282c18dd493a11dc8dff1ff2e285c1846947cfdc3698fdceb1fa7bea2a09fe6cb754455d
   languageName: node
   linkType: hard
 
@@ -24458,7 +24458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1, on-finished@npm:^2.4.1":
+"on-finished@npm:2.4.1, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Adds a `morgan: ^1.11.0` resolution, forcing the single `morgan` copy in the tree from `1.10.1` to `1.11.0`.

Resolves [GHSA-4vj7-5mj6-jm8m](https://github.com/advisories/GHSA-4vj7-5mj6-jm8m) — _morgan vulnerable to Log Forging via unneutralized control characters in `:remote-user`_ (Moderate, affects `>=1.2.0 <=1.10.1`, patched `1.11.0`).

## :bulb: Motivation and Context
Dependabot alert. `morgan` is **dev-only** — pulled via `@appium/base-driver` (E2E testing). It is **not** part of the shipped `@sentry/react-native` runtime, whose production dependency tree audits clean. Only a single 1.x copy exists in the tree, so the global resolution is safe.

## :green_heart: How did you test it?
- `yarn install --immutable` passes (lockfile in sync).
- `morgan` now resolves to `1.11.0` (the patched version).
- CI (build, test, lint, integrity, codegen) runs on this PR.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
