### PR TITLE
docs: update CONTRIBUTING paths for the monorepo layout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ Comment out sentry dependency in `RNSentry.podspec`.
 +   s.dependency 'Sentry'
 ```
 
-Add local pods to `sample/ios/Podfile`.
+Add local pods to `samples/react-native/ios/Podfile`.
 
 ```diff
 target 'sample' do
@@ -186,7 +186,7 @@ ls ~/.m2/repository/io/sentry/sentry-android # check that `sentry-java` was publ
 cd sentry-react-native/sample
 ```
 
-Add local maven to `sample/android/build.gradle`.
+Add local maven to `samples/react-native/android/build.gradle`.
 
 ```gradle
 allprojects {
@@ -196,7 +196,7 @@ allprojects {
 }
 ```
 
-Update `sentry-android` version, to the one locally published, in `android/build.gradle`.
+Update `sentry-android` version, to the one locally published, in `packages/core/android/build.gradle`.
 
 ```diff
 dependencies {


### PR DESCRIPTION
## :loudspeaker: Type of change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring

## :scroll: Description

Three `CONTRIBUTING.md` paths predate the monorepo move and no longer exist at the root:

| line | says | now at |
|---|---|---|
| 158 | `sample/ios/Podfile` | `samples/react-native/ios/Podfile` |
| 189 | `sample/android/build.gradle` | `samples/react-native/android/build.gradle` |
| 199 | `android/build.gradle` | `packages/core/android/build.gradle` |

Path corrections only.

## :bulb: Motivation and Context

The repository moved in `ddcabffc` (*"misc: Move to monorepo structure and Yarn V3 (#4057)"*); `sample/ios/Podfile` went earlier in `2d3b9f2b`. The root has neither `android/` nor `sample/`, so the local-SDK sections point at nothing.

Each replacement is the file the instruction means:

- `packages/core/android/build.gradle:186` is `api "io.sentry:sentry-android:$sentryAndroidVersion"`
- `samples/react-native/android/build.gradle:24` opens `repositories { maven {`
- `samples/react-native/ios/Podfile:44` is `pod 'AppTurboModules', :path => "./../tm"`

## :green_heart: How did you test it?

Resolved each path against the current tree: three absent, three present with the referenced content. No code changed.

## :pencil: Checklist

- [ ] I added tests to verify changes. *(documentation only)*
- [x] No new PII added.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed. *(n/a)*
- [x] All tests passing. *(no code changed)*
- [x] No breaking changes.

## AI use

Your `CONTRIBUTING.md` asks that changes be reviewed and tested by a human first, and says agent-generated "fix" PRs will be closed. Straight answer: a documentation checker found these paths. Each was confirmed against `git log` for the commit that moved it, each replacement opened and checked, and the change read before submitting. If you would rather not take it, close it.
