### PR TITLE
fix(ios): Quote script paths so Expo iOS build works with spaces in the project path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Fixes
 
-- Fix Expo iOS build failing when the project path contains spaces ([#6583](https://github.com/getsentry/sentry-react-native/issues/6583))
+- Fix Expo iOS build failing when the project path contains spaces ([#6604](https://github.com/getsentry/sentry-react-native/pull/6604))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Add `enableNdkAppHangTracking` and `ndkAppHangTimeoutIntervalMillis` options to enable Android NDK app hang tracking ([#6548](https://github.com/getsentry/sentry-react-native/pull/6548))
 
+### Fixes
+
+- Fix Expo iOS build failing when the project path contains spaces ([#6583](https://github.com/getsentry/sentry-react-native/issues/6583))
+
 ### Dependencies
 
 - Bump Android SDK from v8.52.0 to v8.53.0 ([#6586](https://github.com/getsentry/sentry-react-native/pull/6586))

--- a/packages/core/plugin/src/withSentryIOS.ts
+++ b/packages/core/plugin/src/withSentryIOS.ts
@@ -33,10 +33,11 @@ export const withSentryIOS: ConfigPlugin<{
         shellPath: '/bin/sh',
         shellScript: getDebugFilesUploadScript(disableAutoUpload),
       });
-    } else if (disableAutoUpload) {
-      addDisableAutoUploadToExistingScript(sentryBuildPhase);
     } else {
-      removeDisableAutoUploadFromExistingScript(sentryBuildPhase);
+      // The "Upload Debug Symbols to Sentry" phase is entirely Sentry-owned, so rewrite it to the
+      // freshly generated script. This keeps in-place upgrades (without `expo prebuild --clean`) in
+      // sync: they pick up the space-safe quoting fix (#6583) and the correct disableAutoUpload state.
+      overwriteDebugFilesUploadScript(sentryBuildPhase, disableAutoUpload);
     }
 
     const bundleReactNativePhase = xcodeProject.pbxItemByComment(
@@ -69,6 +70,9 @@ Please open a bug report at https://github.com/getsentry/sentry-react-native`,
   }
 
   if (script.shellScript.includes('sentry-xcode.sh')) {
+    // Re-quote an existing (possibly pre-fix) Sentry bundle line so in-place upgrades without
+    // `expo prebuild --clean` also pick up the space-safe quoting fix (#6583).
+    requoteExistingSentryBundleScript(script);
     if (disableAutoUpload) {
       addDisableAutoUploadToExistingScript(script);
     } else {
@@ -110,6 +114,42 @@ export function getDebugFilesUploadScript(disableAutoUpload: boolean = false): s
   // passed to `/bin/sh` as a single argument instead of being word-split. See issue #6583.
   const disableAutoUploadExport = disableAutoUpload ? `${SENTRY_DISABLE_AUTO_UPLOAD_EXPORT}\n` : '';
   return `${disableAutoUploadExport}/bin/sh "${SENTRY_REACT_NATIVE_XCODE_DEBUG_FILES_PATH}"`;
+}
+
+export function requoteExistingSentryBundleScript(script: BuildPhase): void {
+  try {
+    const code = JSON.parse(script.shellScript);
+    script.shellScript = JSON.stringify(requoteSentryBundleLine(code));
+  } catch {
+    script.shellScript = requoteSentryBundleLine(script.shellScript);
+  }
+}
+
+function requoteSentryBundleLine(code: string): string {
+  const quotedPrefix = `/bin/sh "${SENTRY_REACT_NATIVE_XCODE_PATH}"`;
+  // Already quoted (current form) or an unknown/custom line: leave it untouched.
+  if (code.includes(quotedPrefix)) {
+    return code;
+  }
+  const unquotedPrefix = `/bin/sh ${SENTRY_REACT_NATIVE_XCODE_PATH} `;
+  const start = code.indexOf(unquotedPrefix);
+  if (start === -1) {
+    return code;
+  }
+  const newlineIndex = code.indexOf('\n', start);
+  const end = newlineIndex === -1 ? code.length : newlineIndex;
+  // Everything after the Sentry script path to end-of-line is the react-native-xcode.sh invocation
+  // (a plain path in the default template, a backtick command substitution in the bare/monorepo one).
+  const invocation = code.slice(start + unquotedPrefix.length, end);
+  const requotedLine = `/bin/sh "${SENTRY_REACT_NATIVE_XCODE_PATH}" "${invocation}"`;
+  return code.slice(0, start) + requotedLine + code.slice(end);
+}
+
+export function overwriteDebugFilesUploadScript(script: BuildPhase, disableAutoUpload: boolean = false): void {
+  // Existing phases are stored JSON-encoded by the `xcode` library (see the create path, which passes a
+  // raw string that the library encodes on write). Re-encode the freshly generated script the same way so
+  // it is written back verbatim without double-encoding.
+  script.shellScript = JSON.stringify(getDebugFilesUploadScript(disableAutoUpload));
 }
 
 export function addDisableAutoUploadToExistingScript(script: BuildPhase): void {

--- a/packages/core/plugin/src/withSentryIOS.ts
+++ b/packages/core/plugin/src/withSentryIOS.ts
@@ -29,12 +29,9 @@ export const withSentryIOS: ConfigPlugin<{
       'PBXShellScriptBuildPhase',
     );
     if (!sentryBuildPhase) {
-      const debugFilesScript = disableAutoUpload
-        ? `${SENTRY_DISABLE_AUTO_UPLOAD_EXPORT}\n/bin/sh ${SENTRY_REACT_NATIVE_XCODE_DEBUG_FILES_PATH}`
-        : `/bin/sh ${SENTRY_REACT_NATIVE_XCODE_DEBUG_FILES_PATH}`;
       xcodeProject.addBuildPhase([], 'PBXShellScriptBuildPhase', 'Upload Debug Symbols to Sentry', null, {
         shellPath: '/bin/sh',
-        shellScript: debugFilesScript,
+        shellScript: getDebugFilesUploadScript(disableAutoUpload),
       });
     } else if (disableAutoUpload) {
       addDisableAutoUploadToExistingScript(sentryBuildPhase);
@@ -98,10 +95,21 @@ export function addSentryWithBundledScriptsToBundleShellScript(
   disableAutoUpload: boolean = false,
 ): string {
   const disableAutoUploadExport = disableAutoUpload ? `${SENTRY_DISABLE_AUTO_UPLOAD_EXPORT}\n` : '';
+  // Match through end-of-line so the full react-native-xcode.sh invocation (which in the bare/monorepo
+  // templates is a backtick command substitution ending in `'"` + backtick) stays inside `${match}`.
+  // Both the Sentry script path and the original invocation are wrapped in double quotes so paths
+  // containing spaces are passed as single arguments instead of being word-split. See issue #6583.
   return script.replace(
-    /^.*?(packager|scripts)\/react-native-xcode\.sh\s*(\\'\\\\")?/m,
-    (match: string) => `${disableAutoUploadExport}/bin/sh ${SENTRY_REACT_NATIVE_XCODE_PATH} ${match}`,
+    /^.*?(packager|scripts)\/react-native-xcode\.sh.*$/m,
+    (match: string) => `${disableAutoUploadExport}/bin/sh "${SENTRY_REACT_NATIVE_XCODE_PATH}" "${match}"`,
   );
+}
+
+export function getDebugFilesUploadScript(disableAutoUpload: boolean = false): string {
+  // The resolved script path is wrapped in double quotes so a project path containing spaces is
+  // passed to `/bin/sh` as a single argument instead of being word-split. See issue #6583.
+  const disableAutoUploadExport = disableAutoUpload ? `${SENTRY_DISABLE_AUTO_UPLOAD_EXPORT}\n` : '';
+  return `${disableAutoUploadExport}/bin/sh "${SENTRY_REACT_NATIVE_XCODE_DEBUG_FILES_PATH}"`;
 }
 
 export function addDisableAutoUploadToExistingScript(script: BuildPhase): void {

--- a/packages/core/scripts/sentry-xcode.sh
+++ b/packages/core/scripts/sentry-xcode.sh
@@ -67,7 +67,8 @@ exitCode=0
 
 if [ "$SENTRY_DISABLE_AUTO_UPLOAD" == true ]; then
   echo "SENTRY_DISABLE_AUTO_UPLOAD=true, skipping sourcemaps upload"
-  /bin/sh -c "$REACT_NATIVE_XCODE"
+  # Re-quote so a project path containing spaces is not word-split when re-parsed by `sh -c`. See #6583.
+  /bin/sh -c "\"$REACT_NATIVE_XCODE\""
 elif echo "$CONFIGURATION" | grep -iq "debug"; then # case insensitive check for "debug"
   # Skip the source maps upload for *Debug* configuration, matching the behavior of the
   # native debug files upload (sentry-xcode-debug-files.sh) and the Android Gradle plugin.
@@ -75,7 +76,8 @@ elif echo "$CONFIGURATION" | grep -iq "debug"; then # case insensitive check for
   # bundling step so the build itself succeeds.
   # See: https://github.com/getsentry/sentry-react-native/issues/6399
   echo "Skipping source maps upload for *Debug* configuration"
-  /bin/sh -c "$REACT_NATIVE_XCODE"
+  # Re-quote so a project path containing spaces is not word-split when re-parsed by `sh -c`. See #6583.
+  /bin/sh -c "\"$REACT_NATIVE_XCODE\""
 else
   # 'warning:' triggers a warning in Xcode, 'error:' triggers an error
   set +x +e # disable printing commands otherwise we might print `error:` by accident and allow continuing on error

--- a/packages/core/test/expo-plugin/modifyXcodeProject.test.ts
+++ b/packages/core/test/expo-plugin/modifyXcodeProject.test.ts
@@ -2,6 +2,7 @@ import { warnOnce } from '../../plugin/src/logger';
 import {
   addDisableAutoUploadToExistingScript,
   addSentryWithBundledScriptsToBundleShellScript,
+  getDebugFilesUploadScript,
   modifyExistingXcodeBuildScript,
   removeDisableAutoUploadFromExistingScript,
 } from '../../plugin/src/withSentryIOS';
@@ -18,7 +19,7 @@ export NODE_BINARY=node
 const buildScriptWithSentry = {
   shellScript: JSON.stringify(`"
 export NODE_BINARY=node
-/bin/sh \`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\` ../node_modules/react-native/scripts/react-native-xcode.sh
+/bin/sh "\`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\`" "../node_modules/react-native/scripts/react-native-xcode.sh"
 "`),
 };
 
@@ -32,7 +33,7 @@ export NODE_BINARY=node
 const monorepoBuildScriptWithSentry = {
   shellScript: JSON.stringify(`"
 export NODE_BINARY=node
-/bin/sh \`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\` \`node --print "require.resolve('react-native/package.json').slice(0, -13) + '/scripts/react-native-xcode.sh'"\`
+/bin/sh "\`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\`" "\`node --print "require.resolve('react-native/package.json').slice(0, -13) + '/scripts/react-native-xcode.sh'"\`"
 "`),
 };
 
@@ -287,7 +288,7 @@ describe('Upload Debug Symbols to Sentry build phase', () => {
   let mockXcodeProject: any;
   let addBuildPhaseSpy: jest.Mock;
   const expectedShellScript =
-    "/bin/sh `${NODE_BINARY:-node} --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode-debug-files.sh'\"`";
+    "/bin/sh \"`${NODE_BINARY:-node} --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode-debug-files.sh'\"`\"";
 
   const getOptions = () => {
     const callArgs = addBuildPhaseSpy.mock.calls[0];
@@ -387,5 +388,62 @@ describe('Upload Debug Symbols to Sentry build phase', () => {
       expect(options.shellPath).toBe('/bin/sh');
       expect(options.shellScript).toBe(expectedShellScript);
     });
+  });
+});
+
+describe('Project paths with spaces are quoted (issue #6583)', () => {
+  let consoleWarnMock: jest.SpyInstance<void, [message?: any, ...optionalParams: any[]], any>;
+
+  beforeEach(() => {
+    consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnMock.mockRestore();
+  });
+
+  it('wraps the Sentry script path and the react-native-xcode.sh invocation in double quotes', () => {
+    const input = `"
+export NODE_BINARY=node
+../node_modules/react-native/scripts/react-native-xcode.sh
+"`;
+    const result = addSentryWithBundledScriptsToBundleShellScript(input);
+
+    // The Sentry wrapper path (backtick command substitution) must be wrapped in double quotes.
+    expect(result).toContain('/bin/sh "`');
+    // The original react-native-xcode.sh invocation must be wrapped in double quotes.
+    expect(result).toContain('"../node_modules/react-native/scripts/react-native-xcode.sh"');
+    // No unquoted `/bin/sh ` followed directly by a backtick (the pre-fix, word-splitting form).
+    expect(result).not.toMatch(/\/bin\/sh `/);
+  });
+
+  it('keeps the full backtick invocation inside the added quotes for the bare/monorepo template', () => {
+    // In the bare/monorepo template the invocation is itself a backtick command substitution
+    // ending in `'"` + backtick. Matching to end-of-line keeps it balanced inside the quotes.
+    const input = `"
+export NODE_BINARY=node
+\`node --print "require.resolve('react-native/package.json').slice(0, -13) + '/scripts/react-native-xcode.sh'"\`
+"`;
+    const result = addSentryWithBundledScriptsToBundleShellScript(input);
+
+    expect(result).toContain(
+      `"\`node --print "require.resolve('react-native/package.json').slice(0, -13) + '/scripts/react-native-xcode.sh'"\`"`,
+    );
+    // Balanced backticks: the substitution opened after the quote is also closed before it.
+    expect((result.match(/`/g) || []).length % 2).toBe(0);
+  });
+
+  it('quotes the debug files upload script path', () => {
+    const result = getDebugFilesUploadScript();
+    expect(result).toContain('/bin/sh "`');
+    expect(result).toContain('sentry-xcode-debug-files.sh');
+    expect(result).not.toMatch(/\/bin\/sh `/);
+  });
+
+  it('quotes the debug files upload script path with disableAutoUpload', () => {
+    const result = getDebugFilesUploadScript(true);
+    expect(result).toMatch(/^export SENTRY_DISABLE_AUTO_UPLOAD=true\n\/bin\/sh "`/);
+    expect(result).toContain('sentry-xcode-debug-files.sh');
+    expect(result).not.toMatch(/\/bin\/sh `/);
   });
 });

--- a/packages/core/test/expo-plugin/modifyXcodeProject.test.ts
+++ b/packages/core/test/expo-plugin/modifyXcodeProject.test.ts
@@ -4,6 +4,7 @@ import {
   addSentryWithBundledScriptsToBundleShellScript,
   getDebugFilesUploadScript,
   modifyExistingXcodeBuildScript,
+  overwriteDebugFilesUploadScript,
   removeDisableAutoUploadFromExistingScript,
 } from '../../plugin/src/withSentryIOS';
 
@@ -127,9 +128,14 @@ export NODE_BINARY=node
 /bin/sh \`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\` ../node_modules/react-native/scripts/react-native-xcode.sh
 "`),
     };
-    const before = scriptWithExport.shellScript;
     modifyExistingXcodeBuildScript(scriptWithExport, true);
-    expect(scriptWithExport.shellScript).toBe(before);
+    const parsed = JSON.parse(scriptWithExport.shellScript);
+    // Export is kept exactly once (not duplicated)...
+    expect(parsed.match(/export SENTRY_DISABLE_AUTO_UPLOAD=true/g)).toHaveLength(1);
+    // ...and the pre-fix unquoted line is re-quoted on upgrade (issue #6583).
+    expect(parsed).toContain('/bin/sh "`');
+    expect(parsed).toContain('"../node_modules/react-native/scripts/react-native-xcode.sh"');
+    expect(parsed).not.toMatch(/\/bin\/sh `/);
   });
 
   it('Does not modify already-configured script when disableAutoUpload is false', () => {
@@ -388,6 +394,97 @@ describe('Upload Debug Symbols to Sentry build phase', () => {
       expect(options.shellPath).toBe('/bin/sh');
       expect(options.shellScript).toBe(expectedShellScript);
     });
+  });
+});
+
+describe('Bundle phase re-quoted on in-place upgrade (issue #6583)', () => {
+  let consoleWarnMock: jest.SpyInstance<void, [message?: any, ...optionalParams: any[]], any>;
+
+  beforeEach(() => {
+    consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleWarnMock.mockRestore();
+  });
+
+  // The unquoted forms a pre-fix plugin version left behind in an existing bundle phase.
+  const oldUnquotedBundleScript = {
+    shellScript: JSON.stringify(`"
+export NODE_BINARY=node
+/bin/sh \`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\` ../node_modules/react-native/scripts/react-native-xcode.sh
+"`),
+  };
+
+  const oldUnquotedMonorepoBundleScript = {
+    shellScript: JSON.stringify(`"
+export NODE_BINARY=node
+/bin/sh \`"$NODE_BINARY" --print "require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'"\` \`node --print "require.resolve('react-native/package.json').slice(0, -13) + '/scripts/react-native-xcode.sh'"\`
+"`),
+  };
+
+  it('re-quotes an existing unquoted default-template bundle line', () => {
+    const script = Object.assign({}, oldUnquotedBundleScript);
+    modifyExistingXcodeBuildScript(script);
+    expect(JSON.parse(script.shellScript)).toStrictEqual(JSON.parse(buildScriptWithSentry.shellScript));
+  });
+
+  it('re-quotes an existing unquoted monorepo-template bundle line', () => {
+    const script = Object.assign({}, oldUnquotedMonorepoBundleScript);
+    modifyExistingXcodeBuildScript(script);
+    expect(JSON.parse(script.shellScript)).toStrictEqual(JSON.parse(monorepoBuildScriptWithSentry.shellScript));
+  });
+
+  it('re-quotes and still injects the export when disableAutoUpload is true', () => {
+    const script = Object.assign({}, oldUnquotedBundleScript);
+    modifyExistingXcodeBuildScript(script, true);
+    const parsed = JSON.parse(script.shellScript);
+    expect(parsed).toContain('export SENTRY_DISABLE_AUTO_UPLOAD=true');
+    expect(parsed).toContain('/bin/sh "`');
+    expect(parsed).not.toMatch(/\/bin\/sh `/);
+  });
+
+  it('leaves an already-quoted bundle line unchanged (idempotent)', () => {
+    const script = Object.assign({}, buildScriptWithSentry);
+    modifyExistingXcodeBuildScript(script);
+    expect(JSON.parse(script.shellScript)).toStrictEqual(JSON.parse(buildScriptWithSentry.shellScript));
+  });
+});
+
+describe('overwriteDebugFilesUploadScript: existing phase re-quoted on upgrade (issue #6583)', () => {
+  // The unquoted form a pre-fix plugin version left behind in an existing project.
+  const oldUnquotedDebugFiles =
+    "/bin/sh `${NODE_BINARY:-node} --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode-debug-files.sh'\"`";
+
+  it('rewrites an existing unquoted phase to the quoted, space-safe form', () => {
+    const script = { shellScript: JSON.stringify(oldUnquotedDebugFiles) };
+    overwriteDebugFilesUploadScript(script);
+    const parsed = JSON.parse(script.shellScript);
+    expect(parsed).toBe(getDebugFilesUploadScript(false));
+    expect(parsed).toContain('/bin/sh "`');
+    expect(parsed).not.toMatch(/\/bin\/sh `/);
+  });
+
+  it('rewrites and injects the disable-auto-upload export when requested', () => {
+    const script = { shellScript: JSON.stringify(oldUnquotedDebugFiles) };
+    overwriteDebugFilesUploadScript(script, true);
+    const parsed = JSON.parse(script.shellScript);
+    expect(parsed).toBe(getDebugFilesUploadScript(true));
+    expect(parsed).toMatch(/^export SENTRY_DISABLE_AUTO_UPLOAD=true\n\/bin\/sh "`/);
+  });
+
+  it('drops a previously injected export when disableAutoUpload is toggled back to false', () => {
+    const script = { shellScript: JSON.stringify(getDebugFilesUploadScript(true)) };
+    overwriteDebugFilesUploadScript(script, false);
+    const parsed = JSON.parse(script.shellScript);
+    expect(parsed).not.toContain('SENTRY_DISABLE_AUTO_UPLOAD');
+    expect(parsed).toContain('/bin/sh "`');
+  });
+
+  it('is idempotent when the phase is already quoted', () => {
+    const script = { shellScript: JSON.stringify(getDebugFilesUploadScript(false)) };
+    overwriteDebugFilesUploadScript(script);
+    expect(JSON.parse(script.shellScript)).toBe(getDebugFilesUploadScript(false));
   });
 });
 

--- a/packages/core/test/scripts/sentry-xcode-scripts.test.ts
+++ b/packages/core/test/scripts/sentry-xcode-scripts.test.ts
@@ -481,6 +481,64 @@ describe('sentry-xcode.sh', () => {
     expect(result.stdout).toContain('Mock React Native bundle');
   });
 
+  describe('project path containing spaces (issue #6583)', () => {
+    // Put react-native-xcode.sh in a directory whose path contains a space. The disable and Debug
+    // branches re-parse REACT_NATIVE_XCODE via `/bin/sh -c`, which word-splits on the space unless
+    // the path is re-quoted.
+    const makeSpacedScript = (): string => {
+      const spacedDir = path.join(tempDir, 'My App');
+      fs.mkdirSync(spacedDir, { recursive: true });
+      const spacedScript = path.join(spacedDir, 'react-native-xcode.sh');
+      fs.writeFileSync(spacedScript, '#!/bin/bash\necho "Mock React Native bundle"\nexit 0\n');
+      fs.chmodSync(spacedScript, '755');
+      return spacedScript;
+    };
+
+    const runWithArg = (arg: string, env: Record<string, string> = {}) => {
+      const mockCollectModulesScript = path.join(tempDir, 'collect-modules.sh');
+      fs.writeFileSync(mockCollectModulesScript, '#!/bin/bash\nexit 0\n');
+      fs.chmodSync(mockCollectModulesScript, '755');
+      try {
+        const stdout = execSync(`bash "${XCODE_SCRIPT}" "${arg}"`, {
+          env: {
+            ...process.env,
+            NODE_BINARY: process.execPath,
+            SENTRY_CLI_EXECUTABLE: mockSentryCliScript,
+            PROJECT_DIR: tempDir,
+            DERIVED_FILE_DIR: tempDir,
+            SENTRY_COLLECT_MODULES: mockCollectModulesScript,
+            ...env,
+          },
+          encoding: 'utf8',
+          stdio: 'pipe',
+        });
+        return { stdout, stderr: '', exitCode: 0 };
+      } catch (error: any) {
+        return {
+          stdout: error.stdout?.toString() || '',
+          stderr: error.stderr?.toString() || '',
+          exitCode: error.status || 1,
+        };
+      }
+    };
+
+    it('runs react-native-xcode.sh from a spaced path when SENTRY_DISABLE_AUTO_UPLOAD=true', () => {
+      const result = runWithArg(makeSpacedScript(), { SENTRY_DISABLE_AUTO_UPLOAD: 'true' });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Mock React Native bundle');
+      expect(result.stdout).not.toContain('No such file or directory');
+    });
+
+    it('runs react-native-xcode.sh from a spaced path for Debug configuration', () => {
+      const result = runWithArg(makeSpacedScript(), { CONFIGURATION: 'Debug' });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Mock React Native bundle');
+      expect(result.stdout).not.toContain('No such file or directory');
+    });
+  });
+
   describe('SENTRY_PROJECT_ROOT override', () => {
     it('resolves SOURCEMAP_FILE relative to SENTRY_PROJECT_ROOT instead of PROJECT_DIR/..', () => {
       const customRoot = path.join(tempDir, 'monorepo-package');


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description

The Expo config plugin and `sentry-xcode.sh` invoked scripts via **unquoted command substitutions**. When the resolved path contains a space (e.g. `/Users/me/My App/...`), the shell word-splits it and the build fails with:

```
/bin/sh: /Users/me/My: No such file or directory
```

This wraps the resolved script paths in double quotes across the plugin and the shell script:

1. **`plugin/src/withSentryIOS.ts` — "Bundle React Native code and images" phase.** Both the Sentry wrapper path and the original `react-native-xcode.sh` invocation are now quoted. The match regex was extended to end-of-line so the full backtick command substitution used by the bare/monorepo template (which ends in `'"` + backtick) stays balanced inside the added quotes.
2. **`plugin/src/withSentryIOS.ts` — "Upload Debug Symbols to Sentry" phase.** The `sentry-xcode-debug-files.sh` path is now quoted. Extracted into a small exported `getDebugFilesUploadScript()` helper so it is unit-testable.
3. **`scripts/sentry-xcode.sh`.** The `SENTRY_DISABLE_AUTO_UPLOAD=true` branch **and** the `Debug`-configuration branch re-parse `REACT_NATIVE_XCODE` via `/bin/sh -c`; both are now re-quoted, matching the already-quoted upload branch (line 64).
4. **In-place upgrades (no `expo prebuild --clean`).** The quoting above only ran when the build phases were **created**. If a project already contained the (old, unquoted) phases, the plugin previously toggled only the disable-auto-upload export and left the unquoted script untouched — so upgrading the SDK on a committed `ios/` project kept breaking on spaced paths. Both phases are now re-quoted on upgrade:
   - The **debug-symbols** phase is entirely Sentry-owned, so it is rewritten to the freshly generated, quoted script.
   - The **bundle** phase is re-quoted only when the exact old unquoted Sentry line is found; already-quoted or user-customized lines are left untouched.

> The original report covered the disable-upload branch; the identical bug in the Debug-configuration branch (`sentry-xcode.sh:78`) and the in-place upgrade path are fixed here as well.


## :bulb: Motivation and Context

Fixes #6583 — any Expo app whose path contains a space fails to build on iOS.


## :green_heart: How did you test it?

- Reproduced the exact failure with a real spaced-path fixture, then confirmed it is resolved end-to-end by running the **compiled plugin's** generated build phases through the real `sentry-xcode.sh`.
- Verified the **in-place upgrade** path against the real `xcode` library: an existing phase, once rewritten, round-trips through `pbxproj` write/read without double-encoding, and the produced `/bin/sh "..."` line passes a spaced project path as a single argument.
- Added regression tests that **fail without the fix and pass with it**:
  - `test/scripts/sentry-xcode-scripts.test.ts` — executes `sentry-xcode.sh` with `react-native-xcode.sh` in a `My App` (spaced) directory for both the disable-upload and Debug branches.
  - `test/expo-plugin/modifyXcodeProject.test.ts` — asserts the generated bundle and debug-files scripts quote their paths (standard + bare/monorepo templates), and covers the upgrade path: pre-fix unquoted bundle and debug-symbols phases are re-quoted, the export is not duplicated, and already-quoted phases are left unchanged (idempotent).
- Updated existing fixtures to the quoted output. Full suite green: **1885** SDK + **334** tools + **40** shell-script tests pass; `yarn lint:lerna` clean.


## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
