### PR TITLE
chore(ci): remove Cirrus runners and use only Bitrise

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -58,11 +58,7 @@ jobs:
             name: iOS
             appPlain: performance-tests/test-app-plain.ipa
           - platform: android
-            runs-on:
-              [
-                "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04",
-                "runner_group_id:10",
-              ]
+            runs-on: ubuntu-24.04-16core
             name: Android
             appPlain: performance-tests/TestAppPlain/android/app/build/outputs/apk/release/app-release.apk
     steps:
@@ -251,11 +247,7 @@ jobs:
             rn-version: "0.86.2"
             runs-on: macos-26-xlarge
           - platform: android
-            runs-on:
-              [
-                "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04",
-                "runner_group_id:10",
-              ]
+            runs-on: ubuntu-24.04-16core
         exclude:
           # exclude all rn versions lower than 0.80.0 for new architecture
           - rn-version: "0.71.19"
@@ -384,12 +376,11 @@ jobs:
   react-native-test:
     name:
       Test RN ${{ matrix.rn-version }} ${{ matrix.rn-architecture }} ${{ matrix.engine }} ${{ matrix.platform }} ${{
-      matrix.build-type }} ${{ matrix.ios-use-frameworks }} on ${{matrix.runner_provider}}
+      matrix.build-type }} ${{ matrix.ios-use-frameworks }}
     needs: [react-native-build, diff_check, detect-changes]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' }}
 
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:tahoe"]') || matrix.runs-on }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
@@ -399,24 +390,11 @@ jobs:
         build-type: ["production"]
         ios-use-frameworks: ["no"] # test only no frameworks
         engine: ["hermes"]
-        runner_provider: ["cirrus", "bitrise"]
         include:
           - platform: ios
-            rn-version: "0.86.2"
-            runs-on:
-              [
-                "ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0",
-                "runner_group_id:10",
-              ]
+            runs-on: ["bitrise_pool_name:tahoe"]
           - platform: android
-            runs-on:
-              [
-                "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04",
-                "runner_group_id:10",
-              ]
-        exclude:
-          - platform: android
-            runner_provider: bitrise
+            runs-on: ubuntu-24.04-16core
 
     steps:
       - name: Check if platform is needed
@@ -472,7 +450,7 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - name: Setup asdf Node.js (Bitrise)
-        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.runner_provider == 'bitrise' }}
+        if: ${{ steps.platform-check.outputs.skip != 'true' && matrix.platform == 'ios' }}
         run: |
           asdf global nodejs system
           corepack enable
@@ -546,7 +524,7 @@ jobs:
           xcrun simctl bootstatus booted -b
           # Launch and dismiss Settings.app to ensure SpringBoard and system services
           # are fully initialized — this avoids Maestro connecting to a half-booted
-          # simulator on Cirrus Labs Tart VMs.
+          # simulator.
           xcrun simctl launch booted com.apple.Preferences
           sleep 5
           xcrun simctl terminate booted com.apple.Preferences
