### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/workflows/size-analysis.yml
+++ b/.github/workflows/size-analysis.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install Sentry CLI
         if: env.SENTRY_AUTH_TOKEN != ''
-        run: curl -sL https://sentry.io/get-cli/ | sh
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - name: Upload Android Bundle to Sentry Size Analysis
         if: env.SENTRY_AUTH_TOKEN != ''
@@ -155,7 +155,7 @@ jobs:
 
       - name: Install Sentry CLI
         if: env.SENTRY_AUTH_TOKEN != ''
-        run: curl -sL https://sentry.io/get-cli/ | sh
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       - name: Upload iOS XCArchive to Sentry Size Analysis
         if: env.SENTRY_AUTH_TOKEN != ''


### PR DESCRIPTION
## Summary
- Two "Install Sentry CLI" steps in `size-analysis.yml` (Android and iOS jobs) used `curl -sL https://sentry.io/get-cli/ | sh`, piping a remote install script directly into a shell.
- Replaced both with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.
- Preserved the existing `if: env.SENTRY_AUTH_TOKEN != ''` condition on both steps.

## Test plan
- [x] Validated `size-analysis.yml` parses correctly
- [ ] Verify both Android and iOS size analysis jobs still install sentry-cli correctly on this PR

Fixes VULN-2348

🤖 Generated with [Claude Code](https://claude.com/claude-code)