### PR TITLE
test(ios): Speed up sentry-xcode-scripts tests

### DIFF
--- a/packages/core/test/scripts/sentry-xcode-scripts.test.ts
+++ b/packages/core/test/scripts/sentry-xcode-scripts.test.ts
@@ -61,10 +61,15 @@ describe('sentry-xcode-debug-files.sh', () => {
     }
   };
 
+  // These tests exercise the upload path only and never create a dSYM bundle. Without disabling
+  // the dSYM wait they would each hit the full wait_for_dsym_files() timeout (~10s), so set
+  // SENTRY_DSYM_WAIT_ENABLED=false to keep them fast. The dSYM wait behavior is covered by the
+  // dedicated 'dSYM wait functionality' block below.
   it('exits with 0 when upload succeeds', () => {
     const result = runScript({
       MOCK_CLI_EXIT_CODE: '0',
       MOCK_CLI_OUTPUT: 'Upload successful',
+      SENTRY_DSYM_WAIT_ENABLED: 'false',
     });
 
     expect(result.exitCode).toBe(0);
@@ -76,6 +81,7 @@ describe('sentry-xcode-debug-files.sh', () => {
       MOCK_CLI_EXIT_CODE: '1',
       MOCK_CLI_OUTPUT: 'Upload failed: API error',
       SENTRY_ALLOW_FAILURE: 'true',
+      SENTRY_DSYM_WAIT_ENABLED: 'false',
     });
 
     expect(result.exitCode).toBe(0);
@@ -88,6 +94,7 @@ describe('sentry-xcode-debug-files.sh', () => {
     const result = runScript({
       MOCK_CLI_EXIT_CODE: '1',
       MOCK_CLI_OUTPUT: 'Upload failed: API error',
+      SENTRY_DSYM_WAIT_ENABLED: 'false',
     });
 
     // Original behavior: script exits 0, but Xcode fails build due to "error:" prefix
@@ -102,6 +109,7 @@ describe('sentry-xcode-debug-files.sh', () => {
       MOCK_CLI_EXIT_CODE: '1',
       MOCK_CLI_OUTPUT: 'Upload failed: Network error',
       SENTRY_ALLOW_FAILURE: 'false',
+      SENTRY_DSYM_WAIT_ENABLED: 'false',
     });
 
     // Original behavior: script exits 0, but Xcode fails build due to "error:" prefix


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
Four upload-behavior tests in the `sentry-xcode-debug-files.sh` block of `sentry-xcode-scripts.test.ts` never create a dSYM bundle and did not disable the dSYM wait. As a result each one fell into `wait_for_dsym_files()` and waited out the full default timeout (10 attempts with progressive backoff ≈ 10s) for a dSYM that is never produced. The tests passed anyway — the script proceeds after the timeout — so the cost was invisible, just slow.

Since these tests assert only on upload success/error output, this sets `SENTRY_DSYM_WAIT_ENABLED=false` on those four tests. The dedicated `dSYM wait functionality` block still exercises the wait behavior and is unchanged.

No change in coverage.


## :bulb: Motivation and Context
`test/scripts/sentry-xcode-scripts.test.ts` took ~59s while every other test file finishes in seconds. The four affected tests accounted for ~44s of that (~11s each), all spent sleeping in the dSYM wait loop rather than testing anything.

Verified at the script level: invoking `sentry-xcode-debug-files.sh` with the exact env these tests use runs for **10.835s** with the wait enabled vs **0.048s** with `SENTRY_DSYM_WAIT_ENABLED=false`.


## :green_heart: How did you test it?
Ran the file before and after:

- Before: `Time: 59.148 s`, 40 passed
- After: `Time: 14.74 s`, 40 passed

The remaining time is legitimate — the dedicated wait tests intentionally sleep 1–2s and assert on real timing.


## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)