@@ -562,6 +540,6 @@ jobs:
         if: ${{ always() && steps.platform-check.outputs.skip != 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-${{ matrix.runner_provider }}-logs
+          name: ${{ matrix.rn-version }}-${{ matrix.rn-architecture }}-${{ matrix.engine }}-${{ matrix.platform }}-${{ matrix.build-type }}-${{ matrix.ios-use-frameworks }}-logs
           path: |
             ./dev-packages/e2e-tests/maestro-logs

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-  MAESTRO_VERSION: '2.7.0'
+  MAESTRO_VERSION: "2.7.0"
   IOS_DEVICE: "iPhone 17"
   IOS_VERSION: ">=18.0"
 
@@ -58,7 +58,7 @@ jobs:
             name: iOS
             appPlain: performance-tests/test-app-plain.ipa
           - platform: android
-            runs-on: ubuntu-24.04-16core
+            runs-on: ubuntu-latest
             name: Android
             appPlain: performance-tests/TestAppPlain/android/app/build/outputs/apk/release/app-release.apk
     steps:
@@ -247,7 +247,7 @@ jobs:
             rn-version: "0.86.2"
             runs-on: macos-26-xlarge
           - platform: android
-            runs-on: ubuntu-24.04-16core
+            runs-on: ubuntu-latest
         exclude:
           # exclude all rn versions lower than 0.80.0 for new architecture
           - rn-version: "0.71.19"
@@ -394,7 +394,7 @@ jobs:
           - platform: ios
             runs-on: ["bitrise_pool_name:tahoe"]
           - platform: android
-            runs-on: ubuntu-24.04-16core
+            runs-on: ubuntu-latest
 
     steps:
       - name: Check if platform is needed

--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -58,7 +58,7 @@ jobs:
             name: iOS
             appPlain: performance-tests/test-app-plain.ipa
           - platform: android
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04
             name: Android
             appPlain: performance-tests/TestAppPlain/android/app/build/outputs/apk/release/app-release.apk
     steps:
@@ -247,7 +247,7 @@ jobs:
             rn-version: "0.86.2"
             runs-on: macos-26-xlarge
           - platform: android
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04
         exclude:
           # exclude all rn versions lower than 0.80.0 for new architecture
           - rn-version: "0.71.19"
@@ -394,7 +394,7 @@ jobs:
           - platform: ios
             runs-on: ["bitrise_pool_name:tahoe"]
           - platform: android
-            runs-on: ubuntu-latest
+            runs-on: ubuntu-24.04
 
     steps:
       - name: Check if platform is needed

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -32,15 +32,10 @@ jobs:
       caller_ref: ${{ github.ref }}
 
   test-ios:
-    name: ios on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]') }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    name: ios
+    runs-on: ["bitrise_pool_name:tahoe"]
     needs: [diff_check, detect-changes]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.detect-changes.outputs.needs_ios == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runner_provider: ["cirrus", "bitrise"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -54,7 +49,6 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - name: Setup asdf Node.js (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
         run: |
           asdf global nodejs system
           corepack enable
@@ -63,34 +57,15 @@ jobs:
         run: yarn install
 
       - uses: actions/cache@v6
-        name: Cache Ruby
-        if: matrix.runner_provider != 'bitrise'
-        with:
-          path: |
-            ~/.rbenv/versions
-            ~/.rbenv/cache
-          key: ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
-
-      - uses: actions/cache@v6
         name: Cache Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
         with:
           path: ~/.asdf/installs/ruby
           key: asdf-ruby-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ruby-version') }}
 
       - name: Install Ruby (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
         run: |
           asdf install ruby 3.3.0
           asdf local ruby 3.3.0
-
-      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
-        if: matrix.runner_provider != 'bitrise'
-        with:
-          ruby-version: "3.3.0"
-        env:
-          # Disable rbenv to avoid .ruby-version conflicts
-          RBENV_VERSION: system
 
       - name: Install CocoaPods
         run: gem install cocoapods
@@ -138,8 +113,7 @@ jobs:
 
   test-android:
     name: android
-    runs-on:
-      ["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04", "runner_group_id:10"]
+    runs-on: ubuntu-24.04-16core
     needs: [diff_check, detect-changes]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.detect-changes.outputs.needs_android == 'true' }}
     steps:

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -113,7 +113,7 @@ jobs:
 
   test-android:
     name: android
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-latest
     needs: [diff_check, detect-changes]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.detect-changes.outputs.needs_android == 'true' }}
     steps:

--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -113,7 +113,7 @@ jobs:
 
   test-android:
     name: android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [diff_check, detect-changes]
     if: ${{ needs.diff_check.outputs.skip_ci != 'true' && needs.detect-changes.outputs.needs_android == 'true' }}
     steps:

--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -327,9 +327,8 @@ jobs:
           path: samples/react-native-macos/macos/*.log
 
   test-ios:
-    name: Test ios production REV2 on ${{matrix.runner_provider}}
-    runs-on: ${{ matrix.runner_provider == 'bitrise' && fromJSON('["bitrise_pool_name:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-tahoe-xcode:26.2.0", "runner_group_id:10"]') }}
-    continue-on-error: ${{ matrix.runner_provider == 'bitrise' }}
+    name: Test ios production REV2
+    runs-on: ["bitrise_pool_name:tahoe"]
     needs: [diff_check, detect-changes, build-ios]
     if: >-
       ${{
@@ -337,10 +336,6 @@ jobs:
         && needs.detect-changes.outputs.needs_sample_react_native == 'true'
         && (needs.detect-changes.outputs.sample_react_native == 'true' || needs.detect-changes.outputs.needs_ios == 'true')
       }}
-    strategy:
-      fail-fast: false
-      matrix:
-        runner_provider: ["cirrus", "bitrise"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -370,7 +365,6 @@ jobs:
           cache-dependency-path: yarn.lock
 
       - name: Setup asdf Node.js (Bitrise)
-        if: matrix.runner_provider == 'bitrise'
         run: |
           asdf global nodejs system
           corepack enable


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description

Remove all Cirrus Labs runner configurations from CI workflows and standardize on Bitrise runners for macOS/iOS jobs and `ubuntu-24.04-16core` for Android/Linux jobs.

Changes across three workflow files:
- **`native-tests.yml`**: iOS `test-ios` now runs solely on Bitrise (`bitrise_pool_name:tahoe`), removed `runner_provider` matrix and Cirrus-only steps (rbenv cache, `ruby/setup-ruby`). Android `test-android` switched from Cirrus to `ubuntu-24.04-16core`.
- **`sample-application.yml`**: iOS `test-ios` now runs solely on Bitrise, removed `runner_provider` matrix and conditionals.
- **`e2e-v2.yml`**: Android runners in `metrics`, `react-native-build`, and `react-native-test` switched from Cirrus to `ubuntu-24.04-16core`. iOS `react-native-test` now runs on Bitrise, removed `runner_provider` matrix, `continue-on-error`, and Cirrus runner refs.


## :bulb: Motivation and Context

Consolidate CI runners by removing Cirrus Labs machines and using only Bitrise for macOS/iOS workloads.


## :green_heart: How did you test it?

CI workflow changes — will be validated by running the workflows on this PR.


## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps