### PR TITLE
fix(ios): Re-land SentrySDK.internal migration, bump Cocoa SDK to 9.24.0

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -61,15 +61,12 @@ jobs:
         ios-use-frameworks: ["no-frameworks"]
         build-type: ["dev", "production"]
         sentry-consumption: ["xcframework"]
-        # `xcframework` is the default: RNSentry vendors a prebuilt
-        # `Sentry-Dynamic.xcframework` downloaded from sentry-cocoa's release.
-        # Keep a single CocoaPods job to catch regressions in the source-build
-        # fallback (`SENTRY_USE_XCFRAMEWORK=0`).
-        include:
-          - rn-architecture: "new"
-            ios-use-frameworks: "no-frameworks"
-            build-type: "production"
-            sentry-consumption: "cocoapods"
+        # `xcframework` is the only supported mode: RNSentry vendors a prebuilt
+        # `Sentry.xcframework` downloaded from sentry-cocoa's release.
+        # There is no CocoaPods job because the source-build fallback
+        # (`SENTRY_USE_XCFRAMEWORK=0`) is gone — sentry-cocoa stopped
+        # publishing to the CocoaPods trunk in 9.20.0, so the podspec raises
+        # when that opt-out is set.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -105,7 +102,6 @@ jobs:
           [[ "${{ matrix.build-type }}" == "production" ]] && export ENABLE_PROD=1 || export ENABLE_PROD=0
           [[ "${{ matrix.rn-architecture }}" == "new" ]] && export ENABLE_NEW_ARCH=1 || export ENABLE_NEW_ARCH=0
           [[ "${{ matrix.ios-use-frameworks }}" == "dynamic-frameworks" ]] && export USE_FRAMEWORKS=dynamic
-          [[ "${{ matrix.sentry-consumption }}" == "cocoapods" ]] && export SENTRY_USE_XCFRAMEWORK=0
 
           ./scripts/pod-install.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
 
 ## Unreleased
 
