### PR TITLE
fix(replay): Warn when replay sample rates are set but the Replay integration is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- Warn when replay sample rates are set but the Replay integration is missing ([#6612](https://github.com/getsentry/sentry-react-native/pull/6612))
 - Fix Expo iOS build failing when the project path contains spaces ([#6604](https://github.com/getsentry/sentry-react-native/pull/6604))
 - Fix Android fragment memory leak in `RNSentryReactFragmentLifecycleTracer` ([#6599](https://github.com/getsentry/sentry-react-native/pull/6599))
 

--- a/packages/core/src/js/replay/browserReplay.ts
+++ b/packages/core/src/js/replay/browserReplay.ts
@@ -14,6 +14,8 @@ type ReplayConfiguration = Parameters<typeof replayIntegration>[0];
 // https://github.com/getsentry/sentry-javascript/blob/e00cb04f1bbf494067cd8475d392266ba296987a/packages/replay-internal/src/integration.ts#L109
 const INTEGRATION_NAME = 'Replay';
 
+export const BROWSER_REPLAY_INTEGRATION_NAME = INTEGRATION_NAME;
+
 /**
  * Browser Replay integration for React Native.
  *

--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -215,11 +215,12 @@ function warnIfReplayIntegrationMissing(options: ReactNativeClientOptions): void
   // Only a rate > 0 actually enables replay; `0` is a valid way to keep it off, so it must not warn.
   const isEnabledRate = (rate: number | undefined): boolean => typeof rate === 'number' && rate > 0;
   const experiments = options._experiments;
-  const hasReplayOptions =
-    isEnabledRate(options.replaysOnErrorSampleRate) ||
-    isEnabledRate(options.replaysSessionSampleRate) ||
-    isEnabledRate(experiments?.replaysOnErrorSampleRate) ||
-    isEnabledRate(experiments?.replaysSessionSampleRate);
+const hasReplayOptions = [
+    options.replaysOnErrorSampleRate,
+    options.replaysSessionSampleRate,
+    experiments?.replaysOnErrorSampleRate,
+    experiments?.replaysSessionSampleRate,
+].some(isEnabledRate);
 
   if (!hasReplayOptions) {
     return;

--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -22,6 +22,8 @@ import { FeedbackFormProvider } from './feedback/FeedbackFormProvider';
 import { getDevServer } from './integrations/debugsymbolicatorutils';
 import { getDefaultIntegrations } from './integrations/default';
 import { shouldEnableNativeNagger } from './options';
+import { BROWSER_REPLAY_INTEGRATION_NAME } from './replay/browserReplay';
+import { MOBILE_REPLAY_INTEGRATION_NAME } from './replay/mobilereplay';
 import { enableSyncToNative } from './scopeSync';
 import { TouchEventBoundary } from './touchevents';
 import { ReactNativeProfiler } from './tracing';
@@ -180,6 +182,7 @@ export function init(passedOptions: ReactNativeOptions): void {
     integrations: safeFactory(userOptions.integrations, { loggerMessage: 'The integrations threw an error' }),
     defaultIntegrations,
   });
+  warnIfReplayIntegrationMissing(options);
   initAndBind(ReactNativeClient, options);
   if (__DEV__) {
     checkSentryJsSdkVersionMismatch();
@@ -197,6 +200,39 @@ export function init(passedOptions: ReactNativeOptions): void {
     // it into JS as `__SENTRY_OPTIONS__`, and native reads it before JS runs).
     registerFeatureMarker(CAPTURE_APP_START_ERRORS_INTEGRATION_NAME);
   }
+}
+
+/**
+ * Warns when replay sample rates are configured but the matching Replay integration is missing.
+ *
+ * The mobile integration is auto-added by `getDefaultIntegrations` when sample rates are set, but
+ * that path is skipped when the user supplies their own `defaultIntegrations`. On web the browser
+ * integration is never auto-added. In both cases replay would otherwise fail silently.
+ */
+function warnIfReplayIntegrationMissing(options: ReactNativeClientOptions): void {
+  const hasReplayOptions =
+    typeof options.replaysOnErrorSampleRate === 'number' ||
+    typeof options.replaysSessionSampleRate === 'number' ||
+    typeof options._experiments?.replaysOnErrorSampleRate === 'number' ||
+    typeof options._experiments?.replaysSessionSampleRate === 'number';
+
+  if (!hasReplayOptions) {
+    return;
+  }
+
+  const expectedIntegrationName = isWeb() ? BROWSER_REPLAY_INTEGRATION_NAME : MOBILE_REPLAY_INTEGRATION_NAME;
+  const hasReplayIntegration = options.integrations.some(integration => integration.name === expectedIntegrationName);
+
+  if (hasReplayIntegration) {
+    return;
+  }
+
+  const factoryName = isWeb() ? 'browserReplayIntegration()' : 'mobileReplayIntegration()';
+  debug.warn(
+    `[Sentry] \`replaysSessionSampleRate\` or \`replaysOnErrorSampleRate\` is set but the \`${expectedIntegrationName}\` integration is missing. ` +
+      `Session Replay may not work as expected. Add \`Sentry.${factoryName}\` to the \`integrations\` option to enable it. ` +
+      `See https://docs.sentry.io/platforms/react-native/session-replay/#set-up`,
+  );
 }
 
 /**

--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -212,11 +212,14 @@ export function init(passedOptions: ReactNativeOptions): void {
  * integration is never auto-added. In both cases replay would otherwise fail silently.
  */
 function warnIfReplayIntegrationMissing(options: ReactNativeClientOptions): void {
+  // Only a rate > 0 actually enables replay; `0` is a valid way to keep it off, so it must not warn.
+  const isEnabledRate = (rate: number | undefined): boolean => typeof rate === 'number' && rate > 0;
+  const experiments = options._experiments;
   const hasReplayOptions =
-    typeof options.replaysOnErrorSampleRate === 'number' ||
-    typeof options.replaysSessionSampleRate === 'number' ||
-    typeof options._experiments?.replaysOnErrorSampleRate === 'number' ||
-    typeof options._experiments?.replaysSessionSampleRate === 'number';
+    isEnabledRate(options.replaysOnErrorSampleRate) ||
+    isEnabledRate(options.replaysSessionSampleRate) ||
+    isEnabledRate(experiments?.replaysOnErrorSampleRate) ||
+    isEnabledRate(experiments?.replaysSessionSampleRate);
 
   if (!hasReplayOptions) {
     return;

--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -182,8 +182,10 @@ export function init(passedOptions: ReactNativeOptions): void {
     integrations: safeFactory(userOptions.integrations, { loggerMessage: 'The integrations threw an error' }),
     defaultIntegrations,
   });
-  warnIfReplayIntegrationMissing(options);
   initAndBind(ReactNativeClient, options);
+  // Must run after `initAndBind`: that is where `@sentry/core` enables the debug logger
+  // (`debug.enable()` when `debug: true`), so `debug.warn` is a no-op before it.
+  warnIfReplayIntegrationMissing(options);
   if (__DEV__) {
     checkSentryJsSdkVersionMismatch();
   }

--- a/packages/core/src/js/sdk.tsx
+++ b/packages/core/src/js/sdk.tsx
@@ -215,25 +215,26 @@ function warnIfReplayIntegrationMissing(options: ReactNativeClientOptions): void
   // Only a rate > 0 actually enables replay; `0` is a valid way to keep it off, so it must not warn.
   const isEnabledRate = (rate: number | undefined): boolean => typeof rate === 'number' && rate > 0;
   const experiments = options._experiments;
-const hasReplayOptions = [
+  const hasReplayOptions = [
     options.replaysOnErrorSampleRate,
     options.replaysSessionSampleRate,
     experiments?.replaysOnErrorSampleRate,
     experiments?.replaysSessionSampleRate,
-].some(isEnabledRate);
+  ].some(isEnabledRate);
 
   if (!hasReplayOptions) {
     return;
   }
 
-  const expectedIntegrationName = isWeb() ? BROWSER_REPLAY_INTEGRATION_NAME : MOBILE_REPLAY_INTEGRATION_NAME;
+  const web = isWeb();
+  const expectedIntegrationName = web ? BROWSER_REPLAY_INTEGRATION_NAME : MOBILE_REPLAY_INTEGRATION_NAME;
   const hasReplayIntegration = options.integrations.some(integration => integration.name === expectedIntegrationName);
 
   if (hasReplayIntegration) {
     return;
   }
 
-  const factoryName = isWeb() ? 'browserReplayIntegration()' : 'mobileReplayIntegration()';
+  const factoryName = web ? 'browserReplayIntegration()' : 'mobileReplayIntegration()';
   debug.warn(
     `[Sentry] \`replaysSessionSampleRate\` or \`replaysOnErrorSampleRate\` is set but the \`${expectedIntegrationName}\` integration is missing. ` +
       `Session Replay may not work as expected. Add \`Sentry.${factoryName}\` to the \`integrations\` option to enable it. ` +

--- a/packages/core/test/sdk.test.ts
+++ b/packages/core/test/sdk.test.ts
@@ -1306,6 +1306,26 @@ describe('Tests the SDK functionality', () => {
       expect(debug.warn).not.toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
     });
 
+    it('does not warn when replay sample rates are set to 0 (replay disabled)', () => {
+      init({
+        replaysSessionSampleRate: 0,
+        replaysOnErrorSampleRate: 0,
+        defaultIntegrations: [],
+      });
+
+      expect(debug.warn).not.toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+    });
+
+    it('warns when only replaysOnErrorSampleRate is greater than 0 and the integration is missing', () => {
+      init({
+        replaysSessionSampleRate: 0,
+        replaysOnErrorSampleRate: 1.0,
+        defaultIntegrations: [],
+      });
+
+      expect(debug.warn).toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+    });
+
     it('warns with the browser integration hint when on web and the browser replay integration is missing', () => {
       (notWeb as jest.Mock).mockImplementation(() => false);
       (isWeb as jest.Mock).mockImplementation(() => true);

--- a/packages/core/test/sdk.test.ts
+++ b/packages/core/test/sdk.test.ts
@@ -10,13 +10,14 @@ import { getDevServer } from '../src/js/integrations/debugsymbolicatorutils';
 import { init, withScope } from '../src/js/sdk';
 import { REACT_NATIVE_TRACING_INTEGRATION_NAME, reactNativeTracingIntegration } from '../src/js/tracing';
 import { makeNativeTransport } from '../src/js/transports/native';
-import { getDefaultEnvironment, isExpoGo, notWeb } from '../src/js/utils/environment';
+import { getDefaultEnvironment, isExpoGo, isWeb, notWeb } from '../src/js/utils/environment';
 import { registerFeatureMarker } from '../src/js/utils/featureMarkers';
 import { RN_GLOBAL_OBJ } from '../src/js/utils/worldwide';
 import { NATIVE } from './mockWrapper';
 import { firstArg, secondArg } from './testutils';
 
 jest.spyOn(debug, 'error');
+jest.spyOn(debug, 'warn');
 jest.mock('../src/js/wrapper', () => jest.requireActual('./mockWrapper'));
 jest.mock('../src/js/utils/environment');
 jest.mock('@sentry/core', () => ({
@@ -1243,6 +1244,89 @@ describe('Tests the SDK functionality', () => {
 
     expectNotIntegration('Replay');
     expectNotIntegration('MobileReplay');
+  });
+
+  describe('replay integration missing warning', () => {
+    // Phrase unique to the missing-integration warning, so assertions don't collide with
+    // other replay warnings (e.g. the Expo Go / unsupported-platform noop warnings).
+    const MISSING_WARNING = 'integration is missing';
+
+    beforeEach(() => {
+      // Isolate from mock implementations leaked by earlier tests (isExpoGo/isWeb are not reset in the outer beforeEach).
+      (isExpoGo as jest.Mock).mockImplementation(() => false);
+      (isWeb as jest.Mock).mockImplementation(() => false);
+    });
+
+    it('warns when replay sample rates are set but the mobile replay integration is missing', () => {
+      init({
+        replaysSessionSampleRate: 1.0,
+        // Supplying defaultIntegrations skips the auto-add of mobileReplayIntegration
+        defaultIntegrations: [],
+      });
+
+      expectNotIntegration('MobileReplay');
+      expect(debug.warn).toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+      expect(debug.warn).toHaveBeenCalledWith(expect.stringContaining('mobileReplayIntegration()'));
+    });
+
+    it('warns when only replaysOnErrorSampleRate is set but the mobile replay integration is missing', () => {
+      init({
+        replaysOnErrorSampleRate: 1.0,
+        defaultIntegrations: [],
+      });
+
+      expect(debug.warn).toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+    });
+
+    it('warns when experimental replay sample rates are set but the mobile replay integration is missing', () => {
+      init({
+        _experiments: {
+          replaysSessionSampleRate: 1.0,
+        },
+        defaultIntegrations: [],
+      });
+
+      expect(debug.warn).toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+    });
+
+    it('does not warn when the mobile replay integration is auto-added', () => {
+      init({
+        replaysSessionSampleRate: 1.0,
+      });
+
+      expectIntegration('MobileReplay');
+      expect(debug.warn).not.toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+    });
+
+    it('does not warn when no replay sample rates are set', () => {
+      init({
+        defaultIntegrations: [],
+      });
+
+      expect(debug.warn).not.toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+    });
+
+    it('warns with the browser integration hint when on web and the browser replay integration is missing', () => {
+      (notWeb as jest.Mock).mockImplementation(() => false);
+      (isWeb as jest.Mock).mockImplementation(() => true);
+      init({
+        replaysSessionSampleRate: 1.0,
+      });
+
+      expect(debug.warn).toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+      expect(debug.warn).toHaveBeenCalledWith(expect.stringContaining('browserReplayIntegration()'));
+    });
+
+    it('does not warn when on web and the browser replay integration is present', () => {
+      (notWeb as jest.Mock).mockImplementation(() => false);
+      (isWeb as jest.Mock).mockImplementation(() => true);
+      init({
+        replaysSessionSampleRate: 1.0,
+        integrations: [createMockedIntegration({ name: 'Replay' })],
+      });
+
+      expect(debug.warn).not.toHaveBeenCalledWith(expect.stringContaining(MISSING_WARNING));
+    });
   });
 
   // TODO: No longer an experiment on major version.


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Emit a `debug.warn` at `Sentry.init` when a replay sample rate (`replaysSessionSampleRate` / `replaysOnErrorSampleRate`, or their `_experiments` variants) is set but the matching Replay integration is not present in the resolved integrations list — `MobileReplay` on native, `Replay` (browser) on web.

- Added `warnIfReplayIntegrationMissing(options)` in `sdk.tsx`, called right after `getIntegrationsToSetup` so it inspects the *resolved* integration set.
- Exported `BROWSER_REPLAY_INTEGRATION_NAME` from `browserReplay.ts` so the check matches by name constant instead of a magic string.
- The message is platform-aware and points at the correct factory (`mobileReplayIntegration()` / `browserReplayIntegration()`) plus the setup docs.

Warning-only by design: it **never mutates** the resolved integrations. The wording is "may not work as expected" rather than "will not be recorded" because on native, session recording is actually driven by the sample rates alone — what silently breaks without the integration is error→replay linking, on-error (buffer) flush for JS errors, and masking customization; on web nothing records at all.

## :bulb: Motivation and Context
Closes #6600.

When `mobileReplayIntegration()` is omitted but sample rates are set, replay setup can fail silently — no error or alert. The SDK already auto-adds the mobile integration via `getDefaultIntegrations`, but that path is skipped when the user supplies their own `defaultIntegrations` (array or `false`) or a function-form `integrations` that filters it out, and the browser integration is never auto-added. In those cases there is currently no signal to the developer.

I considered auto-adding the integration instead of warning, but rejected it: the documented way to disable a Sentry integration is to remove it via `integrations`/`defaultIntegrations`, and re-injecting it would override that explicit intent and could silently turn Session Replay (a PII/cost-sensitive feature) back on — a fail-open regression. `debug.warn` only emits when `debug: true`, so there is no production noise.

## :green_heart: How did you test it?
Added unit tests in `packages/core/test/sdk.test.ts` (new `replay integration missing warning` describe block):
- warns when session / on-error / `_experiments` sample rates are set but the mobile integration is missing (via `defaultIntegrations: []`)
- does not warn when the mobile integration is auto-added (default path)
- does not warn when no sample rates are set
- warns with the `browserReplayIntegration()` hint on web when the browser integration is missing
- does not warn on web when the browser integration is present

`yarn jest test/sdk.test.ts` → 125 passed. oxlint (type-aware) and oxfmt clean on changed files.

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
