### PR TITLE
fix(deps): Bump deepmerge-ts to ^8.0.0 (stack-exhaustion advisory)

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,8 @@
     "@appium/support@npm:7.0.6/uuid": "^13.0.1",
     "node-simctl@npm:8.1.6/uuid": "^13.0.1",
     "shell-quote": "^1.10.0",
-    "downlevel-dts@npm:0.11.0/typescript": "5.9.3"
+    "downlevel-dts@npm:0.11.0/typescript": "5.9.3",
+    "deepmerge-ts": "^8.0.0"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14965,10 +14965,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge-ts@npm:^5.0.0, deepmerge-ts@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "deepmerge-ts@npm:5.1.0"
-  checksum: 10c0/28f810e6f3c638020922c3abfb4f20bc8fff00262dbc5a1f5283ecae0b8ffd3b3b95aaca3c8992d8680eb5754c11d87edff1915235e145c5afdc53102665418f
+"deepmerge-ts@npm:^8.0.0":
+  version: 8.0.2
+  resolution: "deepmerge-ts@npm:8.0.2"
+  checksum: 10c0/2be1628a305b8621e4e1abec9ec397aba9745d3c50da714a12e1ac60dc3eb32ee4ea8e1be4c240baf18bbc26f6c6c3e75a4492cfa74cebef70321e5a4ad4f1c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
Adds a global `resolutions` entry forcing `deepmerge-ts` to `^8.0.0`.

Resolves Dependabot alert #627 — **GHSA-ggr8-5vv4-36mx** (DeepmergeTS stack exhaustion when merging recursive object graphs, High). The advisory affects `< 8.0.0`; the fix is `8.0.0` (latest `8.0.2`).

`deepmerge-ts` is pulled in only transitively by WebdriverIO 8.x (`@wdio/config`, `@wdio/utils`, `webdriver`), which pins `^5.1.0`. This is **e2e tooling only** — it is not part of the shipped `@sentry/react-native` SDK (production tree audits clean).

## :bulb: Motivation and Context
Clears a High-severity Dependabot alert. WebdriverIO 8.x was built against deepmerge-ts 5.x, so the concern was the 3-major jump. Verified safe:
- Install is clean and `yarn install --immutable` passes.
- WebdriverIO only consumes `deepmerge` and `deepmergeCustom`; both remain exported as functions in 8.0.2.
- Runtime merge semantics are unchanged (objects deep-merge, arrays concat, `mergeArrays: false` = later-wins). The breaking changes across the 6/7/8 majors were TypeScript type-level only.

Alert: https://github.com/getsentry/sentry-react-native/security/dependabot/627

## :green_heart: How did you test it?
- `yarn install --immutable` passes (lockfile in sync).
- Confirmed resolved version is `deepmerge-ts@8.0.2` across all consumers.
- Verified the `deepmerge` / `deepmergeCustom` API surface and merge semantics WebdriverIO relies on are preserved in 8.x via a runtime smoke test.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
Three sibling alerts (#624/#625 image-size, #626 extract-zip) have no upstream fix available yet and remain open.