+### Changes
+
+- Migrate iOS internals from the deprecated `PrivateSentrySDKOnly` SPI to `SentrySDK.internal` ([#6541](https://github.com/getsentry/sentry-react-native/pull/6541))
+
+  Re-lands [#6380](https://github.com/getsentry/sentry-react-native/pull/6380), reverted in 8.20.0 by [#6491](https://github.com/getsentry/sentry-react-native/pull/6491) because it broke iOS screenshot capture. The underlying sentry-cocoa bug is fixed in 9.24.0.
+
+<!-- prettier-ignore-start -->
+> [!WARNING]
+> **Action required if you target React Native < 0.75.**
+> `RNSentry` now ships Swift code, which makes it a Swift pod under CocoaPods. If your `Podfile` doesn't already modularize React Native's ObjC pods (RN >= 0.75 does this by default), add `use_modular_headers!` to your `ios/Podfile` before running `pod install`. Otherwise `pod install` fails with an error like:
+> `The Swift pod 'RNSentry' depends upon 'React-hermes', which does not define modules.`
+<!-- prettier-ignore-end -->
+
 ### Fixes
 
 - Make the `RNSentry` SPEC CHECKSUM in `Podfile.lock` machine-independent ([#6534](https://github.com/getsentry/sentry-react-native/pull/6534))
@@ -35,14 +48,6 @@
 ### Fixes
 
 - `sentry-expo-upload-sourcemaps` now reads plugin config when the plugin is registered as `@sentry/react-native` ([#6543](https://github.com/getsentry/sentry-react-native/pull/6543))
-
-### Changes
-
-- Migrate iOS internals from the deprecated `PrivateSentrySDKOnly` SPI to `SentrySDK.internal` ([#6541](https://github.com/getsentry/sentry-react-native/pull/6541))
-
-  Re-lands [#6380](https://github.com/getsentry/sentry-react-native/pull/6380), which was reverted in 8.20.0 because it broke iOS screenshot capture ([#6497](https://github.com/getsentry/sentry-react-native/issues/6497)). The underlying sentry-cocoa bug is fixed in 9.24.0.
-
-  The `RNSentry` pod now contains Swift code. On React Native versions where RN pods are not modularized by default (e.g. RN 0.71), add `use_modular_headers!` to your `ios/Podfile`.
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,22 @@
 
 - `sentry-expo-upload-sourcemaps` now reads plugin config when the plugin is registered as `@sentry/react-native` ([#6543](https://github.com/getsentry/sentry-react-native/pull/6543))
 
+### Changes
+
+- Migrate iOS internals from the deprecated `PrivateSentrySDKOnly` SPI to `SentrySDK.internal` ([#6541](https://github.com/getsentry/sentry-react-native/pull/6541))
+
+  Re-lands [#6380](https://github.com/getsentry/sentry-react-native/pull/6380), which was reverted in 8.20.0 because it broke iOS screenshot capture ([#6497](https://github.com/getsentry/sentry-react-native/issues/6497)). The underlying sentry-cocoa bug is fixed in 9.24.0.
+
+  The `RNSentry` pod now contains Swift code. On React Native versions where RN pods are not modularized by default (e.g. RN 0.71), add `use_modular_headers!` to your `ios/Podfile`.
+
 ### Dependencies
 
 - Bump Android SDK from v8.50.1 to v8.51.0 ([#6539](https://github.com/getsentry/sentry-react-native/pull/6539))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#8510)
   - [diff](https://github.com/getsentry/sentry-java/compare/8.50.1...8.51.0)
+- Bump Cocoa SDK from v9.19.1 to v9.24.0 ([#6541](https://github.com/getsentry/sentry-react-native/pull/6541))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#9240)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/9.19.1...9.24.0)
 
 ## 8.21.0
 

--- a/dev-packages/e2e-tests/patch-scripts/rn.patch.podfile.js
+++ b/dev-packages/e2e-tests/patch-scripts/rn.patch.podfile.js
@@ -63,8 +63,27 @@ if (currentMatch) {
   debug.log('Warning: Could not find platform :ios line to patch');
 }
 
+// RNSentry now contains Swift code (via the RNSentryInternal bridge over
+// SentrySDK.internal). CocoaPods refuses to integrate a Swift pod against
+// non-modular ObjC dependencies (e.g. React-hermes on older RN versions),
+// so ensure the Podfile requests modular headers globally.
+let modularPatched = false;
+if (!content.includes('use_modular_headers!')) {
+  const patched = content.replace(
+    /prepare_react_native_project!\s*\n/,
+    'prepare_react_native_project!\nuse_modular_headers!\n',
+  );
+  if (patched !== content) {
+    content = patched;
+    modularPatched = true;
+    debug.log('Patching Podfile with use_modular_headers!');
+  } else {
+    debug.log('Warning: Could not find prepare_react_native_project! anchor to inject use_modular_headers!');
+  }
+}
+
 // Write the file if any changes were made
-if (shouldPatch || currentMatch) {
+if (shouldPatch || currentMatch || modularPatched) {
   fs.writeFileSync(args['pod-file'], content);
   debug.log('Podfile patched successfully!');
 } else {

--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -46,23 +46,15 @@ Pod::Spec.new do |s|
   # in `android/CMakeLists.txt`. The files are guarded with
   # `RCT_NEW_ARCH_ENABLED` so they compile to empty TUs on Old Arch.
   #
-  # We include `.swift` (for `RNSentrySwiftLinkStub.swift`) only on RN >=
-  # 0.75. Adding a Swift file makes CocoaPods treat RNSentry as a Swift
-  # pod, which then requires modular headers from its ObjC dependencies
-  # (React-Core, React-hermes) — RN < 0.75 doesn't emit those, so
-  # `pod install` fails with:
-  #   "The Swift pod `RNSentry` depends upon `React-hermes`, which does
-  #    not define modules."
-  # The stub is only needed when linking Sentry.xcframework's Swift
-  # symbols into a dynamic framework anyway (RN 0.86+ `use_frameworks!
-  # :dynamic`), so gating on RN 0.75 is safe.
-  supports_swift_stub = rn_version[:major] >= 1 || (rn_version[:major] == 0 && rn_version[:minor] >= 75)
-  if supports_swift_stub
-    s.source_files = 'ios/**/*.{h,m,mm,swift}', 'cpp/**/*.{h,cpp}'
-    s.swift_versions = ['5.5']
-  else
-    s.source_files = 'ios/**/*.{h,m,mm}', 'cpp/**/*.{h,cpp}'
-  end
+  # Swift is compiled unconditionally because `RNSentryInternal.swift` is
+  # the sole ObjC↔Swift bridge over `SentrySDK.internal.*` — every `.m`/
+  # `.mm` file in this pod calls into it. That makes RNSentry a Swift pod
+  # in CocoaPods' eyes, which in turn requires modular headers from its
+  # ObjC dependencies. Users on React Native < 0.75 (where `React-hermes`
+  # and friends aren't modularized by default) must add
+  # `use_modular_headers!` to their Podfile — see CHANGELOG.
+  s.source_files = 'ios/**/*.{h,m,mm,swift}', 'cpp/**/*.{h,cpp}'
+  s.swift_versions = ['5.5']
   s.public_header_files = 'ios/RNSentry.h', 'ios/RNSentrySDK.h', 'ios/RNSentryStart.h', 'ios/RNSentryVersion.h', 'ios/RNSentryBreadcrumb.h', 'ios/RNSentryReplay.h', 'ios/RNSentryReplayBreadcrumbConverter.h', 'ios/Replay/RNSentryReplayMask.h', 'ios/Replay/RNSentryReplayUnmask.h', 'ios/RNSentryTimeToDisplay.h'
 
   s.compiler_flags = other_cflags
@@ -71,7 +63,7 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES'
   }
 
-  sentry_cocoa_version = '9.19.1'
+  sentry_cocoa_version = '9.24.0'
 
   # Consume sentry-cocoa as a prebuilt `Sentry.xcframework` by default.
   #

--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -78,7 +78,13 @@ Pod::Spec.new do |s|
   # (`Signatures/*.signature` collision during archive).
   #
   # Set `SENTRY_USE_XCFRAMEWORK=0` to fall back to the source-built
-  # `Sentry` CocoaPod (e.g. for offline builds behind a restrictive proxy).
+  # `Sentry` CocoaPod. This fallback is unavailable for sentry-cocoa
+  # >= 9.20.0: upstream deleted `Sentry.podspec` and dropped the
+  # `cocoapods` publishing target in that release, so 9.19.1 is the last
+  # version on the CocoaPods trunk. Opting out therefore raises below
+  # with an explanation rather than letting CocoaPods fail with an
+  # opaque "None of your spec sources contain a spec satisfying the
+  # dependency: `Sentry (= x.y.z)`".
   #
   # `SENTRY_USE_SPM` was the name in earlier drafts of this PR; honor it as a
   # deprecated alias so CI or local envs still exporting `SENTRY_USE_SPM=0`
@@ -147,7 +153,18 @@ Pod::Spec.new do |s|
     pod_target_xcconfig.merge!(xcframework_search_paths)
     s.user_target_xcconfig = xcframework_search_paths
   else
-    s.dependency 'Sentry', sentry_cocoa_version
+    raise <<~MSG
+      [Sentry] SENTRY_USE_XCFRAMEWORK=0 is no longer supported.
+
+      sentry-cocoa stopped publishing to the CocoaPods trunk in 9.20.0
+      (`Sentry.podspec` was removed upstream), so `pod 'Sentry', '#{sentry_cocoa_version}'`
+      cannot resolve — 9.19.1 is the last version available there.
+
+      Unset SENTRY_USE_XCFRAMEWORK to use the prebuilt `Sentry.xcframework`.
+      For builds without network access to GitHub Releases, pre-populate the
+      cache on a machine that has access and point the build at it with
+      SENTRY_XCFRAMEWORK_CACHE_DIR.
+    MSG
   end
 
   # Assign before `install_modules_dependencies` so it can merge its

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTester.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		33DEDFED2D8DC825006066E4 /* RNSentryOnDrawReporter+Test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33DEDFEC2D8DC820006066E4 /* RNSentryOnDrawReporter+Test.mm */; };
 		33DEDFF02D9185EB006066E4 /* RNSentryTimeToDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DEDFEF2D9185E3006066E4 /* RNSentryTimeToDisplayTests.swift */; };
 		33F58AD02977037D008F60EA /* RNSentryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 33F58ACF2977037D008F60EA /* RNSentryTests.m */; };
+		33F58AD12977037D008F60EB /* RNSentryScreenshotSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F58ACE2977037D008F60EB /* RNSentryScreenshotSourceTests.swift */; };
 		2639D71D3BD04F17B0BAC987 /* RNSentryTurboModulePerfControllerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = E795057A6D534A80A9D06356 /* RNSentryTurboModulePerfControllerTests.mm */; };
 		AEFB00422CC90C4B00EC8A9A /* RNSentryBreadcrumbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3360843C2C340C76008CC412 /* RNSentryBreadcrumbTests.swift */; };
 		B4DEB41739F14AA38202D4D4 /* RNSentryUriValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E3742693F7643C2ADE1BDF2 /* RNSentryUriValidationTests.m */; };
@@ -50,6 +51,7 @@
 		33DEDFEE2D8DD431006066E4 /* RNSentryTimeToDisplay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RNSentryTimeToDisplay.h; path = ../ios/RNSentryTimeToDisplay.h; sourceTree = SOURCE_ROOT; };
 		33DEDFEF2D9185E3006066E4 /* RNSentryTimeToDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNSentryTimeToDisplayTests.swift; sourceTree = "<group>"; };
 		33F58ACF2977037D008F60EA /* RNSentryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNSentryTests.m; sourceTree = "<group>"; };
+		33F58ACE2977037D008F60EB /* RNSentryScreenshotSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RNSentryScreenshotSourceTests.swift; sourceTree = "<group>"; };
 		3E3742693F7643C2ADE1BDF2 /* RNSentryUriValidationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNSentryUriValidationTests.m; sourceTree = "<group>"; };
 		650CB718ACFBD05609BF2126 /* libPods-RNSentryCocoaTesterTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNSentryCocoaTesterTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E795057A6D534A80A9D06356 /* RNSentryTurboModulePerfControllerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RNSentryTurboModulePerfControllerTests.mm; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 				332D33492CDCC8E100547D76 /* RNSentryTests.h */,
 				336084382C32E382008CC412 /* RNSentryReplayBreadcrumbConverterTests.swift */,
 				33F58ACF2977037D008F60EA /* RNSentryTests.m */,
+				33F58ACE2977037D008F60EB /* RNSentryScreenshotSourceTests.swift */,
 				3339C4802D6625570088EB3A /* RNSentryUserTests.m */,
 				3E3742693F7643C2ADE1BDF2 /* RNSentryUriValidationTests.m */,
 				E795057A6D534A80A9D06356 /* RNSentryTurboModulePerfControllerTests.mm */,
@@ -267,6 +270,7 @@
 				336084392C32E382008CC412 /* RNSentryReplayBreadcrumbConverterTests.swift in Sources */,
 				33DEDFED2D8DC825006066E4 /* RNSentryOnDrawReporter+Test.mm in Sources */,
 				33F58AD02977037D008F60EA /* RNSentryTests.m in Sources */,
+				33F58AD12977037D008F60EB /* RNSentryScreenshotSourceTests.swift in Sources */,
 				3339C4812D6625570088EB3A /* RNSentryUserTests.m in Sources */,
 				B4DEB41739F14AA38202D4D4 /* RNSentryUriValidationTests.m in Sources */,
 				2639D71D3BD04F17B0BAC987 /* RNSentryTurboModulePerfControllerTests.mm in Sources */,

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryReplayOptionsTests.swift
@@ -1,4 +1,4 @@
-import Sentry
+@_spi(Private) import Sentry
 import XCTest
 
 // File length grows as replay option coverage is added; lint runs with `--strict`.
@@ -117,7 +117,7 @@ final class RNSentryReplayOptions: XCTestCase {
         ] as NSDictionary).mutableCopy() as! NSMutableDictionary
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
         XCTAssertEqual(actualOptions.sessionReplay.sessionSampleRate, 0.75)
     }
 
@@ -128,7 +128,7 @@ final class RNSentryReplayOptions: XCTestCase {
         ] as NSDictionary).mutableCopy() as! NSMutableDictionary
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
         XCTAssertEqual(actualOptions.sessionReplay.onErrorSampleRate, 0.75)
     }
 
@@ -158,7 +158,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.maskAllImages, true)
         assertContainsClass(classArray: actualOptions.sessionReplay.maskedViewClasses, stringClass: "RCTImageView")
@@ -173,7 +173,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.maskAllImages, false)
         XCTAssertEqual(actualOptions.sessionReplay.maskedViewClasses.count, 0)
@@ -188,7 +188,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.maskAllText, true)
         assertContainsClass(classArray: actualOptions.sessionReplay.maskedViewClasses, stringClass: "RCTTextView")
@@ -215,7 +215,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.maskAllText, false)
         XCTAssertEqual(actualOptions.sessionReplay.maskedViewClasses.count, 0)
@@ -229,7 +229,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertTrue(actualOptions.sessionReplay.enableViewRendererV2)
     }
@@ -243,7 +243,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertTrue(actualOptions.sessionReplay.enableViewRendererV2)
     }
@@ -257,7 +257,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertFalse(actualOptions.sessionReplay.enableViewRendererV2)
     }
@@ -270,7 +270,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertFalse(actualOptions.sessionReplay.enableFastViewRendering)
     }
@@ -284,7 +284,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertTrue(actualOptions.sessionReplay.enableFastViewRendering)
     }
@@ -298,7 +298,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertFalse(actualOptions.sessionReplay.enableFastViewRendering)
     }
@@ -311,7 +311,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.quality, SentryReplayOptions.SentryReplayQuality.medium)
     }
@@ -325,7 +325,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.quality, SentryReplayOptions.SentryReplayQuality.low)
     }
@@ -339,7 +339,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.quality, SentryReplayOptions.SentryReplayQuality.medium)
     }
@@ -353,7 +353,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.quality, SentryReplayOptions.SentryReplayQuality.high)
     }
@@ -367,7 +367,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         XCTAssertEqual(actualOptions.sessionReplay.quality, SentryReplayOptions.SentryReplayQuality.medium)
     }
@@ -381,7 +381,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         let includedViewClasses = actualOptions.sessionReplay.includedViewClasses
         XCTAssertEqual(includedViewClasses.count, 3)
@@ -399,7 +399,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         let excludedViewClasses = actualOptions.sessionReplay.excludedViewClasses
         XCTAssertEqual(excludedViewClasses.count, 3)
