### PR TITLE
Convert union type to string to fix codegen error

### DIFF
--- a/packages/core/src/js/NativeRNSentry.ts
+++ b/packages/core/src/js/NativeRNSentry.ts
@@ -108,7 +108,8 @@ export type NativeStackFrames = {
 };
 
 export type NativeAppStartResponse = {
-  type: 'cold' | 'warm' | 'unknown';
+  /** 'cold' | 'warm' | 'unknown' */
+  type: string;
   has_fetched: boolean;
   app_start_timestamp_ms?: number;
   spans: {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Running `assemble` on Android errors with the message:
> Unsupported type for param "type". Found: StringLiteralUnionTypeAnnotation


## :bulb: Motivation and Context
Union types are no longer supported in React Native Codegen. I'm not able to find documentation confirming this, but it appears to be an issue others have encountered.

Related:
https://github.com/react/react-native/issues/49566
https://github.com/getsentry/sentry-react-native/issues/4870
https://github.com/react-native-webview/react-native-webview/issues/3767