### PR TITLE
fix(core): Use the debug logger, not the Logs API, for SDK diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 
 ### Fixes
 
+- Send SDK-internal diagnostics to the debug logger instead of the Sentry Logs API ([#6585](https://github.com/getsentry/sentry-react-native/pull/6585))
+
+  Ten internal warnings in the TurboModule instrumentation, scope sync and the Expo Router error boundary were written against `logger`, which captures a log record and sends it to your project. They now go to `debug`, printed only when the SDK is initialized with `debug: true`.
+
 - Measure callback-style native module calls until their completion callback fires ([#6561](https://github.com/getsentry/sentry-react-native/pull/6561))
 
   Bridge methods that report completion through success/failure callbacks instead of a Promise return `undefined`, so they were recorded as sync calls with a near-zero duration. Their `turbo_module.*` durations are now correct, and slow ones produce a `native.turbo_module` breadcrumb. On the Old Architecture a failure callback is also counted as an error, following React Native's own `(failure, success)` trailing-argument convention.

--- a/packages/core/src/js/scopeSync.ts
+++ b/packages/core/src/js/scopeSync.ts
@@ -1,6 +1,6 @@
 import type { Breadcrumb, Scope } from '@sentry/core';
 
-import { logger } from '@sentry/react';
+import { debug } from '@sentry/core';
 
 import { DEFAULT_BREADCRUMB_LEVEL } from './breadcrumb';
 import { fillTyped } from './utils/fill';
@@ -112,7 +112,7 @@ export function enableSyncToNative(scope: Scope): void {
     if (finalBreadcrumb) {
       NATIVE.addBreadcrumb(finalBreadcrumb);
     } else {
-      logger.warn('[ScopeSync] Last created breadcrumb is undefined. Skipping sync to native.');
+      debug.warn('[ScopeSync] Last created breadcrumb is undefined. Skipping sync to native.');
     }
 
     return scope;

--- a/packages/core/src/js/tracing/expoRouterErrorBoundary.tsx
+++ b/packages/core/src/js/tracing/expoRouterErrorBoundary.tsx
@@ -4,10 +4,10 @@ import {
   addBreadcrumb,
   addExceptionMechanism,
   captureException,
+  debug,
   getActiveSpan,
   getClient,
   getRootSpan,
-  logger,
   SPAN_STATUS_ERROR,
   spanToJSON,
 } from '@sentry/core';
@@ -93,7 +93,7 @@ export function wrapExpoRouterErrorBoundary<P extends ExpoRouterErrorBoundaryPro
         reportRouterBoundaryError(error);
         reportedErrors.add(error);
       } catch (e) {
-        logger.error(
+        debug.error(
           `[wrapExpoRouterErrorBoundary] Failed to report boundary error: ${e instanceof Error ? e.message : String(e)}`,
         );
       }

--- a/packages/core/src/js/turbomodule/wrapNativeModules.ts
+++ b/packages/core/src/js/turbomodule/wrapNativeModules.ts
@@ -1,4 +1,4 @@
-import { logger } from '@sentry/core';
+import { debug } from '@sentry/core';
 import { NativeModules } from 'react-native';
 
 import type { TurboModuleArch } from './turboModuleAggregator';
@@ -64,7 +64,7 @@ export function wrapAllNativeModules(options: WrapNativeModulesOptions = {}): st
   try {
     moduleNames = Object.keys(NativeModules);
   } catch (e) {
-    logger.warn(`[TurboModuleTracker] Failed to enumerate NativeModules for legacy wrapping: ${String(e)}`);
+    debug.warn(`[TurboModuleTracker] Failed to enumerate NativeModules for legacy wrapping: ${String(e)}`);
     return [];
   }
 
@@ -195,5 +195,5 @@ function warnNotEnumerable(): void {
     : 'because `NativeModules` exposed no enumerable entries.';
   const hint =
     'Pass the modules you care about to turboModuleContextIntegration({ modules: [{ name, module }] }) instead.';
-  logger.warn(`[TurboModuleTracker] Legacy NativeModules auto-wrap found no modules to instrument ${reason} ${hint}`);
+  debug.warn(`[TurboModuleTracker] Legacy NativeModules auto-wrap found no modules to instrument ${reason} ${hint}`);
 }

--- a/packages/core/src/js/turbomodule/wrapTurboModule.ts
+++ b/packages/core/src/js/turbomodule/wrapTurboModule.ts
@@ -1,4 +1,4 @@
-import { logger } from '@sentry/core';
+import { debug } from '@sentry/core';
 
 import type { TurboModuleCallKind } from './turboModuleTracker';
 
@@ -60,7 +60,7 @@ export function wrapTurboModule<T extends object>(
   if (methodNames.length === 0) {
     // Do NOT add to wrappedModules — a later call (e.g. once a JSI HostObject
     // has materialised its methods) should still get a chance to wrap.
-    logger.warn(
+    debug.warn(
       `[TurboModuleTracker] No methods discovered on '${name}' — TurboModule context will not be attached for this module. ` +
         `This usually means the module is a JSI HostObject that only materialises methods on first access.`,
     );
@@ -101,12 +101,12 @@ export function wrapTurboModule<T extends object>(
       try {
         callId = pushTurboModuleCall({ name, method: key, kind: 'sync' });
       } catch (e) {
-        logger.warn(`[TurboModuleTracker] push failed for ${name}.${key}: ${String(e)}`);
+        debug.warn(`[TurboModuleTracker] push failed for ${name}.${key}: ${String(e)}`);
       }
       try {
         recordId = notifyTurboModuleCallStart(name, key, 'sync', arch);
       } catch (e) {
-        logger.warn(`[TurboModuleTracker] notifyStart failed for ${name}.${key}: ${String(e)}`);
+        debug.warn(`[TurboModuleTracker] notifyStart failed for ${name}.${key}: ${String(e)}`);
       }
 
       // Must happen before the call: the wrapped callbacks have to be the ones
@@ -185,7 +185,7 @@ export function wrapTurboModule<T extends object>(
     // module is frozen, or every method is a read-only accessor. Surface this
     // so the silent no-op is debuggable (the issue would otherwise look like
     // "no crash context attached" with no obvious cause).
-    logger.warn(
+    debug.warn(
       `[TurboModuleTracker] '${name}' has methods but none could be wrapped — TurboModule context will not be attached. ` +
         `This usually means the module is frozen or its methods are non-writable accessors.`,
     );
@@ -223,7 +223,7 @@ function safePop(callId: number | undefined, name: string, method: string): void
   try {
     popTurboModuleCall(callId);
   } catch (e) {
-    logger.warn(`[TurboModuleTracker] pop failed for ${name}.${method}: ${String(e)}`);
+    debug.warn(`[TurboModuleTracker] pop failed for ${name}.${method}: ${String(e)}`);
   }
 }
 
@@ -234,7 +234,7 @@ function safeRelabel(callId: number | undefined, kind: TurboModuleCallKind, name
   try {
     relabelTurboModuleCallKind(callId, kind);
   } catch (e) {
-    logger.warn(`[TurboModuleTracker] relabel failed for ${name}.${method}: ${String(e)}`);
+    debug.warn(`[TurboModuleTracker] relabel failed for ${name}.${method}: ${String(e)}`);
   }
 }
 

--- a/packages/core/test/turbomodule/wrapNativeModules.test.ts
+++ b/packages/core/test/turbomodule/wrapNativeModules.test.ts
@@ -1,4 +1,4 @@
-import { logger } from '@sentry/core';
+import { debug } from '@sentry/core';
 import { NativeModules } from 'react-native';
 
 import { wrapAllNativeModules } from '../../src/js/turbomodule/wrapNativeModules';
@@ -195,7 +195,7 @@ describe('wrapAllNativeModules', () => {
     // Scoped to NativeModules so jest's own use of Object.keys keeps working.
     const realKeys = Object.keys;
     jest.spyOn(Object, 'keys').mockImplementation((o: object) => (o === NativeModules ? [] : realKeys(o)));
-    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const warn = jest.spyOn(debug, 'warn').mockImplementation(() => undefined);
 
     const wrapped = wrapAllNativeModules();
 

--- a/packages/core/test/turbomodule/wrapTurboModule.test.ts
+++ b/packages/core/test/turbomodule/wrapTurboModule.test.ts
@@ -166,7 +166,7 @@ describe('wrapTurboModule', () => {
   });
 
   it('retries wrapping a previously-empty module (lazy JSI HostObject)', () => {
-    const warnSpy = jest.spyOn(require('@sentry/core').logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(require('@sentry/core').debug, 'warn').mockImplementation(() => undefined);
 
     // First call: methods not yet materialised — should warn, NOT mark as wrapped.
     const lazyModule: { doStuff?: () => string } = Object.create(null) as { doStuff?: () => string };
@@ -213,7 +213,7 @@ describe('wrapTurboModule', () => {
   });
 
   it('warns when methods are discovered but none could be wrapped (frozen module)', () => {
-    const warnSpy = jest.spyOn(require('@sentry/core').logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(require('@sentry/core').debug, 'warn').mockImplementation(() => undefined);
 
     const frozen = Object.freeze({ doStuff: () => 'ok' });
 
@@ -223,7 +223,7 @@ describe('wrapTurboModule', () => {
   });
 
   it('still calls the original method when the tracker push throws (native bridge error)', () => {
-    const warnSpy = jest.spyOn(require('@sentry/core').logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(require('@sentry/core').debug, 'warn').mockImplementation(() => undefined);
     // Simulate a scope-sync hook that calls into a native bridge which throws.
     jest.spyOn(scope, 'setContext').mockImplementation(() => {
       throw new Error('NATIVE.setContext boom');
@@ -246,7 +246,7 @@ describe('wrapTurboModule', () => {
   });
 
   it('still calls the original method when the tracker pop throws', () => {
-    const warnSpy = jest.spyOn(require('@sentry/core').logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(require('@sentry/core').debug, 'warn').mockImplementation(() => undefined);
 
     const originalFn = jest.fn(() => 42);
     const module = { doStuff: originalFn };
@@ -287,7 +287,7 @@ describe('wrapTurboModule', () => {
   });
 
   it('warns and bails out cleanly when no methods are discoverable', () => {
-    const warnSpy = jest.spyOn(require('@sentry/core').logger, 'warn').mockImplementation(() => undefined);
+    const warnSpy = jest.spyOn(require('@sentry/core').debug, 'warn').mockImplementation(() => undefined);
 
     const opaque = Object.create(null) as object;
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
`logger` from `@sentry/core` is the structured **Logs API** — every call captures a log record and ships it to the user's project. `debug` is the internal debug logger, printed to the console only under `debug: true`. Ten internal diagnostics were written against `logger`, so an SDK-internal failure turned into a billable log event the user cannot silence.

Switched to `debug` in multiple Turbo Modules related files.

## :bulb: Motivation and Context
Follow-up to https://github.com/getsentry/sentry-react-native/pull/6561#discussion_r3753179915, agreed with @lucas-zimerman to do separately. The `logger` calls predate #6561.


## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
- `tools/sentryOptionsSerializer.ts` (7 calls) as described above.
