### PR TITLE
ci: Replace secrets: inherit with explicit SENTRY_AUTH_TOKEN pass

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -37,7 +37,8 @@ jobs:
       caller_ref: ${{ github.ref }}
   auth_token_check:
     uses: ./.github/workflows/skip-ci-noauth.yml
-    secrets: inherit
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   metrics:
     runs-on: ${{ matrix.runs-on }}
     needs: [diff_check, detect-changes, auth_token_check]

--- a/.github/workflows/skip-ci-noauth.yml
+++ b/.github/workflows/skip-ci-noauth.yml
@@ -6,6 +6,9 @@ on:
       skip_ci:
         description: "Value 'true' if the CI cannot access the SENTRY_AUTH_TOKEN, otherwise, not defined."
         value: ${{ jobs.auth_token_check.outputs.skip_ci }}
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: false
 
 jobs:
   auth_token_check:


### PR DESCRIPTION
## Summary
- The `auth_token_check` job in `e2e-v2.yml` used `secrets: inherit` when calling `skip-ci-noauth.yml`, exposing every repository secret to that workflow.
- `skip-ci-noauth.yml` only reads `secrets.SENTRY_AUTH_TOKEN` (to check whether it's accessible) but never declared it under `workflow_call.secrets`.
- Added an explicit `secrets.SENTRY_AUTH_TOKEN` declaration to `skip-ci-noauth.yml` and updated `e2e-v2.yml` to pass only that secret by name.

## Test plan
- [x] Confirmed `skip-ci-noauth.yml` only references `secrets.SENTRY_AUTH_TOKEN`
- [ ] Verify the `auth_token_check` job still correctly detects token availability on this PR

Fixes VULN-2347

🤖 Generated with [Claude Code](https://claude.com/claude-code)