### PR TITLE
fix(android): fragment memory leak in  RNSentryReactFragmentLifecycleTracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Add `enableNdkAppHangTracking` and `ndkAppHangTimeoutIntervalMillis` options to enable Android NDK app hang tracking ([#6548](https://github.com/getsentry/sentry-react-native/pull/6548))
 
+### Fixes
+
+- Fix Android fragment memory leak in `RNSentryReactFragmentLifecycleTracer` ([#6599](https://github.com/getsentry/sentry-react-native/pull/6599))
+
 ### Dependencies
 
 - Bump Android SDK from v8.52.0 to v8.53.0 ([#6586](https://github.com/getsentry/sentry-react-native/pull/6586))

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReactFragmentLifecycleTracerTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReactFragmentLifecycleTracerTest.kt
@@ -41,6 +41,23 @@ class RNSentryReactFragmentLifecycleTracerTest {
         verify(mockEventDispatcher, times(1)).addListener(any())
     }
 
+	@Test
+	fun tracerRemovesListenerWhenFragmentViewDestroyed(){
+		val mockEventDispatcher = mock<EventDispatcher>()
+		val fragment = mock<ScreenStackFragment>()
+
+		val tracer = createSutWith()
+		mockUIManager(mockEventDispatcher)
+
+		callOnFragmentViewCreated(fragment, mockScreenViewWithReactContext(),tracer)
+		verify(mockEventDispatcher, times(1)).addListener(any())
+
+
+		callOnFragmentViewDestroyed(fragment,tracer)
+		verify(mockEventDispatcher, times(1)).removeListener(any())
+
+	}
+
     @Test
     fun tracerDoesNotAddListenerForGenericFragment() {
         val mockEventDispatcher = mock<EventDispatcher>()
@@ -87,13 +104,21 @@ class RNSentryReactFragmentLifecycleTracerTest {
     private fun callOnFragmentViewCreated(
         mockFragment: Fragment,
         mockView: View,
+        tracer: RNSentryReactFragmentLifecycleTracer = createSutWith()
     ) {
-        createSutWith().onFragmentViewCreated(
+        tracer.onFragmentViewCreated(
             mock(),
             mockFragment,
             mockView,
             null,
         )
+    }
+
+    private fun callOnFragmentViewDestroyed(
+        mockFragment: Fragment,
+        tracer: RNSentryReactFragmentLifecycleTracer = createSutWith()
+    ) {
+        tracer.onFragmentViewDestroyed(mock(), mockFragment)
     }
 
     private fun createSutWith(): RNSentryReactFragmentLifecycleTracer {

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReactFragmentLifecycleTracerTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/rnsentryandroidtester/RNSentryReactFragmentLifecycleTracerTest.kt
@@ -41,22 +41,20 @@ class RNSentryReactFragmentLifecycleTracerTest {
         verify(mockEventDispatcher, times(1)).addListener(any())
     }
 
-	@Test
-	fun tracerRemovesListenerWhenFragmentViewDestroyed(){
-		val mockEventDispatcher = mock<EventDispatcher>()
-		val fragment = mock<ScreenStackFragment>()
+    @Test
+    fun tracerRemovesListenerWhenFragmentViewDestroyed() {
+        val mockEventDispatcher = mock<EventDispatcher>()
+        val fragment = mock<ScreenStackFragment>()
 
-		val tracer = createSutWith()
-		mockUIManager(mockEventDispatcher)
+        val tracer = createSutWith()
+        mockUIManager(mockEventDispatcher)
 
-		callOnFragmentViewCreated(fragment, mockScreenViewWithReactContext(),tracer)
-		verify(mockEventDispatcher, times(1)).addListener(any())
+        callOnFragmentViewCreated(fragment, mockScreenViewWithReactContext(), tracer)
+        verify(mockEventDispatcher, times(1)).addListener(any())
 
-
-		callOnFragmentViewDestroyed(fragment,tracer)
-		verify(mockEventDispatcher, times(1)).removeListener(any())
-
-	}
+        callOnFragmentViewDestroyed(fragment, tracer)
+        verify(mockEventDispatcher, times(1)).removeListener(any())
+    }
 
     @Test
     fun tracerDoesNotAddListenerForGenericFragment() {
@@ -104,7 +102,7 @@ class RNSentryReactFragmentLifecycleTracerTest {
     private fun callOnFragmentViewCreated(
         mockFragment: Fragment,
         mockView: View,
-        tracer: RNSentryReactFragmentLifecycleTracer = createSutWith()
+        tracer: RNSentryReactFragmentLifecycleTracer = createSutWith(),
     ) {
         tracer.onFragmentViewCreated(
             mock(),
@@ -116,7 +114,7 @@ class RNSentryReactFragmentLifecycleTracerTest {
 
     private fun callOnFragmentViewDestroyed(
         mockFragment: Fragment,
-        tracer: RNSentryReactFragmentLifecycleTracer = createSutWith()
+        tracer: RNSentryReactFragmentLifecycleTracer = createSutWith(),
     ) {
         tracer.onFragmentViewDestroyed(mock(), mockFragment)
     }

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryReactFragmentLifecycleTracer.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryReactFragmentLifecycleTracer.java
@@ -91,6 +91,7 @@ public class RNSentryReactFragmentLifecycleTracer extends FragmentLifecycleCallb
       public void onEventDispatch(Event event) {
         if ("com.swmansion.rnscreens.events.ScreenAppearEvent".equals(event.getClass().getCanonicalName())) {
           this.dispatcher.removeListener(this);
+          listenerWrapperMap.remove(f);
           FirstDrawDoneListener.registerForNextDraw(v, emitNewFrameEvent, buildInfoProvider);
         }
       }

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryReactFragmentLifecycleTracer.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryReactFragmentLifecycleTracer.java
@@ -12,6 +12,8 @@ import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherListener;
+import java.util.HashMap;
+import java.util.Map;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.BuildInfoProvider;
@@ -24,6 +26,7 @@ public class RNSentryReactFragmentLifecycleTracer extends FragmentLifecycleCallb
   private @NotNull final BuildInfoProvider buildInfoProvider;
   private @NotNull final Runnable emitNewFrameEvent;
   private @NotNull final ILogger logger;
+  private final Map<Fragment,EventDispatcherListenerWrapper> listenerWrapperMap = new HashMap<>();
 
   public RNSentryReactFragmentLifecycleTracer(
       @NotNull BuildInfoProvider buildInfoProvider,
@@ -83,18 +86,40 @@ public class RNSentryReactFragmentLifecycleTracer extends FragmentLifecycleCallb
       return;
     }
 
-    final @NotNull Runnable emitNewFrameEvent = this.emitNewFrameEvent;
-    eventDispatcher.addListener(
-        new EventDispatcherListener() {
-          @Override
-          public void onEventDispatch(Event event) {
-            if ("com.swmansion.rnscreens.events.ScreenAppearEvent"
-                .equals(event.getClass().getCanonicalName())) {
-              eventDispatcher.removeListener(this);
-              FirstDrawDoneListener.registerForNextDraw(v, emitNewFrameEvent, buildInfoProvider);
-            }
-          }
-        });
+    EventDispatcherListenerWrapper listenerWrapper = new EventDispatcherListenerWrapper(eventDispatcher) {
+      @Override
+      public void onEventDispatch(Event event) {
+        if ("com.swmansion.rnscreens.events.ScreenAppearEvent".equals(event.getClass().getCanonicalName())) {
+          this.dispatcher.removeListener(this);
+          FirstDrawDoneListener.registerForNextDraw(v, emitNewFrameEvent, buildInfoProvider);
+        }
+      }
+    };
+
+    eventDispatcher.addListener(listenerWrapper);
+    listenerWrapperMap.put(f, listenerWrapper);
+  }
+
+
+  @Override
+  public void onFragmentViewDestroyed(@NonNull FragmentManager fm, @NonNull Fragment f) {
+    super.onFragmentViewDestroyed(fm, f);
+    EventDispatcherListenerWrapper listenerWrapper = listenerWrapperMap.get(f);
+    if (listenerWrapper != null && listenerWrapper.dispatcher != null) {
+      listenerWrapper.dispatcher.removeListener(listenerWrapper);
+      listenerWrapperMap.remove(f);
+    }
+  }
+
+
+  static abstract class EventDispatcherListenerWrapper implements EventDispatcherListener {
+
+    protected final EventDispatcher dispatcher;
+
+    public EventDispatcherListenerWrapper(EventDispatcher dispatcher) {
+      this.dispatcher = dispatcher;
+    }
+
   }
 
   private static @Nullable EventDispatcher getEventDispatcherForReactTag(

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryReactFragmentLifecycleTracer.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryReactFragmentLifecycleTracer.java
@@ -12,12 +12,12 @@ import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.Event;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherListener;
-import java.util.HashMap;
-import java.util.Map;
 import io.sentry.ILogger;
 import io.sentry.SentryLevel;
 import io.sentry.android.core.BuildInfoProvider;
 import io.sentry.android.core.internal.util.FirstDrawDoneListener;
+import java.util.HashMap;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,7 +26,7 @@ public class RNSentryReactFragmentLifecycleTracer extends FragmentLifecycleCallb
   private @NotNull final BuildInfoProvider buildInfoProvider;
   private @NotNull final Runnable emitNewFrameEvent;
   private @NotNull final ILogger logger;
-  private final Map<Fragment,EventDispatcherListenerWrapper> listenerWrapperMap = new HashMap<>();
+  private final Map<Fragment, EventDispatcherListenerWrapper> listenerWrapperMap = new HashMap<>();
 
   public RNSentryReactFragmentLifecycleTracer(
       @NotNull BuildInfoProvider buildInfoProvider,
@@ -86,21 +86,22 @@ public class RNSentryReactFragmentLifecycleTracer extends FragmentLifecycleCallb
       return;
     }
 
-    EventDispatcherListenerWrapper listenerWrapper = new EventDispatcherListenerWrapper(eventDispatcher) {
-      @Override
-      public void onEventDispatch(Event event) {
-        if ("com.swmansion.rnscreens.events.ScreenAppearEvent".equals(event.getClass().getCanonicalName())) {
-          this.dispatcher.removeListener(this);
-          listenerWrapperMap.remove(f);
-          FirstDrawDoneListener.registerForNextDraw(v, emitNewFrameEvent, buildInfoProvider);
-        }
-      }
-    };
+    EventDispatcherListenerWrapper listenerWrapper =
+        new EventDispatcherListenerWrapper(eventDispatcher) {
+          @Override
+          public void onEventDispatch(Event event) {
+            if ("com.swmansion.rnscreens.events.ScreenAppearEvent"
+                .equals(event.getClass().getCanonicalName())) {
+              this.dispatcher.removeListener(this);
+              listenerWrapperMap.remove(f);
+              FirstDrawDoneListener.registerForNextDraw(v, emitNewFrameEvent, buildInfoProvider);
+            }
+          }
+        };
 
     eventDispatcher.addListener(listenerWrapper);
     listenerWrapperMap.put(f, listenerWrapper);
   }
-
 
   @Override
   public void onFragmentViewDestroyed(@NonNull FragmentManager fm, @NonNull Fragment f) {
@@ -112,15 +113,13 @@ public class RNSentryReactFragmentLifecycleTracer extends FragmentLifecycleCallb
     }
   }
 
-
-  static abstract class EventDispatcherListenerWrapper implements EventDispatcherListener {
+  abstract static class EventDispatcherListenerWrapper implements EventDispatcherListener {
 
     protected final EventDispatcher dispatcher;
 
     public EventDispatcherListenerWrapper(EventDispatcher dispatcher) {
       this.dispatcher = dispatcher;
     }
-
   }
 
   private static @Nullable EventDispatcher getEventDispatcherForReactTag(


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail and optionally add screenshots -->
Resolve fragment memory leak by removing `EventDispatcherListener` added in `onFragmentViewCreated` after `onFragmentViewDestroyed` is called.




## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->



Originally, we only remove EventDispatcherListener when received `ScreenAppearEvent` 
this behavior cause Fragment memory leak. 

If the Fragment is destroyed before the ScreenAppearEvent arrives, the listener will not be removed from the EventDispatcher. Because of this listener captures v, which is the Fragment's container view,
thereby retaining a reference to the Fragment and ultimately causing a memory leak. 

<img width="1247" height="441" alt="image" src="https://github.com/user-attachments/assets/32f46ec2-f211-449f-82d7-b38a52f930e4" />




<img width="3884" height="1648" alt="image" src="https://github.com/user-attachments/assets/37655345-7e90-4f51-9538-dc6023794943" />


## :green_heart: How did you test it?
<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I added tests to verify changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [x] All tests passing.
- [ ] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
