### PR TITLE
docs(core): Correct enableTurboModuleTracking docs and document TurboModule plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@
 - Make the `RNSentry` SPEC CHECKSUM in `Podfile.lock` machine-independent ([#6534](https://github.com/getsentry/sentry-react-native/pull/6534))
 
   The prebuilt `Sentry.xcframework` is now referenced through a `$(PODS_ROOT)/sentry-xcframeworks/…` symlink instead of the absolute per-user cache path, so `Podfile.lock` no longer churns between developers and CI. Expect a one-time `RNSentry` checksum change on the next `pod install`; the `SENTRY_XCFRAMEWORK_CACHE_DIR=/tmp/…` workaround is no longer needed.
+
+### Internal
+
+- Mark `enableTurboModuleTracking` as internal and correct its documentation ([#6168](https://github.com/getsentry/sentry-react-native/issues/6168))
+
+  The option only installs the native `TurboModulePerfLogger`; no sink consumes its callbacks, so enabling it emits no data. Its documentation claimed it fed crash attribution, per-module spans and aggregated stats — those all come from `turboModuleContextIntegration()`, which is enabled by default with `enableNative` and never reads this option. No behaviour change.
+
 ### Dependencies
 
 - Bump Android SDK from v8.51.0 to v8.52.0 ([#6566](https://github.com/getsentry/sentry-react-native/pull/6566))

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -156,3 +156,116 @@ jest.mock('react-native', () => ({
   },
 }));
 ```
+
+## TurboModule Instrumentation
+
+There are **two independent stacks** with confusingly similar names. Read this
+before touching either.
+
+### 1. JS stack — live, on by default
+
+Wraps native module methods in JS. This is what produces every user-visible
+TurboModule signal today. Registered in `integrations/default.ts` whenever
+`options.enableNative` is `true`, with no separate opt-in.
+
+Data flow, in call order:
+
+| File | Role |
+|------|------|
+| `turbomodule/wrapTurboModule.ts` | `wrapTurboModule(name, module, { skip, arch })` — replaces each method with a timing wrapper. De-dupes via a module-level `WeakSet`. Walks the prototype chain (`Object.getPrototypeOf`) because JSI HostObject proxies expose nothing as own properties. |
+| `turbomodule/turboModuleTracker.ts` | LIFO stack of in-flight calls, mirrored onto the **isolation scope** (that is what `enableSyncToNative` forwards to native). This is the crash-attribution frame. Writes `contexts.turbo_module` plus the `turbo_module.name` / `turbo_module.method` tags. |
+| `turbomodule/turboModuleAggregator.ts` | O(1) counters per `(module, method, kind, arch)` plus a fixed-bucket latency histogram (`HISTOGRAM_BUCKETS_MS`). Fans out to record/call-start observers. |
+| `turbomodule/wrapNativeModules.ts` | Old Architecture `NativeModules.*` auto-wrap. Returns `[]` immediately when `isTurboModuleEnabled()`. Opt-in via `enableLegacyNativeModules`. |
+| `integrations/turboModuleContext.ts` | Wiring: integration `name` is `'TurboModuleContext'`, factory is `turboModuleContextIntegration()`. Owns `TurboModuleContextOptions` and all defaults. |
+| `integrations/turboModuleContextFlush.ts` | Drains the aggregate onto transaction events (child span + measurements) and onto a periodic standalone event. |
+
+Gotchas, all of which have already caused bugs:
+
+- **Never wrap the scope-sync methods on `RNSentry`.** `RNSENTRY_SKIP` in
+  `turboModuleContext.ts` excludes `setTag`, `setContext`, `addBreadcrumb`,
+  `setUser` and friends. Wrapping them recurses: recording a call syncs the
+  scope, which calls back into the wrapped method.
+- **`RNSentry` is in the default `ignoreTurboModules`** for the same reason —
+  the SDK's own transport calls would dominate the aggregate and re-arm the
+  periodic flush timer forever.
+- **`logger` imported from `@sentry/core` is the Logs API, not the debug
+  logger.** `@sentry/core` exports `logger` as `./logs/public-api` and the
+  debug logger as `debug`. The 7 `logger.warn` calls in `wrapTurboModule.ts`
+  and 2 in `wrapNativeModules.ts` therefore capture log *events* from the wrap
+  hot path, recursing through the wrapped `RNSentry.captureEnvelope`. **Use
+  `debug` in new code here**; the pre-existing calls are a known bug.
+- **Crash attribution pops synchronously**, even for async calls. Holding the
+  frame until completion that may never arrive would blame this module for an
+  unrelated later native crash.
+- **A method with no completion signal is recorded as ~0ms.** Only a plain
+  return and a thenable return are recognised. Fire-and-forget bridge methods
+  that report completion through a trailing callback return `undefined`, so they
+  close on return and land in the aggregate as sync calls with a near-zero
+  duration. Tracked in
+  [#6542](https://github.com/getsentry/sentry-react-native/issues/6542).
+
+Tests: `test/turbomodule/*.test.ts` and `test/integrations/turboModuleContext.test.ts`.
+
+### 2. Native stack — installed, inert
+
+Gated by the `enableTurboModuleTracking` option (`src/js/options.ts`).
+
+- `cpp/SentryTurboModulePerfLogger.{h,cpp}` — a
+  `facebook::react::NativeModulePerfLogger` subclass that claims React Native's
+  perf-logger slot and forwards every callback to a swappable sink.
+- `cpp/SentryTurboModulePerfSink.h` — the `ISentryTurboModulePerfSink`
+  interface.
+- Install points: `ios/RNSentry.mm`, `android/.../RNSentryModuleImpl.java`,
+  `android/src/main/jni/OnLoad.cpp`.
+
+**The SDK ships no production sink.**
+`SentryTurboModulePerfController::setSink` is only ever called from
+`RNSentryCocoaTester/.../RNSentryTurboModulePerfControllerTests.mm`, so
+`enableTurboModuleTracking: true` currently forwards every callback into
+`nullptr` and emits nothing. The option is `@internal` for that reason.
+
+The two stacks do **not** talk to each other. `turboModuleContextIntegration`
+never reads `enableTurboModuleTracking`, and nothing in JS consumes the native
+perf-logger callbacks. If you are adding a consumer, register a sink — do not
+route it through the JS wrapper.
+
+### Emitted keys
+
+Two namespaces, which is a known inconsistency:
+
+- `turbo_module.*` — scope context, event tags, root-span attributes
+  (`turboModuleContext.ts`).
+- `turbo_modules.*` — aggregate child-span data and measurements
+  (`turboModuleContextFlush.ts`), plus the span op `turbo_modules.aggregate`
+  and origin `auto.tracing.turbo_modules`.
+
+Per-`(module, method)` keys embed the dynamic segment in the middle
+(`turbo_module.<name>.<method>.call_count`). `safeKeyPart` escapes `_` to `__`
+then `.` to `_` so a module name cannot forge a key boundary.
+
+Both the namespace split and the mid-key dynamic segment are **not registrable
+in [sentry-conventions](https://github.com/getsentry/sentry-conventions)**,
+whose schema only models a trailing `has_dynamic_suffix`. Unifying them is
+tracked in [#6168](https://github.com/getsentry/sentry-react-native/issues/6168).
+Do not add new keys under either prefix until that lands — conventions must be
+merged *before* an SDK ships an attribute, and renaming a shipped name costs a
+90-day `backfill` deprecation cycle.
+
+### Old Architecture support policy
+
+The legacy `NativeModules` path (`enableLegacyNativeModules`) is **opt-in and
+best-effort**, and stays that way while React Native still ships the Old
+Architecture. It is not deprecated and has no removal timeline. Unlike the New
+Architecture path, which only sees modules the app actually imports, it
+instruments every registered bridge module including third-party ones — hence
+the opt-in and the `IMPLICIT_MODULE_SKIP` list in `wrapNativeModules.ts`
+(`RNSentry`, `Timing`, `UIManager`, and the animated modules).
+
+### Privacy
+
+Native module and method names are app-defined identifiers and are sent by
+default — in tags, in `contexts.turbo_module`, in span attributes and in slow
+call breadcrumbs — **regardless of `sendDefaultPii`**. This is deliberate: the
+crash-attribution frame is the reason the integration is default-on. Users who
+need to reduce it can pass `ignoreTurboModules`, or disable
+`enableAggregateStats` / `enableSpanAttribution`.

--- a/packages/core/src/js/options.ts
+++ b/packages/core/src/js/options.ts
@@ -321,25 +321,32 @@ export interface BaseReactNativeOptions {
   enableStallTracking?: boolean;
 
   /**
-   * Install Sentry's native `TurboModulePerfLogger` and forward every Turbo
-   * Module lifecycle callback (`moduleCreate*`, sync/async method call
-   * start/end/fail, execution start/end/fail) to the higher-level Sentry
-   * instrumentation (crash attribution, per-module spans, aggregated stats).
+   * Claim React Native's `NativeModulePerfLogger` slot with Sentry's native
+   * `TurboModulePerfLogger` and forward every Turbo Module lifecycle callback
+   * (`moduleCreate*`, sync/async method call start/end/fail, execution
+   * start/end/fail) to the C++ sink installed via
+   * `SentryTurboModulePerfController::setSink`.
    *
-   * Only takes effect on React Native 0.75+ New Architecture. On Old Architecture
-   * this option is a no-op.
+   * Enabling this on its own emits nothing: the SDK ships no production sink
+   * yet, so every forwarded callback is dropped. The flag exists so the native
+   * install path can land ahead of the features that will consume it.
    *
-   * The native perf logger is installed lazily on the first opt-in: while
-   * this flag is off (the default), Sentry never claims React Native's
-   * `NativeModulePerfLogger` slot and incurs no native-library mapping
-   * cost. The first `initNativeSdk` call with `enableTurboModuleTracking:
-   * true` loads the native library, installs the logger, and starts
-   * forwarding callbacks to the Sentry sink. Off by default because the
-   * higher-level features building on top of this hook ship in follow-up
-   * releases.
+   * This is **not** the switch for the TurboModule instrumentation users can
+   * see today. Crash attribution, span attribution, slow-call breadcrumbs and
+   * the call aggregate all come from `turboModuleContextIntegration()`, which
+   * is a JS-side wrapper enabled by default whenever `enableNative` is `true`
+   * and never reads this option.
+   *
+   * Only takes effect on React Native 0.75+ New Architecture. On Old
+   * Architecture this option is a no-op.
+   *
+   * The native perf logger is installed lazily on the first opt-in: while this
+   * flag is off (the default), Sentry never claims the slot and incurs no
+   * native-library mapping cost.
    *
    * @default false
    * @experimental
+   * @internal
    */
   enableTurboModuleTracking?: boolean;
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description

Documentation only. No behaviour change, no public API change.

`enableTurboModuleTracking`'s JSDoc claimed it forwards Turbo Module callbacks "to the higher-level Sentry instrumentation (crash attribution, per-module spans, aggregated stats)". Neither half holds:

- It installs the native `TurboModulePerfLogger`, which forwards to a sink — and `SentryTurboModulePerfController::setSink` has no caller outside `RNSentryCocoaTester`. Enabling it emits nothing.
- Everything the text promised comes from `turboModuleContextIntegration()`, registered whenever `enableNative` is true, which never reads this option.

The option is now `@internal` and documented accurately. Kept rather than removed: the native install path already shipped in 8.17.0 and a sink is the intended consumer.

Adds a `packages/core/AGENTS.md` section covering the two independent stacks and the traps in them — notably that `logger` from `@sentry/core` is the Logs API, not the debug logger, so the existing `logger.warn` calls in `turbomodule/` capture log events from the wrap hot path and recurse through the wrapped `RNSentry.captureEnvelope`. Documented, not fixed, to keep this diff docs-only.


## :bulb: Motivation and Context

First slice of #6168. Two of that issue's premises were wrong and are corrected here rather than propagated into docs: there is no `turboModulesIntegration` (it is `turboModuleContextIntegration`), and `slowCallThresholdMs` / `ignoreTurboModules` / `maxTopModulesPerSpan` are on `TurboModuleContextOptions`, not on the SDK options.

The attribute rename is **not** here — conventions must merge before an SDK ships them, so it is gated on getsentry/sentry-conventions#564.


## :green_heart: How did you test it?

No tests added — docs and JSDoc only.

`yarn build:sdk`, `yarn api-report:check` (surface unchanged), `yarn lint` (0 errors), `yarn circularDepCheck`, `yarn test` — 1850 + 334 + 1 passing.

Native and E2E suites not run.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

1. getsentry/sentry-conventions#564 — register and unify the attributes. Blocks the rest.
2. SDK rename: apply the agreed keys, emit old + new through the backfill window, then lock the API report.
3. sentry-docs PR.

Separate follow-ups: the `logger` → `debug` fix in `turbomodule/`, and #6542. When #6561 lands, the AGENTS.md section needs the `turboModuleCallbacks.ts` row added back.
