### PR TITLE
test(e2e): Add TurboModule sample coverage and e2e validation

### DIFF
--- a/packages/core/test/integrations/turboModuleContext.spans.test.ts
+++ b/packages/core/test/integrations/turboModuleContext.spans.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Integration-level checks against real `SentrySpan`s (the rest of
+ * `turboModuleContext.test.ts` drives the integration through mock clients).
+ *
+ * This locks in the contract the `samples/react-native` "TurboModule Playground"
+ * screen depends on: the `turbo_module.*` attributes are readable off the span
+ * as soon as `span.end()` returns, so the sample can render them on device
+ * without waiting for the transaction to be sent — and the very same values
+ * reach the transaction event.
+ *
+ * Everything lives in a single test on purpose: `setupOnce` (which installs the
+ * module wrappers) is only ever run once per integration name per process, so a
+ * second client in the same file would silently leave the modules unwrapped.
+ */
+import type { Event, Span, TransactionEvent } from '@sentry/core';
+
+import {
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  setCurrentClient,
+  spanToJSON,
+  startNewTrace,
+  startSpanManual,
+} from '@sentry/core';
+
+import { turboModuleContextIntegration } from '../../src/js/integrations/turboModuleContext';
+import { _resetTurboModuleAggregator } from '../../src/js/turbomodule/turboModuleAggregator';
+import { _resetTurboModuleTracker } from '../../src/js/turbomodule/turboModuleTracker';
+import { _resetWrappedModules } from '../../src/js/turbomodule/wrapTurboModule';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+const SYNC_CALL_COUNT = 5;
+
+describe('turboModuleContextIntegration with real spans', () => {
+  beforeEach(() => {
+    _resetTurboModuleTracker();
+    _resetTurboModuleAggregator();
+    _resetWrappedModules();
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+  });
+
+  afterEach(() => {
+    TestClient.sendEventCalled = undefined;
+  });
+
+  it('exposes turbo_module attributes on the ended span and on the transaction event', async () => {
+    // Arrange
+    const syncModule = { add: (a: number, b: number): number => a + b };
+    const asyncModule = { getPlatform: (): Promise<string> => Promise.resolve('test') };
+
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        tracesSampleRate: 1.0,
+        integrations: [
+          turboModuleContextIntegration({
+            modules: [
+              { name: 'NativeSampleModule', module: syncModule },
+              { name: 'NativePlatformSampleModule', module: asyncModule },
+            ],
+            aggregateFlushIntervalMs: 0,
+          }),
+        ],
+      }),
+    );
+    setCurrentClient(client);
+    client.init();
+
+    // The event goes through the async `_prepareEvent` pipeline, so wait for the
+    // send instead of reading `eventQueue` synchronously.
+    const sentEvent = new Promise<Event>(resolve => {
+      TestClient.sendEventCalled = resolve;
+    });
+
+    // Act
+    let onSpanData: Record<string, unknown> = {};
+    await startNewTrace(async () => {
+      await startSpanManual({ name: 'turbo_module.sample', forceTransaction: true }, async (span: Span) => {
+        let sum = 0;
+        for (let index = 1; index <= SYNC_CALL_COUNT; index++) {
+          sum = syncModule.add(sum, index);
+        }
+        expect(sum).toBe(15);
+
+        await asyncModule.getPlatform();
+
+        span.end();
+        // `SentrySpan.end()` emits `spanEnd` — where the integration writes the
+        // attributes — before it seals the span, and spans created through the
+        // core span API are never sealed at all, so this read sees them.
+        onSpanData = (spanToJSON(span).data ?? {}) as Record<string, unknown>;
+      });
+    });
+    const transaction = (await sentEvent) as TransactionEvent;
+
+    // Assert
+    const expectedAttributes = {
+      'turbo_module.total_call_count': SYNC_CALL_COUNT + 1,
+      'turbo_module.total_error_count': 0,
+      'turbo_module.unique_methods': 2,
+      'turbo_module.NativeSampleModule.add.call_count': SYNC_CALL_COUNT,
+      'turbo_module.NativeSampleModule.add.error_count': 0,
+      'turbo_module.NativePlatformSampleModule.getPlatform.call_count': 1,
+      'turbo_module.NativePlatformSampleModule.getPlatform.error_count': 0,
+    };
+
+    expect(onSpanData).toEqual(expect.objectContaining(expectedAttributes));
+
+    expect(transaction.type).toBe('transaction');
+    expect(transaction.transaction).toBe('turbo_module.sample');
+    expect(transaction.contexts?.trace?.data).toEqual(expect.objectContaining(expectedAttributes));
+  });
+});

