### PR TITLE
test(e2e): Assert TTID/TTFD spans share their navigation transaction's trace and parent span

### DIFF
--- a/samples/react-native/e2e/tests/captureSpaceflightNewsScreenTransaction/captureSpaceflightNewsScreenTransaction.test.ts
+++ b/samples/react-native/e2e/tests/captureSpaceflightNewsScreenTransaction/captureSpaceflightNewsScreenTransaction.test.ts
@@ -84,6 +84,36 @@ describe('Capture Spaceflight News Screen Transaction', () => {
       });
   });
 
+  it('ttid/ttfd spans share the same trace and parent span as their navigation transaction', async () => {
+    // Display spans must inherit the navigation transaction's `trace_id` (not
+    // get a random one) and reference its root span as their `parent_span_id`,
+    // otherwise they render as orphaned spans in the trace view.
+    const transaction = getFirstNewsEventItem()?.[1];
+    expect(transaction).toBeDefined();
+
+    const traceId = transaction?.contexts?.trace?.trace_id;
+    const rootSpanId = transaction?.contexts?.trace?.span_id;
+    expect(traceId).toEqual(expect.any(String));
+    expect(rootSpanId).toEqual(expect.any(String));
+
+    const ttidSpan = transaction?.spans?.find(
+      span => span.op === 'ui.load.initial_display',
+    );
+    const ttfdSpan = transaction?.spans?.find(
+      span => span.op === 'ui.load.full_display',
+    );
+
+    // A navigation transaction must at least carry the initial-display span.
+    expect(ttidSpan).toBeDefined();
+
+    [ttidSpan, ttfdSpan]
+      .filter((span): span is NonNullable<typeof span> => span !== undefined)
+      .forEach(span => {
+        expect(span.trace_id).toBe(traceId);
+        expect(span.parent_span_id).toBe(rootSpanId);
+      });
+  });
+
   function expectToContainTimeToDisplayMeasurements(
     item: EventItem | undefined,
   ) {


### PR DESCRIPTION
## 📢 Type of change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [X] Tests

## 📜 Description

Adds an end-to-end assertion to the existing `captureSpaceflightNewsScreenTransaction` e2e test verifying that the `ui.load.initial_display` and `ui.load.full_display` spans of a navigation transaction share the transaction's `trace_id` and reference its root span as their `parent_span_id`.

The e2e suite already asserts that navigation transactions carry `time_to_initial_display` / `time_to_full_display` measurements, but it did not assert that the underlying display spans are attached to the correct trace and parent span end-to-end.

## 💡 Motivation and Context

A previous defect caused TTID/TTFD spans to be minted with a random `trace_id` instead of inheriting the navigation transaction's, so they rendered as orphaned spans in the trace view. That defect is guarded at the unit layer, but there was no end-to-end check that the spans emitted in a real navigation envelope are correctly parented. This adds that guard against the on-device serialized transaction.

Closes getsentry/sentry-react-native#6529.

## 💚 How did you test it?

* Added assertion runs inside the existing `captureSpaceflightNewsScreenTransaction` Maestro e2e (iOS + Android, auto- and manual-init).
* Locally verified the file lints (`oxlint`) and type-checks.
* The on-device e2e run happens in CI behind the `ready-to-merge` label.

## :pencil: Checklist

- [X] I added tests to verify changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] All tests passing.
- [X] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](<https://develop.sentry.dev/>) spec.
- [X] No breaking changes.

## 🔮 Next steps

[https://github.com/getsentry/sentry-react-native/issues/6531](<https://github.com/getsentry/sentry-react-native/issues/6531>)