### PR TITLE
[PROOF · DO NOT MERGE] sentry-cocoa 9.26.0 breaks iOS Replay network-detail requests (Spaceflight E2E)

### DIFF
--- a/packages/core/RNSentry.podspec
+++ b/packages/core/RNSentry.podspec
@@ -63,7 +63,7 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES'
   }
 
-  sentry_cocoa_version = '9.26.0'
+  sentry_cocoa_version = '9.24.0'
 
   # Consume sentry-cocoa as a prebuilt `Sentry.xcframework` by default.
   #

--- a/packages/core/scripts/sentry_utils.rb
+++ b/packages/core/scripts/sentry_utils.rb
@@ -60,8 +60,8 @@ SENTRY_COCOA_XCFRAMEWORK_CHECKSUMS = {
   # `Sentry` module. `Sentry-Dynamic.xcframework` would ship the same
   # `Sentry.framework` inside but under a mismatched enclosing name, so
   # CocoaPods generates `-framework Sentry-Dynamic` and fails at link.
-  '9.26.0' => {
-    'Sentry' => 'e1b80746e632d1127975b9ecca2d42398a74e4adac94882a71192eee41b1dc29',
+  '9.24.0' => {
+    'Sentry' => 'c530edd27b20f7c151e73d84a34ee03474e3d5ddab65ffe9d30366f80149668a',
   },
 }.freeze
 


### PR DESCRIPTION
> [!WARNING]
> **Proof-of-issue PR — NOT for merge.** This PR exists to demonstrate, via CI, that **sentry-cocoa 9.26.0** breaks iOS `URLSession` requests to Session Replay network-detail allow-listed URLs. The real fix belongs in sentry-cocoa. Close once the upstream issue is resolved.

## :mag: What this proves

The iOS E2E `captureSpaceflightNewsScreenTransaction.test.ios.auto` flow began failing **deterministically** on `main` and every PR immediately after the sentry-cocoa `9.24.0 → 9.26.0` bump (#6409). It is the only iOS flow making a real external HTTP request, and it was the only one failing (`No visible element found: "Load More Articles"` — the article fetch never completes, so the list never renders).

A three-way E2E bisect (one variable changed at a time) isolates the cause:

| sentry-cocoa | Replay network-detail capture | Spaceflight flow |
|---|---|---|
| 9.26.0 | on | :x: red (4/4 deterministic) |
| 9.24.0 | on | :white_check_mark: green |
| 9.26.0 | **off** | :white_check_mark: green |

Two independent single-variable flips each turn it green → the trigger is sentry-cocoa 9.26.0's **Session Replay network-detail** path. This branch demonstrates the third row: it removes `networkDetailAllowUrls` + `networkCaptureBodies` from the sample's `mobileReplayIntegration`, and iOS E2E goes green while cocoa stays at 9.26.0.

## :dart: Suspected upstream cause

**getsentry/sentry-cocoa#8497** — *"Prevent Session Replay network-detail breadcrumbs from blocking URLSession cancellation on the task monitor"* — the only 9.26.0 change touching both the network-detail path and URLSession lifecycle. #8650 (trace-header setter) is ruled out: it is not gated on replay network-detail, so disabling network-detail would not have fixed it. Last-known-good is 9.24.0 (9.25.0 shipped no networking changes).

## :wrench: Proposed cocoa fix — getsentry/sentry-cocoa#8852

**getsentry/sentry-cocoa#8852** reorders the `URLSession` completion-handler wrappers so the app receives the response *before* Replay network-detail enrichment reads properties on the `URLSessionTask` (which contend on the task's internal monitor).

> [!IMPORTANT]
> **This is expected to be necessary but not sufficient for React Native.** #8852, by its author's own scope note, only fixes the **completion-handler** swizzle path (`captureResponseDetails`). React Native's iOS networking uses **delegate-based** `RCTHTTPRequestHandler` (`dataTaskWithRequest:` with no completion handler), which flows through the **delegate** path (`urlSessionTaskResume` / swizzled `setState:` → `captureRequestDetails`) — explicitly called out as *not* covered by #8852. So this PR is not expected to go green from #8852 alone; it will be re-run to verify once cocoa ships a fix covering the delegate path and cuts a release the RN build can download.

## :green_heart: Evidence (CI runs, `sample-application.yml` → `Test ios`)

- Red — cocoa 9.26.0, capture on: run `32713642451`
- Green — cocoa 9.24.0, capture on: run `32722276675`
- Green — cocoa 9.26.0, capture **off** (this branch): run `32725506585` → `[Passed] captureSpaceflightNewsScreenTransaction.test.ios.auto (24s)`

## :warning: Impact

Any app on sentry-cocoa 9.26.0 using Session Replay with `networkDetailAllowUrls` + body capture will have its requests to those hosts broken — a functional networking regression, not just telemetry loss. Bounded to allow-listed network-detail URLs; other traffic is unaffected.

## :crystal_ball: Next steps (not in this PR)

- Upstream tracking: sentry-cocoa#8852 (completion-handler path). Delegate-path fix still needed for RN.
- Once cocoa ships a fix covering the delegate path **and** cuts a release, restore `networkDetailAllowUrls` + `networkCaptureBodies` here, bump the cocoa pin, and re-run iOS E2E to confirm green.
- This PR is intentionally **not** mergeable — it is a reproduction. Do not restore the removed options here as a "fix"; that is only a workaround.