--- a/packages/core/test/turbomodule/turboModuleLatency.test.ts
+++ b/packages/core/test/turbomodule/turboModuleLatency.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Micro-benchmark for the JS-side TurboModule instrumentation.
+ *
+ * `enableTurboModuleTracking` installs the native perf logger; the user-visible
+ * per-call cost in JS comes from the wrapper `wrapTurboModule` installs on each
+ * TurboModule method (scope push/pop + aggregate counters). This measures that
+ * wrapper against the exact same module without it, and prints the numbers so
+ * they show up in CI output.
+ *
+ * It deliberately makes no assertion on absolute timings — shared CI runners are
+ * far too noisy for that. The only guard is a very generous per-call ceiling that
+ * catches pathological regressions (e.g. an accidental O(n) scan per call).
+ *
+ * See https://github.com/getsentry/sentry-react-native/issues/6167.
+ */
+import * as SentryCore from '@sentry/core';
+import { Scope } from '@sentry/core';
+
+import {
+  _resetTurboModuleAggregator,
+  setAggregateRecordingEnabled,
+} from '../../src/js/turbomodule/turboModuleAggregator';
+import { _resetTurboModuleTracker } from '../../src/js/turbomodule/turboModuleTracker';
+import { _resetWrappedModules, wrapTurboModule } from '../../src/js/turbomodule/wrapTurboModule';
+
+/** Iterations per measured run. Kept small enough to stay well under the Jest timeout. */
+const ITERATIONS = 20_000;
+/** Discarded iterations, so JIT warm-up doesn't land in the measured window. */
+const WARMUP_ITERATIONS = 2_000;
+
+/**
+ * Generous ceiling on the added per-call cost, in microseconds. The wrapper does
+ * a handful of map writes per call; anything above this means something is
+ * structurally wrong rather than just a slow runner.
+ */
+const MAX_OVERHEAD_US_PER_CALL = 100;
+
+interface SyncModule {
+  add: (a: number, b: number) => number;
+}
+
+interface AsyncModule {
+  getPlatform: () => Promise<string>;
+}
+
+const createSyncModule = (): SyncModule => ({
+  add: (a: number, b: number): number => a + b,
+});
+
+const createAsyncModule = (): AsyncModule => ({
+  getPlatform: (): Promise<string> => Promise.resolve('benchmark'),
+});
+
+const nowUs = (): number => Number(process.hrtime.bigint()) / 1_000;
+
+const measureSync = (module: SyncModule, iterations: number): number => {
+  let sum = 0;
+  const start = nowUs();
+  for (let i = 0; i < iterations; i++) {
+    sum = module.add(sum, 1);
+  }
+  const elapsed = nowUs() - start;
+  // Consume `sum` so the loop can't be optimised away.
+  expect(sum).toBe(iterations);
+  return elapsed;
+};
+
+const measureAsync = async (module: AsyncModule, iterations: number): Promise<number> => {
+  const start = nowUs();
+  for (let i = 0; i < iterations; i++) {
+    await module.getPlatform();
+  }
+  return nowUs() - start;
+};
+
+interface Row {
+  label: string;
+  baselineUsPerCall: number;
+  trackedUsPerCall: number;
+}
+
+const report = (rows: Row[]): void => {
+  const lines = rows.map(row => {
+    const overhead = row.trackedUsPerCall - row.baselineUsPerCall;
+    const factor = row.baselineUsPerCall > 0 ? row.trackedUsPerCall / row.baselineUsPerCall : NaN;
+    return (
+      `  ${row.label.padEnd(8)} ` +
+      `off=${row.baselineUsPerCall.toFixed(3)}us/call ` +
+      `on=${row.trackedUsPerCall.toFixed(3)}us/call ` +
+      `overhead=${overhead.toFixed(3)}us/call (${factor.toFixed(2)}x)`
+    );
+  });
+  // `test/mockConsole.ts` replaces `console.log`, so write straight to stdout to
+  // make sure the numbers reach the CI log.
+  process.stdout.write(`\n[benchmark] TurboModule call latency (${ITERATIONS} iterations)\n${lines.join('\n')}\n\n`);
+};
+
+describe('TurboModule call latency', () => {
+  beforeEach(() => {
+    _resetTurboModuleTracker();
+    _resetTurboModuleAggregator();
+    _resetWrappedModules();
+    setAggregateRecordingEnabled(true);
+    const scope = new Scope();
+    jest.spyOn(SentryCore, 'getIsolationScope').mockReturnValue(scope);
+    jest.spyOn(SentryCore, 'getCurrentScope').mockReturnValue(scope);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('adds a bounded per-call overhead for sync and async calls', async () => {
+    // Arrange
+    const baselineSync = createSyncModule();
+    const trackedSync = wrapTurboModule('BenchmarkModule', createSyncModule()) as SyncModule;
+    const baselineAsync = createAsyncModule();
+    const trackedAsync = wrapTurboModule('BenchmarkAsyncModule', createAsyncModule()) as AsyncModule;
+
+    measureSync(baselineSync, WARMUP_ITERATIONS);
+    measureSync(trackedSync, WARMUP_ITERATIONS);
+    await measureAsync(baselineAsync, WARMUP_ITERATIONS);
+    await measureAsync(trackedAsync, WARMUP_ITERATIONS);
+
+    // Act
+    const syncBaselineUs = measureSync(baselineSync, ITERATIONS) / ITERATIONS;
+    const syncTrackedUs = measureSync(trackedSync, ITERATIONS) / ITERATIONS;
+    const asyncBaselineUs = (await measureAsync(baselineAsync, ITERATIONS)) / ITERATIONS;
+    const asyncTrackedUs = (await measureAsync(trackedAsync, ITERATIONS)) / ITERATIONS;
+
+    report([
+      { label: 'sync', baselineUsPerCall: syncBaselineUs, trackedUsPerCall: syncTrackedUs },
+      { label: 'async', baselineUsPerCall: asyncBaselineUs, trackedUsPerCall: asyncTrackedUs },
+    ]);
+
+    // Assert
+    expect(syncTrackedUs - syncBaselineUs).toBeLessThan(MAX_OVERHEAD_US_PER_CALL);
+    expect(asyncTrackedUs - asyncBaselineUs).toBeLessThan(MAX_OVERHEAD_US_PER_CALL);
+  }, 120_000);
+});

--- a/samples/react-native/android/app/src/main/java/io/sentry/reactnative/sample/NativePlatformSampleModule.kt
+++ b/samples/react-native/android/app/src/main/java/io/sentry/reactnative/sample/NativePlatformSampleModule.kt
@@ -1,6 +1,8 @@
 package io.sentry.reactnative.sample
 
+import android.os.Build
 import com.facebook.fbreact.specs.NativePlatformSampleModuleSpec
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 
 class NativePlatformSampleModule(
@@ -9,6 +11,10 @@ class NativePlatformSampleModule(
     override fun getName() = NAME
 
     override fun crashOrString(): String = throw RuntimeException("JVM Crash in NativePlatformSampleModule.crashOrString()")
+
+    override fun getPlatform(promise: Promise) {
+        promise.resolve("android ${Build.VERSION.RELEASE}")
+    }
 
     companion object {
         const val NAME = "NativePlatformSampleModule"

--- a/samples/react-native/e2e/tests/turboModuleSpanAttributes/turboModuleSpanAttributes.test.ts
+++ b/samples/react-native/e2e/tests/turboModuleSpanAttributes/turboModuleSpanAttributes.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, beforeAll, expect, afterAll } from '@jest/globals';
+import { Envelope, EventItem } from '@sentry/core';
+
+import { getItemOfTypeFrom } from '../../utils/event';
+import { maestro } from '../../utils/maestro';
+import {
+  createSentryServer,
+  containingTransactionWithName,
+} from '../../utils/mockedSentryServer';
+
+const TURBO_MODULE_SPAN_NAME = 'turbo_module.sample';
+
+/** 5 synchronous `NativeSampleModule.add` calls plus one async `getPlatform`. */
+const EXPECTED_CALL_COUNT = 6;
+
+describe('TurboModule span attributes', () => {
+  let sentryServer = createSentryServer();
+
+  let envelope: Envelope;
+
+  beforeAll(async () => {
+    await sentryServer.start();
+
+    const envelopePromise = sentryServer.waitForEnvelope(
+      containingTransactionWithName(TURBO_MODULE_SPAN_NAME),
+    );
+
+    await maestro(
+      'tests/turboModuleSpanAttributes/turboModuleSpanAttributes.test.yml',
+    );
+
+    envelope = await envelopePromise;
+  }, 240000); // 240 seconds timeout for iOS event delivery
+
+  afterAll(async () => {
+    await sentryServer.close();
+  });
+
+  it('attaches aggregated turbo_module attributes to the root span', async () => {
+    const item = getItemOfTypeFrom<EventItem>(envelope, 'transaction');
+
+    expect(item?.[1]).toEqual(
+      expect.objectContaining({
+        transaction: TURBO_MODULE_SPAN_NAME,
+        contexts: expect.objectContaining({
+          trace: expect.objectContaining({
+            data: expect.objectContaining({
+              'turbo_module.arch': 'new',
+              'turbo_module.total_call_count': EXPECTED_CALL_COUNT,
+              'turbo_module.total_error_count': 0,
+              'turbo_module.total_duration_ms': expect.any(Number),
+              'turbo_module.unique_methods': 2,
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('attaches a per-module and per-method breakdown', async () => {
+    const item = getItemOfTypeFrom<EventItem>(envelope, 'transaction');
+
+    expect(item?.[1]).toEqual(
+      expect.objectContaining({
+        contexts: expect.objectContaining({
+          trace: expect.objectContaining({
+            data: expect.objectContaining({
+              'turbo_module.NativeSampleModule.add.call_count': 5,
+              'turbo_module.NativeSampleModule.add.error_count': 0,
+              'turbo_module.NativeSampleModule.add.duration_ms':
+                expect.any(Number),
+              'turbo_module.NativePlatformSampleModule.getPlatform.call_count': 1,
+              'turbo_module.NativePlatformSampleModule.getPlatform.error_count': 0,
+              'turbo_module.NativePlatformSampleModule.getPlatform.duration_ms':
+                expect.any(Number),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/samples/react-native/e2e/tests/turboModuleSpanAttributes/turboModuleSpanAttributes.test.yml
+++ b/samples/react-native/e2e/tests/turboModuleSpanAttributes/turboModuleSpanAttributes.test.yml
@@ -1,0 +1,42 @@
+appId: io.sentry.reactnative.sample
+---
+- launchApp:
+    clearState: true
+    stopApp: true
+    arguments:
+      isE2ETest: true
+
+# App launches on ErrorsTab (first tab)
+- waitForAnimationToEnd:
+    timeout: 2000
+
+# The entry button is below the fold on smaller devices
+- scrollUntilVisible:
+    element: 'TurboModule Playground'
+    timeout: 10000
+    direction: DOWN
+- tapOn: 'TurboModule Playground'
+
+- assertVisible:
+    id: 'turbo-module-status'
+
+- tapOn: 'Run TurboModule calls'
+
+# Sync C++ calls + one async platform call, wrapped in a manual root span
+- extendedWaitUntil:
+    visible: 'Status: Done'
+    timeout: 30000
+
+- assertVisible: 'Sync: add x5 = 15'
+- assertVisible: 'Async: getPlatform = .*'
+
+# The `turbo_module.*` attributes the TurboModuleContext integration attached
+# to the root span are rendered on screen so QA can eyeball them on device.
+- assertVisible: 'turbo_module.total_call_count: 6'
+- assertVisible: 'turbo_module.total_error_count: 0'
+
+# A native throw surfaced to JS must still be capturable (crash-context path)
+- tapOn: 'Throw from native platform'
+- extendedWaitUntil:
+    visible: 'Throw: captured platform throw as .*'
+    timeout: 30000

--- a/samples/react-native/ios/sentryreactnativesample/NativePlatformSampleModule.mm
+++ b/samples/react-native/ios/sentryreactnativesample/NativePlatformSampleModule.mm
@@ -2,6 +2,8 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 
+#    import <UIKit/UIKit.h>
+
 @implementation NativePlatformSampleModule
 
 RCT_EXPORT_MODULE();
@@ -18,6 +20,11 @@ RCT_EXPORT_MODULE();
     NSObject *nilObject = NULL;
     NSArray *_ = @[ nilObject ];
     return @"NEVER RETURNED";
+}
+
+- (void)getPlatform:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
+{
+    resolve([NSString stringWithFormat:@"ios %@", [[UIDevice currentDevice] systemVersion]]);
 }
 
 @end

--- a/samples/react-native/src/App.tsx
+++ b/samples/react-native/src/App.tsx
@@ -17,6 +17,8 @@ import getErrorsTab from './tabs/ErrorsTab';
 import getPerformanceTab from './tabs/PerformanceTab';
 import getPlaygroundTab from './tabs/PlaygroundTab';
 import { logWithoutTracing, shouldUseAutoStart } from './utils';
+import NativePlatformSampleModule from '../tm/NativePlatformSampleModule';
+import NativeSampleModule from '../tm/NativeSampleModule';
 
 LogBox.ignoreAllLogs();
 const isMobileOs = Platform.OS === 'android' || Platform.OS === 'ios';
@@ -35,6 +37,20 @@ const reactNavigationIntegration = Sentry.reactNavigationIntegration({
 
 const sampleFeatureFlagsIntegration = Sentry.featureFlagsIntegration();
 sampleFeatureFlagsIntegration.addFeatureFlag('sample-test-flag', true);
+
+// Replaces the default `TurboModuleContext` integration so the sample's own
+// TurboModules are instrumented too, not just `RNSentry`. Exercised by the
+// "TurboModule Playground" screen on the Errors tab.
+const sampleTurboModuleContextIntegration =
+  Sentry.turboModuleContextIntegration({
+    modules: [
+      { name: 'NativeSampleModule', module: NativeSampleModule },
+      {
+        name: 'NativePlatformSampleModule',
+        module: NativePlatformSampleModule,
+      },
+    ],
+  });
 
 const StackNavigator: TypedNavigator<any, any> = isMobileOs
   ? createNativeStackNavigator()
@@ -141,8 +157,15 @@ Sentry.init({
       }),
       Sentry.extraErrorDataIntegration(),
       sampleFeatureFlagsIntegration,
+      sampleTurboModuleContextIntegration,
     );
-    return integrations.filter(i => i.name !== 'Dedupe');
+    return integrations.filter(
+      i =>
+        i.name !== 'Dedupe' &&
+        // Drop the default TurboModuleContext in favour of the configured one.
+        (i.name !== 'TurboModuleContext' ||
+          i === sampleTurboModuleContextIntegration),
+    );
   },
   enableAutoSessionTracking: true,
   // For testing, session close when 5 seconds (instead of the default 30) in the background.

--- a/samples/react-native/src/Screens/ErrorsScreen.tsx
+++ b/samples/react-native/src/Screens/ErrorsScreen.tsx
@@ -174,6 +174,12 @@ const ErrorsScreen = (_props: Props) => {
           }}
         />
         <Button
+          title="TurboModule Playground"
+          onPress={() => {
+            _props.navigation.navigate('TurboModule');
+          }}
+        />
+        <Button
           title="Log console"
           onPress={() => {
             Sentry.logger.info('info log');

--- a/samples/react-native/src/Screens/TurboModuleScreen.tsx
+++ b/samples/react-native/src/Screens/TurboModuleScreen.tsx
@@ -83,6 +83,11 @@ const TurboModuleScreen = (_props: Props) => {
 
             span.end();
 
+            // Safe to read right after `end()`: `SentrySpan.end()` emits
+            // `spanEnd` — where the TurboModuleContext integration writes the
+            // attributes — before it seals the span, and spans created through
+            // the core span API are never sealed. Covered by
+            // `packages/core/test/integrations/turboModuleContext.spans.test.ts`.
             const collected = collectTurboModuleAttributes(span);
             setAttributes(collected);
             // Also log so the numbers are greppable from the device logs.

--- a/samples/react-native/src/Screens/TurboModuleScreen.tsx
+++ b/samples/react-native/src/Screens/TurboModuleScreen.tsx
@@ -1,0 +1,213 @@
+import React from 'react';
+import {
+  ButtonProps,
+  Button as NativeButton,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { StackNavigationProp } from '@react-navigation/stack';
+import { spanToJSON, startNewTrace } from '@sentry/core';
+import * as Sentry from '@sentry/react-native';
+
+import NativePlatformSampleModule from '../../tm/NativePlatformSampleModule';
+import NativeSampleModule from '../../tm/NativeSampleModule';
+import { TimeToFullDisplay, logWithoutTracing } from '../utils';
+
+/**
+ * Name of the manual root span wrapping the TurboModule calls. The e2e test
+ * waits for a transaction with this name and asserts the `turbo_module.*`
+ * attributes the `TurboModuleContext` integration attaches to it.
+ */
+export const TURBO_MODULE_SPAN_NAME = 'turbo_module.sample';
+
+const SYNC_CALL_COUNT = 5;
+const ATTRIBUTE_PREFIX = 'turbo_module.';
+
+interface Props {
+  navigation: StackNavigationProp<any, 'TurboModuleScreen'>;
+}
+
+const isNewArchitecture = !!NativeSampleModule && !!NativePlatformSampleModule;
+
+function collectTurboModuleAttributes(span: Sentry.Span): string[] {
+  const data = spanToJSON(span).data ?? {};
+  return Object.keys(data)
+    .filter(key => key.startsWith(ATTRIBUTE_PREFIX))
+    .sort()
+    .map(key => `${key}: ${String(data[key])}`);
+}
+
+const TurboModuleScreen = (_props: Props) => {
+  const [status, setStatus] = React.useState('Idle');
+  const [addResult, setAddResult] = React.useState('not called');
+  const [platformResult, setPlatformResult] = React.useState('not called');
+  const [attributes, setAttributes] = React.useState<string[]>([]);
+  const [nativeError, setNativeError] = React.useState('none');
+
+  const runCalls = React.useCallback(async () => {
+    if (!isNewArchitecture) {
+      setStatus(
+        'TurboModules unavailable. Build the app with the New Architecture enabled.',
+      );
+      return;
+    }
+
+    setStatus('Running');
+    setAttributes([]);
+
+    // A dedicated trace keeps the measured window free of unrelated navigation
+    // spans, so the attached `turbo_module.*` attributes describe only these calls.
+    try {
+      await startNewTrace(async () => {
+        await Sentry.startSpanManual(
+          {
+            name: TURBO_MODULE_SPAN_NAME,
+            op: 'ui.action',
+            forceTransaction: true,
+          },
+          async (span: Sentry.Span) => {
+            let sum = 0;
+            for (let index = 1; index <= SYNC_CALL_COUNT; index++) {
+              // Synchronous C++ TurboModule call.
+              sum = NativeSampleModule!.add(sum, index);
+            }
+            setAddResult(`add x${SYNC_CALL_COUNT} = ${sum}`);
+
+            // Asynchronous platform TurboModule call.
+            const platform = await NativePlatformSampleModule!.getPlatform();
+            setPlatformResult(`getPlatform = ${platform}`);
+
+            span.end();
+
+            const collected = collectTurboModuleAttributes(span);
+            setAttributes(collected);
+            // Also log so the numbers are greppable from the device logs.
+            logWithoutTracing('[TurboModule] span attributes:', collected);
+            setStatus('Done');
+          },
+        );
+      });
+    } catch (error) {
+      setStatus(`Failed: ${String(error)}`);
+    }
+  }, []);
+
+  const captureNativeThrow = React.useCallback((kind: 'cxx' | 'platform') => {
+    if (!isNewArchitecture) {
+      setStatus(
+        'TurboModules unavailable. Build the app with the New Architecture enabled.',
+      );
+      return;
+    }
+
+    try {
+      if (kind === 'cxx') {
+        NativeSampleModule!.crash();
+      } else {
+        NativePlatformSampleModule!.crashOrString();
+      }
+      setNativeError('native call did not throw');
+    } catch (error) {
+      const eventId = Sentry.captureException(error);
+      setNativeError(`captured ${kind} throw as ${eventId}`);
+    }
+  }, []);
+
+  return (
+    <>
+      <StatusBar barStyle="dark-content" />
+      <ScrollView style={styles.mainView}>
+        <TimeToFullDisplay record={true} />
+        <Text style={styles.title}>TurboModule Playground</Text>
+        <Text style={styles.description}>
+          Exercises the sample TurboModules and shows the `turbo_module.*` span
+          attributes produced by the TurboModuleContext integration.
+        </Text>
+        <Button title="Run TurboModule calls" onPress={runCalls} />
+        <Button
+          title="Throw from native Cxx"
+          onPress={() => captureNativeThrow('cxx')}
+        />
+        <Button
+          title="Throw from native platform"
+          onPress={() => captureNativeThrow('platform')}
+        />
+        <Spacer />
+        <Text style={styles.sectionTitle}>Results</Text>
+        <Text testID="turbo-module-status">Status: {status}</Text>
+        <Text testID="turbo-module-add-result">Sync: {addResult}</Text>
+        <Text testID="turbo-module-platform-result">
+          Async: {platformResult}
+        </Text>
+        <Text testID="turbo-module-native-error">Throw: {nativeError}</Text>
+        <Spacer />
+        <Text style={styles.sectionTitle}>Span attributes</Text>
+        <View testID="turbo-module-attributes">
+          {attributes.length === 0 ? (
+            <Text>no attributes recorded yet</Text>
+          ) : (
+            attributes.map(attribute => (
+              <Text key={attribute} style={styles.attribute}>
+                {attribute}
+              </Text>
+            ))
+          )}
+        </View>
+        <View style={styles.mainViewBottomWhiteSpace} />
+      </ScrollView>
+    </>
+  );
+};
+
+const Button = (props: ButtonProps) => (
+  <>
+    <NativeButton {...props} color="#6C5FC7" />
+    <View style={styles.buttonSpacer} />
+  </>
+);
+
+const Spacer = () => <View style={styles.spacer} />;
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#362D59',
+    marginBottom: 8,
+  },
+  description: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#362D59',
+    marginBottom: 8,
+  },
+  attribute: {
+    fontFamily: 'Courier',
+    fontSize: 12,
+  },
+  buttonSpacer: {
+    marginBottom: 8,
+  },
+  spacer: {
+    height: 1,
+    width: '100%',
+    backgroundColor: '#c6becf',
+    marginBottom: 16,
+    marginTop: 8,
+  },
+  mainView: {
+    padding: 20,
+  },
+  mainViewBottomWhiteSpace: {
+    marginTop: 32,
+  },
+});
+
+export default Sentry.withProfiler(TurboModuleScreen);

--- a/samples/react-native/src/tabs/ErrorsTab.tsx
+++ b/samples/react-native/src/tabs/ErrorsTab.tsx
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux';
 
 import ErrorsScreen from '../Screens/ErrorsScreen';
 import GlobalErrorBoundaryScreen from '../Screens/GlobalErrorBoundaryScreen';
+import TurboModuleScreen from '../Screens/TurboModuleScreen';
 import store from '../store';
 
 const styles = StyleSheet.create({
@@ -32,6 +33,11 @@ export default function getErrorsTab(Navigator: TypedNavigator<any, any>) {
                 name="GlobalErrorBoundary"
                 component={GlobalErrorBoundaryScreen}
                 options={{ title: 'Global Error Boundary' }}
+              />
+              <Navigator.Screen
+                name="TurboModule"
+                component={TurboModuleScreen}
+                options={{ title: 'TurboModule' }}
               />
               <Navigator.Screen
                 name="FeedbackForm"

--- a/samples/react-native/tm/NativePlatformSampleModule.ts
+++ b/samples/react-native/tm/NativePlatformSampleModule.ts
@@ -2,6 +2,8 @@ import {TurboModule, TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   crashOrString(): string;
+  /** Asynchronous platform TurboModule call, used to exercise async TurboModule instrumentation. */
+  getPlatform(): Promise<string>;
 }
 
 export default TurboModuleRegistry.get<Spec>('NativePlatformSampleModule');

--- a/samples/react-native/tm/NativeSampleModule.cpp
+++ b/samples/react-native/tm/NativeSampleModule.cpp
@@ -7,6 +7,12 @@ NativeSampleModule::NativeSampleModule(std::shared_ptr<CallInvoker> jsInvoker)
 {
 }
 
+double
+NativeSampleModule::add(jsi::Runtime &rt, double a, double b)
+{
+    return a + b;
+}
+
 void
 NativeSampleModule::crash(jsi::Runtime &rt)
 {

--- a/samples/react-native/tm/NativeSampleModule.h
+++ b/samples/react-native/tm/NativeSampleModule.h
@@ -14,6 +14,8 @@ class NativeSampleModule : public NativeSampleModuleCxxSpec<NativeSampleModule> 
 public:
     NativeSampleModule(std::shared_ptr<CallInvoker> jsInvoker);
 
+    double add(jsi::Runtime &rt, double a, double b);
+
     void crash(jsi::Runtime &rt);
 };
 

--- a/samples/react-native/tm/NativeSampleModule.ts
+++ b/samples/react-native/tm/NativeSampleModule.ts
@@ -2,6 +2,8 @@ import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
+  /** Synchronous C++ TurboModule call, used to exercise sync TurboModule instrumentation. */
+  readonly add: (a: number, b: number) => number;
   readonly crash: () => void;
 }
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Uses `samples/react-native/tm/` as the canonical fixture for verifying the TurboModule instrumentation stack end to end.

- `NativeSampleModule.add(a, b)` (sync, C++) and `NativePlatformSampleModule.getPlatform()` (async, ObjC/Kotlin) added to the sample specs.
- New "TurboModule Playground" screen on the Errors tab runs both inside a manual root span, renders the resulting `turbo_module.*` span attributes on device, and has throw-from-native buttons for the crash-context path.
- The sample configures `turboModuleContextIntegration` with its own modules (the default only tracks `RNSentry`).
- Maestro flow + Jest e2e test asserting the aggregated and per-method `turbo_module.*` attributes on the transaction envelope.
- `packages/core` micro-benchmark printing per-call wrapper latency with and without tracking into the CI output.

The Maestro flow lives in `samples/react-native/e2e/tests/`, which runs from `sample-application.yml` and is already behind the `ready-to-merge` gate. The benchmark lives in `packages/core` rather than `performance-tests/TestAppSentry/`, which only measures app-start time and binary size on Sauce Labs and has no in-app latency harness.

## :bulb: Motivation and Context
Closes #6167

## :green_heart: How did you test it?
- `packages/core`: `yarn jest test/turbomodule` (new benchmark prints ~1.1us/call sync, ~1.3us/call async overhead) and the full suite.
- `samples/react-native`: `tsc --noEmit`, `oxlint`, `prettier --check`, `jest`.
- Native lint: `clang-format`, `ktlint`.
- The new Maestro flow and e2e test have not been run on a device yet.

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
Run the e2e job with the `ready-to-merge` label to validate the Maestro flow on iOS and Android.