### PR TITLE
fix(android): apply screenshot masking in captureScreenshot()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@
 
 ### Fixes
 
-- Apply screenshot masking in Android `captureScreenshot()` when `screenshot` options are configured
+- Apply screenshot masking in Android `captureScreenshot()` when `screenshot` options are configured ([#6565](https://github.com/getsentry/sentry-react-native/pull/6565))
 
-  Hybrid SDK screenshot capture (`NATIVE.captureScreenshot()`, used by the Feedback Widget and custom integrations) returned unmasked window captures on Android while iOS redacts text and images via `SentryViewPhotographer`. Error-screenshot masking (`attachScreenshot` + `ScreenshotEventProcessor`) was unaffected. Android `captureScreenshot()` now reuses the same view-hierarchy masking pipeline when `options.getScreenshot()` has mask classes configured.
+  Hybrid SDK screenshot capture (`NATIVE.captureScreenshot()`, used by the Feedback Widget and custom integrations) returned unmasked window captures on Android while iOS redacts text and images via `SentryViewPhotographer`. Error-screenshot masking (`attachScreenshot` + `ScreenshotEventProcessor`) was unaffected. Android `captureScreenshot()` now reuses the same view-hierarchy masking pipeline for configured `screenshot` options such as `maskAllText` and `maskAllImages`.
 
 - Attach `debug_meta` to JS error events on Hermes when the Debug ID stack match fails ([#6545](https://github.com/getsentry/sentry-react-native/pull/6545))
 - `sentry-expo-upload-sourcemaps` now reads plugin config when the plugin is registered as `@sentry/react-native` ([#6543](https://github.com/getsentry/sentry-react-native/pull/6543))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 
 ### Fixes
 
+- Apply screenshot masking in Android `captureScreenshot()` when `screenshot` options are configured ([#TBD](https://github.com/getsentry/sentry-react-native/pull/TBD))
+
+  Hybrid SDK screenshot capture (`NATIVE.captureScreenshot()`, used by the Feedback Widget and custom integrations) returned unmasked window captures on Android while iOS redacts text and images via `SentryViewPhotographer`. Error-screenshot masking (`attachScreenshot` + `ScreenshotEventProcessor`) was unaffected. Android `captureScreenshot()` now reuses the same view-hierarchy masking pipeline when `options.getScreenshot()` has mask classes configured.
+
 - Attach `debug_meta` to JS error events on Hermes when the Debug ID stack match fails ([#6545](https://github.com/getsentry/sentry-react-native/pull/6545))
 - `sentry-expo-upload-sourcemaps` now reads plugin config when the plugin is registered as `@sentry/react-native` ([#6543](https://github.com/getsentry/sentry-react-native/pull/6543))
 - Make the `RNSentry` SPEC CHECKSUM in `Podfile.lock` machine-independent ([#6534](https://github.com/getsentry/sentry-react-native/pull/6534))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Fixes
 
-- Apply screenshot masking in Android `captureScreenshot()` when `screenshot` options are configured ([#TBD](https://github.com/getsentry/sentry-react-native/pull/TBD))
+- Apply screenshot masking in Android `captureScreenshot()` when `screenshot` options are configured
 
   Hybrid SDK screenshot capture (`NATIVE.captureScreenshot()`, used by the Feedback Widget and custom integrations) returned unmasked window captures on Android while iOS redacts text and images via `SentryViewPhotographer`. Error-screenshot masking (`attachScreenshot` + `ScreenshotEventProcessor`) was unaffected. Android `captureScreenshot()` now reuses the same view-hierarchy masking pipeline when `options.getScreenshot()` has mask classes configured.
 

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -1,6 +1,5 @@
 package io.sentry.react;
 
-import static io.sentry.android.core.internal.util.ScreenshotUtils.takeScreenshot;
 import static io.sentry.vendor.Base64.NO_PADDING;
 import static io.sentry.vendor.Base64.NO_WRAP;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -10,8 +9,10 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
+import android.graphics.Bitmap;
 import android.net.Uri;
 import android.util.SparseIntArray;
+import android.view.View;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.FrameMetricsAggregator;
 import androidx.fragment.app.FragmentActivity;
@@ -47,10 +48,15 @@ import io.sentry.android.core.InternalSentrySdk;
 import io.sentry.android.core.SentryAndroidDateProvider;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.android.core.SentryFramesDelayResult;
+import io.sentry.android.core.SentryScreenshotOptions;
 import io.sentry.android.core.SentryShakeDetector;
 import io.sentry.android.core.ViewHierarchyEventProcessor;
 import io.sentry.android.core.internal.debugmeta.AssetsDebugMetaLoader;
+import io.sentry.android.core.internal.util.ScreenshotUtils;
 import io.sentry.android.core.internal.util.SentryFrameMetricsCollector;
+import io.sentry.android.replay.util.MaskRenderer;
+import io.sentry.android.replay.util.ViewsKt;
+import io.sentry.android.replay.viewhierarchy.ViewHierarchyNode;
 import io.sentry.android.core.performance.AppStartMetrics;
 import io.sentry.profilemeasurements.ProfileMeasurement;
 import io.sentry.profilemeasurements.ProfileMeasurementValue;
@@ -546,7 +552,7 @@ public class RNSentryModuleImpl {
     final byte[][] bytesWrapper = {{}}; // wrapper to be able to set the value in the runnable
     final Runnable runTakeScreenshot =
         () -> {
-          bytesWrapper[0] = takeScreenshot(activity, logger, buildInfo);
+          bytesWrapper[0] = takeMaskedScreenshot(activity);
           doneSignal.countDown();
         };
 
@@ -564,6 +570,86 @@ public class RNSentryModuleImpl {
     }
 
     return bytesWrapper[0];
+  }
+
+  private static @Nullable byte[] takeMaskedScreenshot(final @NotNull Activity activity) {
+    final @Nullable Bitmap screenshot =
+        ScreenshotUtils.captureScreenshot(activity, logger, buildInfo);
+    if (screenshot == null) {
+      return null;
+    }
+
+    final @Nullable SentryScreenshotOptions maskingOptions = screenshotMaskingOptions();
+    if (maskingOptions == null) {
+      return ScreenshotUtils.compressBitmapToPng(screenshot, logger);
+    }
+
+    final @Nullable Bitmap masked = maskScreenshot(activity, screenshot, maskingOptions);
+    if (masked == null) {
+      return null;
+    }
+
+    return ScreenshotUtils.compressBitmapToPng(masked, logger);
+  }
+
+  private static @Nullable SentryScreenshotOptions screenshotMaskingOptions() {
+    final @NotNull SentryOptions options = ScopesAdapter.getInstance().getOptions();
+    if (!(options instanceof SentryAndroidOptions)) {
+      return null;
+    }
+
+    final @NotNull SentryScreenshotOptions screenshotOptions =
+        ((SentryAndroidOptions) options).getScreenshot();
+    return screenshotOptions.getMaskViewClasses().isEmpty() ? null : screenshotOptions;
+  }
+
+  private static @Nullable Bitmap maskScreenshot(
+      final @NotNull Activity activity,
+      final @NotNull Bitmap screenshot,
+      final @NotNull SentryScreenshotOptions maskingOptions) {
+    Bitmap mutableScreenshot = screenshot;
+    boolean createdCopy = false;
+    try {
+      final @Nullable View rootView =
+          activity.getWindow() != null && activity.getWindow().peekDecorView() != null
+              ? activity.getWindow().peekDecorView().getRootView()
+              : null;
+      if (rootView == null) {
+        screenshot.recycle();
+        return null;
+      }
+
+      final @NotNull ViewHierarchyNode rootNode =
+          ViewHierarchyNode.Companion.fromView(rootView, null, 0, maskingOptions);
+      ViewsKt.traverse(rootView, rootNode, maskingOptions, logger, null);
+
+      if (!screenshot.isMutable()) {
+        mutableScreenshot = screenshot.copy(Bitmap.Config.ARGB_8888, true);
+        if (mutableScreenshot == null) {
+          screenshot.recycle();
+          return null;
+        }
+        createdCopy = true;
+      }
+
+      try (final MaskRenderer maskRenderer = new MaskRenderer()) {
+        maskRenderer.renderMasks(mutableScreenshot, rootNode, null);
+      }
+
+      if (createdCopy && !screenshot.isRecycled()) {
+        screenshot.recycle();
+      }
+      return mutableScreenshot;
+    } catch (Throwable e) { // NOPMD - masking must never crash the screenshot flow
+      logger.log(SentryLevel.ERROR, "Failed to mask screenshot.", e);
+      if (createdCopy && !mutableScreenshot.isRecycled()) {
+        mutableScreenshot.recycle();
+      }
+      if (!screenshot.isRecycled()) {
+        screenshot.recycle();
+      }
+      return null;
+    }
   }
 
   public void fetchViewHierarchy(Promise promise) {

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryModuleImpl.java
@@ -598,9 +598,7 @@ public class RNSentryModuleImpl {
       return null;
     }
 
-    final @NotNull SentryScreenshotOptions screenshotOptions =
-        ((SentryAndroidOptions) options).getScreenshot();
-    return screenshotOptions.getMaskViewClasses().isEmpty() ? null : screenshotOptions;
+    return ((SentryAndroidOptions) options).getScreenshot();
   }
 
   private static @Nullable Bitmap maskScreenshot(


### PR DESCRIPTION
## 📜 Description

On Android, `RNSentryModuleImpl.captureScreenshot()` (hybrid SDK / `NATIVE.captureScreenshot()`) captured a raw window bitmap via `ScreenshotUtils.takeScreenshot()` with **no masking**, while iOS routes the same API through `PrivateSentrySDKOnly.captureScreenshots()` → `SentryViewPhotographer`, which redacts text and images by default.

Screenshot masking options bridged in [#6007](<https://github.com/getsentry/sentry-react-native/issues/6007>) (`screenshot.maskAllText`, `maskAllImages`, view classes) are applied today only on the `attachScreenshot` **error path** via `ScreenshotEventProcessor`. They are **not** used by the hybrid capture path.

That creates a platform asymmetry for any feature built on `NATIVE.captureScreenshot()`:

* Feedback Widget “Take screenshot”
* Custom feedback / bug-report flows (our production case in Bob Mobile)
* Any direct `Sentry.captureScreenshot()` usage

**iOS:** personal text redacted in the capture primitive  <br>**Android:** cleartext text in the PNG until this fix

This PR mirrors the masking pipeline already used in `ScreenshotEventProcessor`:

1. Capture bitmap (`ScreenshotUtils.captureScreenshot`)
2. Build view hierarchy + `MaskRenderer.renderMasks` when `options.getScreenshot().getMaskViewClasses()` is non-empty
3. Compress to PNG

When masking is configured but fails, the method returns `null` (fail closed) rather than returning an unmasked capture.

Requires `sentry-android-replay` at runtime — already pulled in by `sentry-android`, same as error-screenshot masking.

## 💡 Motivation and Context

We hit this in production while building a custom in-app feedback modal that attaches a screenshot. iOS behaved as documented (“data will be blurred”); Android did not, despite setting `screenshot: { maskAllText: true, maskAllImages: true }` in `Sentry.init()`.

Related:

* getsentry/sentry-react-native#5763 / [#6007](<https://github.com/getsentry/sentry-react-native/issues/6007>) — exposed masking **options** for error screenshots (init bridge only)
* [getsentry/sentry-java#5077](<https://github.com/getsentry/sentry-java/issues/5077>) — Android masking implementation in `ScreenshotEventProcessor`

This closes the gap for the **hybrid capture API**, not just init options.

## 💚 How did you test it?

* Verified the change compiles against current `main` (same imports/pattern as `ScreenshotEventProcessor`)
* Exercised manually in Bob Mobile (custom feedback modal): Android screenshot attachments now redact on-screen text when masking options are enabled

*No new automated test in this PR yet* — happy to add an Android instrumentation/unit test if maintainers point to the preferred harness.

## :pencil: Checklist

- [X] I added a changelog entry
- [ ] I added tests to verify the changes (seeking guidance on preferred Android test location)
- [X] No new PII added / no `sendDefaultPii` changes

Made with [Cursor](<https://cursor.com>)