@@ -420,7 +420,7 @@ final class RNSentryReplayOptions: XCTestCase {
 
         RNSentryReplay.updateOptions(optionsDict)
 
-        let actualOptions = try! PrivateSentrySDKOnly.options(with: optionsDict as! [String: Any])
+        let actualOptions = try! SentrySDK.internal.options(fromDictionary: optionsDict as! [String: Any])
 
         let includedViewClasses = actualOptions.sessionReplay.includedViewClasses
         XCTAssertEqual(includedViewClasses.count, 2)

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryScreenshotSourceTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryScreenshotSourceTests.swift
@@ -1,0 +1,47 @@
+@_spi(Private) import Sentry
+import XCTest
+
+/// Guards the iOS screenshot regression from 8.19.0 (#6497), which forced the revert
+/// of the `SentrySDK.internal` migration (#6380) in 8.20.0.
+///
+/// RN reads `SentrySDK.internal` before `SentrySDK.start`: `RNSentryStart` does it
+/// itself, and JS integrations call native methods (`fetchNativeAppStart`,
+/// `fetchNativeSdkInfo`) while the SDK is still initializing. Constructing
+/// `SentryInternalApi` eagerly reads `SentryDependencyContainer.screenshotSource`,
+/// which used to be a `lazy var` that permanently cached the `nil` its builder returns
+/// while `startOptions` is unset. That killed every iOS screenshot for the rest of the
+/// process — Feedback Widget screenshot, `attachScreenshot` and
+/// `Sentry.captureScreenshot()` all silently returned nothing.
+///
+/// Fixed in sentry-cocoa 9.24.0 (getsentry/sentry-cocoa#8578) by turning
+/// `screenshotSource` into a computed property that rebuilds until `startOptions`
+/// is available. This test fails against any earlier version.
+final class RNSentryScreenshotSourceTests: XCTestCase {
+
+    func testScreenshotCaptureSurvivesInternalApiAccessBeforeStart() throws {
+        // Model a process that has not started the SDK yet.
+        SentrySDK.close()
+        SentryDependencyContainer.reset()
+        // `reset()` deliberately carries `startOptions` over to the new container, so
+        // clear it explicitly.
+        SentrySDK.setStart(with: nil)
+
+        // The pre-start access that used to poison the screenshot source.
+        _ = SentrySDK.internal
+
+        var error: NSError?
+        RNSentryStart.start(
+            options: [
+                "dsn": "https://abcd@efgh.ingest.sentry.io/123456",
+                "attachScreenshot": true
+            ],
+            error: &error)
+        if let error = error {
+            throw error
+        }
+
+        XCTAssertNotNil(
+            SentrySDK.internal.screenshot.capture(),
+            "screenshot capture must still work after SentrySDK.internal was read before SentrySDK.start")
+    }
+}

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartFromFileTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartFromFileTests.swift
@@ -1,3 +1,4 @@
+@_spi(Private) import Sentry
 import XCTest
 
 final class RNSentryStartFromFileTests: XCTestCase {
@@ -11,7 +12,7 @@ final class RNSentryStartFromFileTests: XCTestCase {
 
         XCTAssertTrue(wasConfigurationCalled)
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         XCTAssertNil(actualOptions.dsn)
         XCTAssertNil(actualOptions.parsedDsn)
     }
@@ -25,7 +26,7 @@ final class RNSentryStartFromFileTests: XCTestCase {
 
         XCTAssertTrue(wasConfigurationCalled)
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         XCTAssertNil(actualOptions.dsn)
         XCTAssertNil(actualOptions.parsedDsn)
     }
@@ -39,7 +40,7 @@ final class RNSentryStartFromFileTests: XCTestCase {
 
         XCTAssertTrue(wasConfigurationCalled)
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         XCTAssertNil(actualOptions.dsn)
         XCTAssertNotNil(actualOptions.parsedDsn)
         XCTAssertEqual(actualOptions.environment, "environment-from-invalid-file")
@@ -54,7 +55,7 @@ final class RNSentryStartFromFileTests: XCTestCase {
 
         XCTAssertTrue(wasConfigurationCalled)
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         XCTAssertNil(actualOptions.dsn)
         XCTAssertNotNil(actualOptions.parsedDsn)
         XCTAssertEqual(actualOptions.environment, "environment-from-valid-file")
@@ -76,7 +77,7 @@ final class RNSentryStartFromFileTests: XCTestCase {
             options.environment = "new-environment"
         }
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         XCTAssertEqual(actualOptions.environment, "new-environment")
     }
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartTests.swift
@@ -1,3 +1,4 @@
+@_spi(Private) import Sentry
 import XCTest
 
 final class RNSentryStartTests: XCTestCase {
@@ -29,7 +30,7 @@ final class RNSentryStartTests: XCTestCase {
             "dsn": "https://abcd@efgh.ingest.sentry.io/123456"
         ])
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         assertReactDefaults(actualOptions)
     }
 
@@ -63,10 +64,10 @@ final class RNSentryStartTests: XCTestCase {
         for startMethod in testCases {
             try startMethod()
 
-            let actualOptions = PrivateSentrySDKOnly.options
+            let actualOptions = SentrySDK.internal.options
 
-            XCTAssertTrue(PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode)
-            XCTAssertTrue(PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode)
+            XCTAssertTrue(SentrySDK.internal.appStart.hybridSDKMode)
+            XCTAssertTrue(SentrySDK.internal.performance.framesTrackingHybridSDKMode)
         }
     }
 
@@ -89,10 +90,10 @@ final class RNSentryStartTests: XCTestCase {
         for startMethod in testCases {
             try startMethod()
 
-            let actualOptions = PrivateSentrySDKOnly.options
+            let actualOptions = SentrySDK.internal.options
 
-            XCTAssertFalse(PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode)
-            XCTAssertFalse(PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode)
+            XCTAssertFalse(SentrySDK.internal.appStart.hybridSDKMode)
+            XCTAssertFalse(SentrySDK.internal.performance.framesTrackingHybridSDKMode)
         }
     }
 
@@ -113,7 +114,7 @@ final class RNSentryStartTests: XCTestCase {
         for startMethod in testCases {
             try startMethod()
 
-            let actualOptions = PrivateSentrySDKOnly.options
+            let actualOptions = SentrySDK.internal.options
 
             let actualEvent = actualOptions.beforeSend!(createUnhandledJsExceptionEvent())
 
@@ -138,7 +139,7 @@ final class RNSentryStartTests: XCTestCase {
         for startMethod in testCases {
             try startMethod()
 
-            let actualOptions = PrivateSentrySDKOnly.options
+            let actualOptions = SentrySDK.internal.options
 
             let actualEvent = actualOptions.beforeSend!(createNativeEvent())
 
@@ -160,7 +161,7 @@ final class RNSentryStartTests: XCTestCase {
             }
         }
 
-        PrivateSentrySDKOnly.options.beforeSend!(genericEvent())
+        SentrySDK.internal.options.beforeSend!(genericEvent())
 
         XCTAssertTrue(executed)
     }
@@ -207,7 +208,7 @@ final class RNSentryStartTests: XCTestCase {
             ]
         ])
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         XCTAssertTrue(actualOptions.attachScreenshot)
         XCTAssertFalse(actualOptions.screenshot.maskAllText)
         XCTAssertTrue(actualOptions.screenshot.maskAllImages)
@@ -219,7 +220,7 @@ final class RNSentryStartTests: XCTestCase {
             "attachScreenshot": true
         ])
 
-        let actualOptions = PrivateSentrySDKOnly.options
+        let actualOptions = SentrySDK.internal.options
         XCTAssertTrue(actualOptions.attachScreenshot)
         XCTAssertTrue(actualOptions.screenshot.maskAllText)
         XCTAssertTrue(actualOptions.screenshot.maskAllImages)
@@ -258,8 +259,8 @@ final class RNSentryStartTests: XCTestCase {
         var actualEvent: Event?
 
         // This is the closest to the sent event we can get using the actual Sentry start method
-        let originalBeforeSend = PrivateSentrySDKOnly.options.beforeSend
-        PrivateSentrySDKOnly.options.beforeSend = { event in
+        let originalBeforeSend = SentrySDK.internal.options.beforeSend
+        SentrySDK.internal.options.beforeSend = { event in
             if let originalBeforeSend = originalBeforeSend {
                 let processedEvent = originalBeforeSend(event)
                 actualEvent = processedEvent

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.h
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.h
@@ -2,13 +2,7 @@
 #import <RNSentry/RNSentry.h>
 #import <RNSentry/RNSentryReplay.h>
 
-@class SentryOptions;
 @class SentryUser;
-
-@interface SentrySDKInternal (PrivateTests)
-
-+ (nullable SentryOptions *)options;
-@end
 
 @interface RNSentry (PrivateTests)
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.m
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryTests.m
@@ -2,6 +2,7 @@
 #import "RNSentry+Test.h"
 #import "RNSentryReplay.h"
 #import "RNSentryStart+Test.h"
+#import "SentrySDKWrapper.h"
 #import <OCMock/OCMock.h>
 #import <RNSentry/RNSentry.h>
 #import <Sentry/PrivateSentrySDKOnly.h>
@@ -68,11 +69,8 @@ sucessfulSymbolicate(const void *, Dl_info *info)
 
 - (void)prepareNativeFrameMocksWithLocalSymbolication:(BOOL)debug
 {
-    SentryOptions *sentryOptions = [[SentryOptions alloc] init];
-    sentryOptions.debug = debug; // no local symbolication
-
-    id sentrySDKMock = OCMClassMock([SentrySDKInternal class]);
-    OCMStub([(Class)sentrySDKMock options]).andReturn(sentryOptions);
+    id sentrySDKWrapperMock = OCMClassMock([SentrySDKWrapper class]);
+    OCMStub(ClassMethod([sentrySDKWrapperMock debug])).andReturn(debug);
 
     id sentryDependencyContainerMock = OCMClassMock([SentryDependencyContainer class]);
     OCMStub(ClassMethod([sentryDependencyContainerMock sharedInstance]))

--- a/packages/core/ios/AGENTS.md
+++ b/packages/core/ios/AGENTS.md
@@ -56,5 +56,15 @@ RCT_EXPORT_METHOD(nativeOperation:(NSString *)param
 2. Edit `RNSentry.podspec` to remove version constraint
 3. Add local pod to sample's Podfile:
    ```ruby
-   pod 'Sentry/HybridSDK', :path => '../../../../sentry-cocoa'
+   pod 'Sentry', :path => '../../../../sentry-cocoa'
    ```
+
+## Internal API access (`SentrySDK.internal`)
+
+RNSentry consumes sentry-cocoa's hybrid-SDK surface (`SentrySDK.internal.*`)
+through a Swift bridge in `RNSentryInternal.swift`. The bridge imports Sentry
+with `@_spi(Private)` because several sub-APIs (`performance.currentScreenFrames`,
+`replay.configure`, `envelope.{store,capture,deserialize}`) are SPI-gated.
+`.m`/`.mm` callers import the auto-generated `RNSentry-Swift.h` and route
+through `[RNSentryInternal …]` instead of touching `PrivateSentrySDKOnly`
+(deprecated since cocoa 9.19.0 and slated for removal in the next major).

--- a/packages/core/ios/RNSentry+fetchNativeStack.m
+++ b/packages/core/ios/RNSentry+fetchNativeStack.m
@@ -2,7 +2,7 @@
 #import "RNSentryBreadcrumb.h"
 #import "RNSentryHexFormatter.h"
 #import "RNSentryId.h"
-#import <Sentry/PrivateSentrySDKOnly.h>
+#import "SentrySDKWrapper.h"
 @import Sentry;
 
 // This method was moved to a new category so we can use `@import Sentry` to use Sentry's Swift
@@ -12,7 +12,7 @@
 - (NSDictionary *)fetchNativeStackFramesBy:(NSArray<NSNumber *> *)instructionsAddr
                                symbolicate:(SymbolicateCallbackType)symbolicate
 {
-    BOOL shouldSymbolicateLocally = [SentrySDKInternal.options debug];
+    BOOL shouldSymbolicateLocally = [SentrySDKWrapper debug];
 
     NSString *appPackageName = [[NSBundle mainBundle] executablePath];
 

--- a/packages/core/ios/RNSentry.h
+++ b/packages/core/ios/RNSentry.h
@@ -14,12 +14,7 @@
 
 typedef int (*SymbolicateCallbackType)(const void *, Dl_info *);
 
-@class SentryOptions;
 @class SentryEvent;
-
-@interface SentrySDKInternal : NSObject
-@property (nonatomic, nullable, readonly, class) SentryOptions *options;
-@end
 
 @interface RNSentry : RCTEventEmitter <RCTBridgeModule>
 

--- a/packages/core/ios/RNSentry.mm
+++ b/packages/core/ios/RNSentry.mm
@@ -16,9 +16,13 @@
 #    define SENTRY_TARGET_PROFILING_SUPPORTED 0
 #endif
 
+#if __has_include(<RNSentry/RNSentry-Swift.h>)
+#    import <RNSentry/RNSentry-Swift.h>
+#else
+#    import "RNSentry-Swift.h"
+#endif
 #import "RNSentryBreadcrumb.h"
 #import "RNSentryId.h"
-#import <Sentry/PrivateSentrySDKOnly.h>
 #import <Sentry/SentryAppStartMeasurement.h>
 #import <Sentry/SentryBreadcrumb.h>
 #import <Sentry/SentryDebugMeta.h>
@@ -403,10 +407,8 @@ RCT_EXPORT_METHOD(disableShakeDetection)
 RCT_EXPORT_METHOD(
     fetchNativeSdkInfo : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject)
 {
-    resolve(@ {
-        @"name" : PrivateSentrySDKOnly.getSdkName,
-        @"version" : PrivateSentrySDKOnly.getSdkVersionString
-    });
+    resolve(
+        @ { @"name" : RNSentryInternal.sdkName, @"version" : RNSentryInternal.sdkVersionString });
 }
 
 RCT_EXPORT_METHOD(
@@ -458,7 +460,7 @@ RCT_EXPORT_METHOD(fetchNativeLogAttributes : (RCTPromiseResolveBlock)resolve rej
             contexts[@"release"] = releaseName;
         }
         // Merge extra context
-        NSDictionary *extraContext = [PrivateSentrySDKOnly getExtraContext];
+        NSDictionary *extraContext = [RNSentryInternal extraContext];
 
         if (extraContext) {
             NSDictionary *extraDevice = extraContext[@"device"];
@@ -496,8 +498,7 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts : (RCTPromiseResolveBlock)resolve re
 
         NSDictionary<NSString *, id> *user = [serializedScope valueForKey:@"user"];
         if (user == nil) {
-            [serializedScope setValue:@ { @"id" : PrivateSentrySDKOnly.installationID }
-                               forKey:@"user"];
+            [serializedScope setValue:@ { @"id" : RNSentryInternal.installationID } forKey:@"user"];
         }
 
         if ([SentrySDKWrapper debug]) {
@@ -510,7 +511,7 @@ RCT_EXPORT_METHOD(fetchNativeDeviceContexts : (RCTPromiseResolveBlock)resolve re
         }
     }];
 
-    NSDictionary<NSString *, id> *extraContext = [PrivateSentrySDKOnly getExtraContext];
+    NSDictionary<NSString *, id> *extraContext = [RNSentryInternal extraContext];
     NSMutableDictionary<NSString *, NSDictionary<NSString *, id> *> *contexts =
         [serializedScope[@"context"] mutableCopy];
 
@@ -547,8 +548,7 @@ RCT_EXPORT_METHOD(
     fetchNativeAppStart : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject)
 {
 #if SENTRY_HAS_UIKIT
-    NSDictionary<NSString *, id> *measurements =
-        [PrivateSentrySDKOnly appStartMeasurementWithSpans];
+    NSDictionary<NSString *, id> *measurements = [RNSentryInternal appStartMeasurementWithSpans];
     if (measurements == nil) {
         resolve(nil);
         return;
@@ -574,7 +574,7 @@ RCT_EXPORT_METHOD(
 {
 
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
-    if (PrivateSentrySDKOnly.isFramesTrackingRunning) {
+    if (RNSentryInternal.isFramesTrackingRunning) {
         if (![SentryScreenFramesWrapper canTrackFrames]) {
             resolve(nil);
             return;
@@ -626,20 +626,20 @@ RCT_EXPORT_METHOD(captureEnvelope : (NSString *_Nonnull)rawBytes options : (NSDi
 {
     NSData *data = [[NSData alloc] initWithBase64EncodedString:rawBytes options:0];
 
-    SentryEnvelope *envelope = [PrivateSentrySDKOnly envelopeWithData:data];
+    SentryEnvelope *envelope = [RNSentryInternal envelopeFromData:data];
     if (envelope == nil) {
         reject(@"SentryReactNative", @"Failed to parse envelope from byte array.", nil);
         return;
     }
 
 #if DEBUG
-    [PrivateSentrySDKOnly captureEnvelope:envelope];
+    [RNSentryInternal capture:envelope];
 #else
     if ([[options objectForKey:@"hardCrashed"] boolValue]) {
         // Storing to disk happens asynchronously with captureEnvelope
-        [PrivateSentrySDKOnly storeEnvelope:envelope];
+        [RNSentryInternal store:envelope];
     } else {
-        [PrivateSentrySDKOnly captureEnvelope:envelope];
+        [RNSentryInternal capture:envelope];
     }
 #endif
     resolve(@YES);
@@ -649,7 +649,7 @@ RCT_EXPORT_METHOD(
     captureScreenshot : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject)
 {
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
-    NSArray<NSData *> *rawScreenshots = [PrivateSentrySDKOnly captureScreenshots];
+    NSArray<NSData *> *rawScreenshots = [RNSentryInternal captureScreenshots];
     NSMutableArray *screenshotsArray = [NSMutableArray arrayWithCapacity:[rawScreenshots count]];
 
     int counter = 1;
@@ -682,7 +682,13 @@ RCT_EXPORT_METHOD(
     fetchViewHierarchy : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromiseRejectBlock)reject)
 {
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
-    NSData *rawViewHierarchy = [PrivateSentrySDKOnly captureViewHierarchy];
+    NSData *rawViewHierarchy = [RNSentryInternal captureViewHierarchy];
+    if (rawViewHierarchy == nil) {
+        // Propagate the capture failure to JS instead of a truthy `[]`, which
+        // would be treated as a successful (empty) attachment.
+        resolve(nil);
+        return;
+    }
 
     NSMutableArray *viewHierarchy = [NSMutableArray arrayWithCapacity:rawViewHierarchy.length];
     const char *bytes = (char *)[rawViewHierarchy bytes];
@@ -733,7 +739,7 @@ RCT_EXPORT_METHOD(addBreadcrumb : (NSDictionary *)breadcrumb)
 #if SENTRY_HAS_UIKIT
     NSString *_Nullable screen = [RNSentryBreadcrumb getCurrentScreenFrom:breadcrumb];
     if (screen != nil) {
-        [PrivateSentrySDKOnly setCurrentScreen:screen];
+        [RNSentryInternal setCurrentScreen:screen];
     }
 #endif // SENTRY_HAS_UIKIT
 }
@@ -816,52 +822,19 @@ RCT_EXPORT_METHOD(pauseAppHangTracking) { [SentrySDKWrapper pauseAppHangTracking
 
 RCT_EXPORT_METHOD(resumeAppHangTracking) { [SentrySDKWrapper resumeAppHangTracking]; }
 
-/**
- * Calls captureReplay on the native replay integration and returns
- * the BOOL result indicating whether the capture succeeded.
- *
- * PrivateSentrySDKOnly.captureReplay is void and discards the result,
- * so we call the integration directly to get the success status.
- * This prevents returning a stale buffer-mode replay ID when the
- * capture actually failed (e.g., replay not running).
- *
- * Falls back to the old void captureReplay if the integration
- * cannot be accessed directly (e.g., future Cocoa SDK changes).
- *
- * See https://github.com/getsentry/sentry-react-native/issues/5074
- */
+// Calls `SentrySDK.internal.replay.capture()` via the Swift bridge and returns
+// the BOOL result. The `@try`/`@catch` is retained as cheap insurance for one
+// release cycle — see getsentry/sentry-react-native#5074 for the historical
+// fault path that motivated defensive handling here.
 + (BOOL)captureReplayWithReturnValue
 {
 #if SENTRY_TARGET_REPLAY_SUPPORTED
     @try {
-        if ([PrivateSentrySDKOnly respondsToSelector:@selector(getReplayIntegration)]) {
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-            id replayIntegration =
-                [PrivateSentrySDKOnly performSelector:@selector(getReplayIntegration)];
-#    pragma clang diagnostic pop
-            if (replayIntegration &&
-                [replayIntegration respondsToSelector:@selector(captureReplay)]) {
-                typedef BOOL (*CaptureReplayIMP)(id, SEL);
-                CaptureReplayIMP captureFunc = (CaptureReplayIMP)
-                    [replayIntegration methodForSelector:@selector(captureReplay)];
-                return captureFunc(replayIntegration, @selector(captureReplay));
-            }
-        }
+        return [RNSentryInternal captureReplay];
     } @catch (NSException *exception) {
-        NSLog(@"[RNSentry] Failed to call captureReplay on integration: %@", exception);
-    }
-    // Fallback: call the void method and assume success if a replay ID exists.
-    // This preserves the old behavior when the integration isn't directly accessible.
-    // clang-format off
-    @try {
-        [PrivateSentrySDKOnly captureReplay];
-        return [PrivateSentrySDKOnly getReplayId] != nil;
-    } @catch (NSException *exception) {
-        NSLog(@"[RNSentry] Failed to call captureReplay fallback: %@", exception);
+        NSLog(@"[RNSentry] Failed to call captureReplay: %@", exception);
         return NO;
     }
-    // clang-format on
 #else
     return NO;
 #endif
@@ -873,7 +846,7 @@ RCT_EXPORT_METHOD(captureReplay : (BOOL)isHardCrash resolver : (
 #if SENTRY_TARGET_REPLAY_SUPPORTED
     BOOL captured = [RNSentry captureReplayWithReturnValue];
     if (captured) {
-        resolve([PrivateSentrySDKOnly getReplayId]);
+        resolve([RNSentryInternal replayId]);
     } else {
         resolve(nil);
     }
@@ -963,7 +936,7 @@ RCT_EXPORT_METHOD(getDataFromUri : (NSString *_Nonnull)uri resolve : (
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getCurrentReplayId)
 {
 #if SENTRY_TARGET_REPLAY_SUPPORTED
-    return [PrivateSentrySDKOnly getReplayId];
+    return [RNSentryInternal replayId];
 #else
     return nil;
 #endif
@@ -989,8 +962,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, startProfiling : (BOOL)platf
         if (nativeProfileTraceId == nil && nativeProfileStartTime == 0 && platformProfilers) {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
             nativeProfileTraceId = [RNSentryId newId];
-            nativeProfileStartTime =
-                [PrivateSentrySDKOnly startProfilerForTrace:nativeProfileTraceId];
+            nativeProfileStartTime = [RNSentryInternal startProfilerForTrace:nativeProfileTraceId];
 #    endif
         } else {
             if (!platformProfilers) {
@@ -1004,7 +976,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, startProfiling : (BOOL)platf
     } catch (const std::exception &ex) {
         if (nativeProfileTraceId != nil) {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-            [PrivateSentrySDKOnly discardProfilerForTrace:nativeProfileTraceId];
+            [RNSentryInternal discardProfilerForTrace:nativeProfileTraceId];
 #    endif
             nativeProfileTraceId = nil;
         }
@@ -1016,7 +988,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, startProfiling : (BOOL)platf
     } catch (...) {
         if (nativeProfileTraceId != nil) {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-            [PrivateSentrySDKOnly discardProfilerForTrace:nativeProfileTraceId];
+            [RNSentryInternal discardProfilerForTrace:nativeProfileTraceId];
 #    endif
             nativeProfileTraceId = nil;
         }
@@ -1036,9 +1008,9 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, stopProfiling)
         if (nativeProfileTraceId != nil && nativeProfileStartTime != 0) {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
             uint64_t nativeProfileStopTime = clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
-            nativeProfile = [PrivateSentrySDKOnly collectProfileBetween:nativeProfileStartTime
-                                                                    and:nativeProfileStopTime
-                                                               forTrace:nativeProfileTraceId];
+            nativeProfile = [RNSentryInternal collectProfileBetween:nativeProfileStartTime
+                                                                and:nativeProfileStopTime
+                                                           forTrace:nativeProfileTraceId];
 #    endif
         }
         // Cleanup native profiles
@@ -1093,7 +1065,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, stopProfiling)
     } catch (const std::exception &ex) {
         if (nativeProfileTraceId != nil) {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-            [PrivateSentrySDKOnly discardProfilerForTrace:nativeProfileTraceId];
+            [RNSentryInternal discardProfilerForTrace:nativeProfileTraceId];
 #    endif
             nativeProfileTraceId = nil;
         }
@@ -1105,7 +1077,7 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, stopProfiling)
     } catch (...) {
         if (nativeProfileTraceId != nil) {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-            [PrivateSentrySDKOnly discardProfilerForTrace:nativeProfileTraceId];
+            [RNSentryInternal discardProfilerForTrace:nativeProfileTraceId];
 #    endif
             nativeProfileTraceId = nil;
         }

--- a/packages/core/ios/RNSentryInternal.swift
+++ b/packages/core/ios/RNSentryInternal.swift
@@ -1,0 +1,259 @@
+import Foundation
+@_spi(Private) import Sentry
+
+/// Thin Objective-C-visible bridge over `SentrySDK.internal.*`.
+///
+/// React Native's iOS code is mostly `.m`/`.mm`, but the new hybrid-SDK API
+/// (`SentrySDK.internal`) is Swift-only and several methods are gated by
+/// `@_spi(Private)`. This file imports with the SPI name and exposes a flat
+/// `@objc` surface that mirrors the call sites we use today.
+///
+/// Platform gating mirrors each `SentryInternal*Api` in sentry-cocoa
+/// (`Sources/Swift/HybridSDK/`). Where a sub-API is excluded on a platform,
+/// stubs return safe defaults so `.m`/`.mm` callers still resolve symbols.
+@_spi(Private) @objc public final class RNSentryInternal: NSObject {
+
+    // MARK: - SDK metadata
+
+    @_spi(Private) @objc public static var sdkName: String { SentrySDK.internal.sdk.name }
+
+    @_spi(Private) @objc public static var sdkVersionString: String { SentrySDK.internal.sdk.versionString }
+
+    @_spi(Private) @objc public static func setSdkName(_ name: String, version: String) {
+        SentrySDK.internal.sdk.setName(name, version: version)
+    }
+
+    @_spi(Private) @objc public static func addSdkPackage(_ name: String, version: String) {
+        SentrySDK.internal.sdk.addPackage(name: name, version: version)
+    }
+
+    @_spi(Private) @objc public static var extraContext: [String: Any] {
+        SentrySDK.internal.sdk.extraContext
+    }
+
+    @_spi(Private) @objc public static var installationID: String {
+        SentrySDK.internal.sdk.installationID
+    }
+
+    // MARK: - Options
+
+    @_spi(Private) @objc public static var options: Options { SentrySDK.internal.options }
+
+    @_spi(Private) @objc public static func options(fromDictionary dict: [String: Any]) throws -> Options {
+        try SentrySDK.internal.options(fromDictionary: dict)
+    }
+
+    // MARK: - App start
+
+    @_spi(Private) @objc public static var appStartMeasurementHybridSDKMode: Bool {
+        get { SentrySDK.internal.appStart.hybridSDKMode }
+        set { SentrySDK.internal.appStart.hybridSDKMode = newValue }
+    }
+
+    @_spi(Private) @objc public static var appStartMeasurementWithSpans: [String: Any]? {
+        SentrySDK.internal.appStart.measurementWithSpans
+    }
+
+    // MARK: - Performance / frames
+
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    @_spi(Private) @objc public static var framesTrackingMeasurementHybridSDKMode: Bool {
+        get { SentrySDK.internal.performance.framesTrackingHybridSDKMode }
+        set { SentrySDK.internal.performance.framesTrackingHybridSDKMode = newValue }
+    }
+
+    @_spi(Private) @objc public static var isFramesTrackingRunning: Bool {
+        SentrySDK.internal.performance.isFramesTrackingRunning
+    }
+
+    @_spi(Private) @objc public static var currentScreenFrames: SentryScreenFrames? {
+        SentrySDK.internal.performance.currentScreenFrames
+    }
+    #else
+    @_spi(Private) @objc public static var framesTrackingMeasurementHybridSDKMode: Bool {
+        get { false }
+        set {}
+    }
+
+    @_spi(Private) @objc public static var isFramesTrackingRunning: Bool { false }
+
+    // `currentScreenFrames` is intentionally NOT declared on non-UIKit
+    // platforms: sentry-cocoa does not compile `SentryScreenFrames` there,
+    // so referencing it as a return type would fail to resolve. Every ObjC
+    // caller (`SentryScreenFramesWrapper.m`) is already gated to
+    // `TARGET_OS_IPHONE || TARGET_OS_MACCATALYST`, so no consumer needs the
+    // stub on macOS/watchOS.
+    #endif
+
+    // MARK: - Envelope
+
+    // Accepts `Data?` (nil-safe) rather than `Data` so the ObjC bridge boundary
+    // doesn't force-unwrap a nil `NSData*` from a failed base64 decode — that
+    // would crash before we ever get a chance to check the result. Matches the
+    // nil-tolerant behaviour of the deprecated `PrivateSentrySDKOnly.envelopeWithData:`.
+    @_spi(Private) @objc public static func envelope(fromData data: Data?) -> SentryEnvelope? {
+        guard let data = data else { return nil }
+        return SentrySDK.internal.envelope.deserialize(from: data)
+    }
+
+    @_spi(Private) @objc public static func capture(_ envelope: SentryEnvelope) {
+        SentrySDK.internal.envelope.capture(envelope)
+    }
+
+    @_spi(Private) @objc public static func store(_ envelope: SentryEnvelope) {
+        SentrySDK.internal.envelope.store(envelope)
+    }
+
+    // MARK: - Screenshot / view hierarchy / screen
+
+    // sentry-cocoa's `SentryInternalScreen/Screenshot/ViewHierarchyApi` are all
+    // gated to `(os(iOS) || os(tvOS)) && !SENTRY_NO_UI_FRAMEWORK`. On visionOS
+    // the new hybrid-SDK surface is intentionally absent, but the same
+    // functionality still lives on `PrivateSentrySDKOnly` (gated by
+    // `SENTRY_HAS_UIKIT`, which covers visionOS). Route the visionOS bridge
+    // through the deprecated SPI so we preserve pre-migration behaviour and
+    // keep this PR non-breaking. Remove the fallback once sentry-cocoa
+    // exposes these APIs on visionOS in the hybrid surface — or once cocoa
+    // drops `PrivateSentrySDKOnly` in a future major and forces our hand.
+    #if os(iOS) || os(tvOS)
+    @_spi(Private) @objc public static var captureScreenshots: [Data]? {
+        SentrySDK.internal.screenshot.capture()
+    }
+
+    @_spi(Private) @objc public static var captureViewHierarchy: Data? {
+        SentrySDK.internal.viewHierarchy.capture()
+    }
+
+    @_spi(Private) @objc public static func setCurrentScreen(_ screenName: String?) {
+        SentrySDK.internal.screen.setCurrent(screenName)
+    }
+    #elseif os(visionOS)
+    @_spi(Private) @objc public static var captureScreenshots: [Data]? {
+        PrivateSentrySDKOnly.captureScreenshots()
+    }
+
+    @_spi(Private) @objc public static var captureViewHierarchy: Data? {
+        PrivateSentrySDKOnly.captureViewHierarchy()
+    }
+
+    @_spi(Private) @objc public static func setCurrentScreen(_ screenName: String?) {
+        PrivateSentrySDKOnly.setCurrentScreen(screenName)
+    }
+    #else
+    @_spi(Private) @objc public static var captureScreenshots: [Data]? { nil }
+    @_spi(Private) @objc public static var captureViewHierarchy: Data? { nil }
+    @_spi(Private) @objc public static func setCurrentScreen(_ screenName: String?) {}
+    #endif
+
+    // MARK: - Replay
+
+    #if os(iOS) || os(tvOS)
+    @_spi(Private) @objc public static func captureReplay() -> Bool {
+        SentrySDK.internal.replay.capture()
+    }
+
+    @_spi(Private) @objc public static var replayId: String? {
+        SentrySDK.internal.replay.replayId
+    }
+
+    @_spi(Private) @objc public static func setReplayRedactContainerClass(_ containerClass: AnyClass) {
+        SentrySDK.internal.replay.setRedactContainerClass(containerClass)
+    }
+
+    @_spi(Private) @objc public static func setReplayIgnoreContainerClass(_ containerClass: AnyClass) {
+        SentrySDK.internal.replay.setIgnoreContainerClass(containerClass)
+    }
+
+    @_spi(Private) @objc public static func configureReplay(
+        breadcrumbConverter: SentryReplayBreadcrumbConverter
+    ) {
+        SentrySDK.internal.replay.configure(
+            breadcrumbConverter: breadcrumbConverter,
+            screenshotProvider: nil
+        )
+    }
+    #else
+    @_spi(Private) @objc public static func captureReplay() -> Bool { false }
+    @_spi(Private) @objc public static var replayId: String? { nil }
+    @_spi(Private) @objc public static func setReplayRedactContainerClass(_ containerClass: AnyClass) {}
+    @_spi(Private) @objc public static func setReplayIgnoreContainerClass(_ containerClass: AnyClass) {}
+    @_spi(Private) @objc public static func configureReplay(
+        breadcrumbConverter: SentryReplayBreadcrumbConverter
+    ) {}
+    #endif
+
+    // MARK: - Swizzle
+
+    // `SentryInternalSwizzleApi` in sentry-cocoa has no platform gating.
+    // We enable the wrapper on every UIKit-capable platform (iOS/tvOS/visionOS
+    // — matching `SENTRY_UIKIT_AVAILABLE`, which is what `SENTRY_HAS_UIKIT`
+    // resolves to in the RNSentry.mm caller). `os(iOS)` in Swift already
+    // covers Mac Catalyst, so no separate `targetEnvironment(macCatalyst)` is
+    // needed.
+    #if os(iOS) || os(tvOS) || os(visionOS)
+    /// Stable identity for the `RNSScreen.viewDidAppear:` swizzle so the underlying
+    /// `oncePerClass` bookkeeping in sentry-cocoa can dedupe re-entries.
+    private static var rnsScreenViewDidAppearKey: UInt8 = 0
+
+    /// Swizzles `-[RNSScreen viewDidAppear:]`, invoking `hook` before the original
+    /// implementation on every call. No-op when RNSScreen is unavailable.
+    @_spi(Private) @objc public static func swizzleRNSScreenViewDidAppear(hook: @escaping () -> Void) {
+        guard let cls = NSClassFromString("RNSScreen") else { return }
+        let selector = NSSelectorFromString("viewDidAppear:")
+
+        // `withUnsafePointer(to:)` scopes the pointer's validity to the closure
+        // body. Perform the entire swizzle call inside so we never rely on the
+        // pointer surviving beyond the closure. The backing storage is a
+        // `static var`, so the address itself stays stable across calls —
+        // sentry-cocoa's `oncePerClass` bookkeeping continues to dedupe.
+        withUnsafePointer(to: &rnsScreenViewDidAppearKey) { keyPtr in
+            _ = SentrySDK.internal.swizzle.instanceMethod(
+                selector,
+                in: cls,
+                mode: .oncePerClass,
+                key: UnsafeRawPointer(keyPtr),
+                factory: { getOriginal in
+                    let block: @convention(block) (AnyObject, ObjCBool) -> Void = { receiver, animated in
+                        hook()
+                        typealias OriginalIMP = @convention(c) (AnyObject, Selector, ObjCBool) -> Void
+                        let original = unsafeBitCast(getOriginal(), to: OriginalIMP.self)
+                        original(receiver, selector, animated)
+                    }
+                    return block as AnyObject
+                }
+            )
+        }
+    }
+    #else
+    @_spi(Private) @objc public static func swizzleRNSScreenViewDidAppear(hook: @escaping () -> Void) {}
+    #endif
+
+    // MARK: - Profiling
+
+    #if !(os(watchOS) || os(tvOS) || os(visionOS))
+    @_spi(Private) @objc public static func startProfiler(forTrace traceId: SentryId) -> UInt64 {
+        SentrySDK.internal.profiling.start(for: traceId)
+    }
+
+    @_spi(Private) @objc(collectProfileBetween:and:forTrace:)
+    public static func collectProfile(
+        between startTime: UInt64,
+        and endTime: UInt64,
+        forTrace traceId: SentryId
+    ) -> [String: Any]? {
+        SentrySDK.internal.profiling.collect(between: startTime, and: endTime, for: traceId)
+    }
+
+    @_spi(Private) @objc public static func discardProfiler(forTrace traceId: SentryId) {
+        SentrySDK.internal.profiling.discard(for: traceId)
+    }
+    #else
+    @_spi(Private) @objc public static func startProfiler(forTrace traceId: SentryId) -> UInt64 { 0 }
+    @_spi(Private) @objc public static func collectProfile(
+        between startTime: UInt64,
+        and endTime: UInt64,
+        forTrace traceId: SentryId
+    ) -> [String: Any]? { nil }
+    @_spi(Private) @objc public static func discardProfiler(forTrace traceId: SentryId) {}
+    #endif
+}

--- a/packages/core/ios/RNSentryRNSScreen.m
+++ b/packages/core/ios/RNSentryRNSScreen.m
@@ -2,31 +2,21 @@
 
 #if SENTRY_HAS_UIKIT
 
+#    if __has_include(<RNSentry/RNSentry-Swift.h>)
+#        import <RNSentry/RNSentry-Swift.h>
+#    else
+#        import "RNSentry-Swift.h"
+#    endif
 #    import "RNSentryDependencyContainer.h"
 #    import "RNSentryFramesTrackerListener.h"
-#    if __has_include(<Sentry/SentrySwizzle.h>)
-#        import <Sentry/SentrySwizzle.h>
-#    else
-#        import "SentrySwizzle.h"
-#    endif
-@import Sentry;
 
 @implementation RNSentryRNSScreen
 
 + (void)swizzleViewDidAppear
 {
-    Class rnsscreenclass = NSClassFromString(@"RNSScreen");
-    if (rnsscreenclass == nil) {
-        return;
-    }
-
-    SEL selector = NSSelectorFromString(@"viewDidAppear:");
-    SentrySwizzleInstanceMethod(rnsscreenclass, selector, SentrySWReturnType(void),
-        SentrySWArguments(BOOL animated), SentrySWReplacement({
-            [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
-            SentrySWCallOriginal(animated);
-        }),
-        SentrySwizzleModeOncePerClass, (void *)selector);
+    [RNSentryInternal swizzleRNSScreenViewDidAppearWithHook:^{
+        [[[RNSentryDependencyContainer sharedInstance] framesTrackerListener] startListening];
+    }];
 }
 
 @end

--- a/packages/core/ios/RNSentryReplay.mm
+++ b/packages/core/ios/RNSentryReplay.mm
@@ -1,10 +1,14 @@
 #import "RNSentryReplay.h"
+#if __has_include(<RNSentry/RNSentry-Swift.h>)
+#    import <RNSentry/RNSentry-Swift.h>
+#else
+#    import "RNSentry-Swift.h"
+#endif
 #import "RNSentryReplayBreadcrumbConverterHelper.h"
 #import "RNSentryReplayQuality.h"
 #import "RNSentryVersion.h"
 #import "Replay/RNSentryReplayMask.h"
 #import "Replay/RNSentryReplayUnmask.h"
-#import <Sentry/PrivateSentrySDKOnly.h>
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 
@@ -76,8 +80,8 @@
 {
     // We can't import RNSentryReplayMask.h here because it's Objective-C++
     // To avoid typos, we test the class existence in the tests
-    [PrivateSentrySDKOnly setRedactContainerClass:[RNSentryReplay getMaskClass]];
-    [PrivateSentrySDKOnly setIgnoreContainerClass:[RNSentryReplay getUnmaskClass]];
+    [RNSentryInternal setReplayRedactContainerClass:[RNSentryReplay getMaskClass]];
+    [RNSentryInternal setReplayIgnoreContainerClass:[RNSentryReplay getUnmaskClass]];
     [RNSentryReplayBreadcrumbConverterHelper configureSessionReplayWithConverter];
 }
 

--- a/packages/core/ios/RNSentryReplayBreadcrumbConverterHelper.m
+++ b/packages/core/ios/RNSentryReplayBreadcrumbConverterHelper.m
@@ -1,6 +1,11 @@
 #import "RNSentryReplayBreadcrumbConverterHelper.h"
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
+#    if __has_include(<RNSentry/RNSentry-Swift.h>)
+#        import <RNSentry/RNSentry-Swift.h>
+#    else
+#        import "RNSentry-Swift.h"
+#    endif
 #    import "RNSentryReplayBreadcrumbConverter.h"
 
 @implementation RNSentryReplayBreadcrumbConverterHelper
@@ -9,7 +14,7 @@
 {
     RNSentryReplayBreadcrumbConverter *breadcrumbConverter =
         [[RNSentryReplayBreadcrumbConverter alloc] init];
-    [PrivateSentrySDKOnly configureSessionReplayWith:breadcrumbConverter screenshotProvider:nil];
+    [RNSentryInternal configureReplayWithBreadcrumbConverter:breadcrumbConverter];
 }
 
 @end

--- a/packages/core/ios/RNSentrySDK.m
+++ b/packages/core/ios/RNSentrySDK.m
@@ -1,6 +1,10 @@
 #import "RNSentrySDK.h"
+#if __has_include(<RNSentry/RNSentry-Swift.h>)
+#    import <RNSentry/RNSentry-Swift.h>
+#else
+#    import "RNSentry-Swift.h"
+#endif
 #import "RNSentryStart.h"
-#import <Sentry/PrivateSentrySDKOnly.h>
 #import <Sentry/Sentry.h>
 
 static NSString *SENTRY_OPTIONS_RESOURCE_NAME = @"sentry.options";
@@ -60,7 +64,7 @@ static NSString *SENTRY_OPTIONS_RESOURCE_TYPE = @"json";
     if (options == nil) {
         // Fallback in case that options file could not be parsed.
         NSError *fallbackError = nil;
-        options = [PrivateSentrySDKOnly optionsWithDictionary:@{ } didFailWithError:&fallbackError];
+        options = [RNSentryInternal optionsFromDictionary:@{ } error:&fallbackError];
         if (fallbackError != nil) {
             NSLog(@"[RNSentry] Failed to create fallback options with error: %@",
                 fallbackError.localizedDescription);

--- a/packages/core/ios/RNSentryStart.m
+++ b/packages/core/ios/RNSentryStart.m
@@ -3,7 +3,11 @@
 #import "RNSentryReplay.h"
 #import "RNSentryVersion.h"
 
-#import <Sentry/PrivateSentrySDKOnly.h>
+#if __has_include(<RNSentry/RNSentry-Swift.h>)
+#    import <RNSentry/RNSentry-Swift.h>
+#else
+#    import "RNSentry-Swift.h"
+#endif
 #import <Sentry/Sentry.h>
 @import Sentry;
 
@@ -31,14 +35,14 @@
 
 + (void)startWithOptions:(SentryOptions *)options jsSdkVersion:(NSString *_Nullable)jsSdkVersion
 {
-    NSString *sdkVersion = [PrivateSentrySDKOnly getSdkVersionString];
-    [PrivateSentrySDKOnly setSdkName:NATIVE_SDK_NAME andVersionString:sdkVersion];
-    [PrivateSentrySDKOnly addSdkPackage:REACT_NATIVE_SDK_PACKAGE_NAME
-                                version:REACT_NATIVE_SDK_PACKAGE_VERSION];
+    NSString *sdkVersion = [RNSentryInternal sdkVersionString];
+    [RNSentryInternal setSdkName:NATIVE_SDK_NAME version:sdkVersion];
+    [RNSentryInternal addSdkPackage:REACT_NATIVE_SDK_PACKAGE_NAME
+                            version:REACT_NATIVE_SDK_PACKAGE_VERSION];
 
     if (jsSdkVersion != nil && ![jsSdkVersion isEqualToString:REACT_NATIVE_SDK_PACKAGE_VERSION]) {
         NSString *otaPackageName = [REACT_NATIVE_SDK_PACKAGE_NAME stringByAppendingString:@":ota"];
-        [PrivateSentrySDKOnly addSdkPackage:otaPackageName version:jsSdkVersion];
+        [RNSentryInternal addSdkPackage:otaPackageName version:jsSdkVersion];
     }
 
     [SentrySDK startWithOptions:options];
@@ -62,8 +66,8 @@
     [RNSentryReplay updateOptions:mutableOptions];
 #endif
 
-    SentryOptions *sentryOptions = [PrivateSentrySDKOnly optionsWithDictionary:mutableOptions
-                                                              didFailWithError:errorPointer];
+    SentryOptions *sentryOptions = [RNSentryInternal optionsFromDictionary:mutableOptions
+                                                                     error:errorPointer];
     if (*errorPointer != nil) {
         return nil;
     }
@@ -237,12 +241,11 @@
     // App Start Hybrid mode doesn't wait for didFinishLaunchNotification and the
     // didBecomeVisibleNotification as they will be missed when auto initializing from JS
     // App Start measurements are created right after the tracking starts
-    PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = options.enableAutoPerformanceTracing;
+    RNSentryInternal.appStartMeasurementHybridSDKMode = options.enableAutoPerformanceTracing;
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
     // Frames Tracking Hybrid Mode ensures tracking
     // is enabled without tracing enabled in the native SDK
-    PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode
-        = options.enableAutoPerformanceTracing;
+    RNSentryInternal.framesTrackingMeasurementHybridSDKMode = options.enableAutoPerformanceTracing;
 #endif
 }
 
@@ -301,8 +304,8 @@ static bool sentHybridSdkDidBecomeActive = NO;
     // If the app is active/in foreground, and we have not sent the SentryHybridSdkDidBecomeActive
     // notification, send it.
     if (appIsActive && !sentHybridSdkDidBecomeActive
-        && (PrivateSentrySDKOnly.options.enableAutoSessionTracking
-            || PrivateSentrySDKOnly.options.enableWatchdogTerminationTracking)) {
+        && (RNSentryInternal.options.enableAutoSessionTracking
+            || RNSentryInternal.options.enableWatchdogTerminationTracking)) {
         // Updates Native App State Manager
         // https://github.com/getsentry/sentry-cocoa/blob/888a145b144b8077e03151a886520f332e47e297/Sources/Sentry/SentryAppStateManager.m#L136
         // Triggers Session Tracker

--- a/packages/core/ios/RNSentryTimeToDisplay.h
+++ b/packages/core/ios/RNSentryTimeToDisplay.h
@@ -1,6 +1,12 @@
 #import <React/RCTBridgeModule.h>
 
-static const int TIME_TO_DISPLAY_ENTRIES_MAX_SIZE = 50;
+// Declared `extern` (not `static`) so it gets external linkage and can be
+// referenced from Swift after RNSentry became a Swift-containing pod
+// (see `RNSentryInternal.swift`). With `static const` the constant has
+// internal linkage per translation unit and Swift's module import fails
+// to resolve it, breaking `RNSentryTimeToDisplayTests.swift` with
+// `Undefined symbol: _TIME_TO_DISPLAY_ENTRIES_MAX_SIZE` at link time.
+extern const int TIME_TO_DISPLAY_ENTRIES_MAX_SIZE;
 
 @interface RNSentryTimeToDisplay : NSObject
 

--- a/packages/core/ios/RNSentryTimeToDisplay.m
+++ b/packages/core/ios/RNSentryTimeToDisplay.m
@@ -2,6 +2,8 @@
 #import <QuartzCore/QuartzCore.h>
 #import <React/RCTLog.h>
 
+const int TIME_TO_DISPLAY_ENTRIES_MAX_SIZE = 50;
+
 // All static state below is accessed from the main thread (CADisplayLink, UI) and from the
 // React Native bridge / JS thread (setActiveSpanId, pop). Synchronize every access.
 @implementation RNSentryTimeToDisplay {

--- a/packages/core/ios/SentrySDKWrapper.m
+++ b/packages/core/ios/SentrySDKWrapper.m
@@ -1,4 +1,9 @@
 #import "SentrySDKWrapper.h"
+#if __has_include(<RNSentry/RNSentry-Swift.h>)
+#    import <RNSentry/RNSentry-Swift.h>
+#else
+#    import "RNSentry-Swift.h"
+#endif
 @import Sentry;
 
 @implementation SentrySDKWrapper
@@ -35,12 +40,12 @@
 
 + (BOOL)debug
 {
-    return PrivateSentrySDKOnly.options.debug;
+    return RNSentryInternal.options.debug;
 }
 
 + (NSString *)releaseName
 {
-    return PrivateSentrySDKOnly.options.releaseName;
+    return RNSentryInternal.options.releaseName;
 }
 
 @end

--- a/packages/core/ios/SentryScreenFramesWrapper.m
+++ b/packages/core/ios/SentryScreenFramesWrapper.m
@@ -1,4 +1,9 @@
 #import "SentryScreenFramesWrapper.h"
+#if __has_include(<RNSentry/RNSentry-Swift.h>)
+#    import <RNSentry/RNSentry-Swift.h>
+#else
+#    import "RNSentry-Swift.h"
+#endif
 @import Sentry;
 
 #if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
@@ -7,7 +12,7 @@
 
 + (BOOL)canTrackFrames
 {
-    return PrivateSentrySDKOnly.currentScreenFrames != nil;
+    return RNSentryInternal.currentScreenFrames != nil;
 }
 
 + (NSNumber *)totalFrames
@@ -15,7 +20,7 @@
     if (![self canTrackFrames]) {
         return nil;
     }
-    return [NSNumber numberWithLong:PrivateSentrySDKOnly.currentScreenFrames.total];
+    return [NSNumber numberWithLong:RNSentryInternal.currentScreenFrames.total];
 }
 
 + (NSNumber *)frozenFrames
@@ -23,7 +28,7 @@
     if (![self canTrackFrames]) {
         return nil;
     }
-    return [NSNumber numberWithLong:PrivateSentrySDKOnly.currentScreenFrames.frozen];
+    return [NSNumber numberWithLong:RNSentryInternal.currentScreenFrames.frozen];
 }
 
 + (NSNumber *)slowFrames
@@ -31,7 +36,7 @@
     if (![self canTrackFrames]) {
         return nil;
     }
-    return [NSNumber numberWithLong:PrivateSentrySDKOnly.currentScreenFrames.slow];
+    return [NSNumber numberWithLong:RNSentryInternal.currentScreenFrames.slow];
 }
 
 + (NSNumber *)framesDelayForStartTimestamp:(double)startTimestampSeconds

--- a/packages/core/scripts/sentry_utils.rb
+++ b/packages/core/scripts/sentry_utils.rb
@@ -60,8 +60,8 @@ SENTRY_COCOA_XCFRAMEWORK_CHECKSUMS = {
   # `Sentry` module. `Sentry-Dynamic.xcframework` would ship the same
   # `Sentry.framework` inside but under a mismatched enclosing name, so
   # CocoaPods generates `-framework Sentry-Dynamic` and fails at link.
-  '9.19.1' => {
-    'Sentry' => 'd6d545af17e49851cda2747b0f45cde78ce08ea37709dde5a956c6b4671224e8',
+  '9.24.0' => {
+    'Sentry' => 'c530edd27b20f7c151e73d84a34ee03474e3d5ddab65ffe9d30366f80149668a',
   },
 }.freeze
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description

Re-lands #6380 (the `PrivateSentrySDKOnly` → `SentrySDK.internal` migration), which shipped in 8.19.0 and was reverted in 8.20.0 by #6491, now that the underlying sentry-cocoa bug is fixed.

Three parts:

1. **Bump sentry-cocoa 9.19.1 → 9.24.0** (podspec + xcframework SHA256, via `scripts/update-cocoa.sh set-version 9.24.0`).
2. **Revert the revert** of #6380 — applied cleanly, no conflicts. The only commits touching `packages/core/ios` since the revert were the two release commits.
3. **New regression guard** — `RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryScreenshotSourceTests.swift`.

Re-landing also restores the two improvements #6491 removed along with the migration: the `fetchViewHierarchy` nil-guard (returns `null` instead of a zero-byte attachment when capture fails) and the `RNSentryTimeToDisplay` `extern` linkage change.

> [!IMPORTANT]
> This re-introduces the RN < 0.75 requirement from 8.19.0: on React Native versions where `React-hermes` (or another RN pod) is not modularized by default (e.g. RN 0.71), users must add `use_modular_headers!` to their `ios/Podfile`. CocoaPods refuses to integrate a Swift pod against non-modular ObjC dependencies, and `RNSentryInternal.swift` makes `RNSentry` a Swift pod. Called out in the CHANGELOG.


## :bulb: Motivation and Context

Fixes #6507.

#6380 broke **all** iOS screenshot capture — Feedback Widget screenshot, `attachScreenshot`, and `Sentry.captureScreenshot()` (#6497).

Root cause was in sentry-cocoa, not in RN: constructing `SentryInternalApi` eagerly reads `SentryDependencyContainer.screenshotSource`, which was a `lazy var` whose builder returns `nil` while `startOptions` is unset. Being `lazy`, that `nil` was cached for the process lifetime. RN reads `SentrySDK.internal` before `SentrySDK.start` — from `RNSentryStart` itself, and from JS integrations calling native methods like `fetchNativeAppStart` / `fetchNativeSdkInfo` during init — so the source was reliably poisoned. A targeted RN-side fix wasn't possible because JS controls the timing of those calls, hence the full revert.

getsentry/sentry-cocoa#8578 makes `screenshotSource` a computed property so `getOptionalLazyVar` re-runs the builder until `startOptions` is available, and only then caches. It shipped in **9.24.0**.

I also confirmed:
- `SentrySDK.internal` is a computed property that builds a fresh `SentryInternalApi` per access, so the eager read in `SentryInternalScreenshotApi.init` is harmless once `screenshotSource` rebuilds.
- `viewHierarchyProvider` is still a `lazy var`, but its builder never touches `startOptions`, so it cannot be poisoned the same way.
- No API drift in `Sources/Swift/HybridSDK/` between 9.19.1 and 9.24.0 — the only diffs are `@_implementationOnly import` → `internal import`. Every symbol `RNSentryInternal.swift` bridges still exists with the same signature.
- Nothing in the 9.20.0–9.24.0 cocoa changelog affects RN. `enableReplayNetworkDetailsCapturing` was removed in 9.22.0 but RN never set it.


## :green_heart: How did you test it?

**New regression test** (`RNSentryScreenshotSourceTests`): reads `SentrySDK.internal` before `SentrySDK.start`, then starts via `RNSentryStart.start` with `attachScreenshot` and asserts `SentrySDK.internal.screenshot.capture()` is non-nil. Verified it is not vacuous:

| sentry-cocoa | Result |
|---|---|
| 9.19.1 (buggy) | ❌ `XCTAssertNotNil failed` — reproduces #6497 |
| 9.24.0 (fixed) | ✅ passes |

**Full native suite** — `RNSentryCocoaTester`, Release config, iPhone simulator, Xcode 26.1: **163 tests, 0 failures**.

**Linters**: `swiftlint --strict` clean (13 files, 0 violations), `clang-format` clean.

No JS/TS source changed, so no api-report or JS test impact.


## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

Needs the `ready-to-merge` label before merging so the native / E2E / sample-app workflows run — the iOS `feedback` E2E flow is what surfaced #6497 in the first place and should be confirmed green.

Two pre-existing problems found while writing the regression test, both unrelated to this change and left for follow-up issues:

1. **`RNSentryStartTests.swift` and `RNSentryStartFromFileTests.swift` are not in the Xcode test target.** They were dropped from `project.pbxproj` around the v7 merge (`6ab6b160`) and have not compiled or run since. They no longer build (`Options.enableTracing` was removed in cocoa v9), and once that's fixed every test in them crashes — see below. I intentionally did not re-enable them here; that's why the new regression test lives in its own file.
2. **`RNSentrySDK.start` proceeds with `options == nil`** when `sentry.options.json` is absent or unparseable (`packages/core/ios/RNSentrySDK.m` L64-72). The `@{}` fallback also fails validation ("Invalid DSN URL") and returns `nil`, but the code carries on into `updateWithReactDefaults:` / `configureOptions(...)` / `startWithOptions:`. Identical before and after #6380 — both `PrivateSentrySDKOnly.optionsWithDictionary:didFailWithError:` and `SentrySDK.internal.options(fromDictionary:)` funnel into the same `SentryOptionsInternal initWithDict:`, which returns `nil` on failure. From ObjC it silently no-ops; from Swift (`options.dsn = …` on an implicitly-unwrapped `SentryOptions!`) it segfaults.
