### PR TITLE
chore(e2e): Bump Android binary size diff limit to 5.8 MiB

### DIFF
--- a/performance-tests/metrics-android.yml
+++ b/performance-tests/metrics-android.yml
@@ -13,4 +13,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 1 MiB
-  diffMax: 5.7 MiB
+  diffMax: 5.8 MiB


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Bumps `binarySizeTest.diffMax` in `performance-tests/metrics-android.yml` from `5.7 MiB` to `5.8 MiB`.

The `metrics (legacy, android)` `BinarySizeTest` compares the APK size of the Sentry test app against the plain test app. On `main` the diff has crept just past the current `5.7 MiB` (`5,976,883 B`) limit:

```
App com.testappsentry is 5.70 MiB larger than app com.testappplain
java.lang.AssertionError: 5982113 should be < 5976883
```

`5.8 MiB` (`6,081,740 B`) clears the current `~5.98 MiB` diff with headroom, following the established +0.1 MiB increment and the same approach as #5542.


## :bulb: Motivation and Context
The check started failing on `main` around Aug 10, 2026, after the Android SDK bump `8.30.0 → 8.52.0` (#6566). The first completed failing run measured `5,976,929 B` (~46 B over the limit) and it has since grown to `5,982,113 B` as more dependency updates landed. This unblocks the metrics job on `main`.


## :green_heart: How did you test it?
The new limit (`6,081,740 B`) is above the currently measured diff (`5,982,113 B`). The value is validated by the existing `BinarySizeTest` in the e2e metrics job.


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
The Sentry-vs-plain size delta is trending upward; a future dedicated look at what's driving the growth may be warranted rather than repeated limit bumps.