### PR TITLE
chore: Extend agents.toml and .agents/skills (#6637)

### DIFF
--- a/.agents/skills/code-guidelines/SKILL.md
+++ b/.agents/skills/code-guidelines/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: code-guidelines
+description: Enforce Sentry React Native SDK code guidelines for implementation, refactoring, and review. Use when implementing features, adding functionality, refactoring, reviewing code, designing APIs, changing the public API surface (the `packages/core/src/js/index.ts` barrel), handling breaking changes, deprecating options, writing integrations, touching the JS↔native bridge, or making architecture decisions in this yarn-workspaces monorepo.
+---
+
+Apply these guidelines to all new and modified code in `packages/core`. Existing code may not follow these conventions — do not refactor it unless asked.
+
+This SDK spans **four surfaces**: TypeScript/JS (`packages/core/src/js/`), Android (Java/Kotlin, `packages/core/android/`), iOS (ObjC/Swift, `packages/core/ios/`), and the **JS↔native bridge** (`RNSentry` TurboModule / legacy NativeModule) that connects them. Read the `AGENTS.md` for the surface you're touching — root, `packages/core/`, `packages/core/android/`, `packages/core/ios/` — before writing. The bridge is where most SDK-specific bugs live; the deep guidance for it is in [`packages/core/AGENTS.md`](../../../packages/core/AGENTS.md).
+
+For non-trivial work — a new feature or integration, a public barrel-file change, or a change that crosses the native bridge — load the **design-first** skill to shape the modules and seams before writing code. When writing or modifying tests, also load the **test-guidelines** skill.
+
+## SDK Development Rules
+
+### Integrations
+
+SDK features are packaged as **integration factory functions** that return an `Integration` (from `@sentry/core`). See `src/js/integrations/` for the canonical shape (e.g. `nativelinkederrors.ts`):
+
+```typescript
+const INTEGRATION_NAME = 'MyFeature';
+
+export const myFeatureIntegration = (options: Partial<MyOptions> = {}): Integration => {
+  return {
+    name: INTEGRATION_NAME,
+    setupOnce: () => { /* one-time global side effects, if any */ },
+    setup: (client: Client) => { /* per-client wiring */ },
+    processEvent: (event, hint, client) => { /* enrich/drop */ return event; },
+  };
+};
+```
+
+- **Check prerequisites and feature flags early** — if the feature is disabled or the native module is missing, log via `debug` and return without wiring anything up.
+- Name the integration with a module-level `INTEGRATION_NAME` constant; don't inline the string.
+- Integrations should be **order-independent**. If yours must run before/after another, reconsider the design.
+- Register default integrations in `src/js/integrations/default.ts`; keep an integration's options and defaults with the integration, not scattered across `options.ts`.
+- Clean up anything global (listeners, timers) — an integration that arms a timer or subscribes to an emitter must have a path that tears it down.
+
+### Native Bridge (JS side)
+
+Every call into native goes through the `NATIVE` wrapper (`src/js/wrapper.ts`) / `RNSentry` TurboModule. Rules:
+
+- **Guard on availability.** If `enableNative` is false or the module isn't linked, degrade gracefully — return a safe fallback, never throw into user code.
+- **Never let a native rejection escape.** Wrap bridge calls; log via `debug` and return a fallback. A thrown promise rejection from the bridge becomes an unhandled rejection in the host app.
+- **Everything crossing the bridge must be serializable** — plain JSON (no functions, class instances, `undefined` holes, circular refs, or `BigInt`). Both the New Architecture (JSI/TurboModule codegen) and the legacy bridge serialize payloads; a non-serializable value is silently dropped or throws on the native side. Verify `toJSON`/normalization round-trips.
+- **Do not wrap `RNSentry`'s own scope-sync methods** (`setTag`, `setContext`, `addBreadcrumb`, `setUser`, `captureEnvelope`, …). Wrapping them recurses — see the `RNSENTRY_SKIP` / `ignoreTurboModules` notes in `packages/core/AGENTS.md`.
+- In this hot path, `logger` from `@sentry/core` is the **Logs API** (emits log events), not the debug logger. Use **`debug`** for diagnostics — see the TurboModule section of `packages/core/AGENTS.md`.
+
+### Native Bridge (native side)
+
+- **Android** (`packages/core/android/`): resolve/reject the `Promise` on every path; never leak it. Release JNI local refs; don't let a native exception cross back into the bridge uncaught. Old vs new arch code lives in `src/oldarch/` and `src/newarch/`; shared code in `src/main/`.
+- **iOS** (`packages/core/ios/`): prefix classes `RNSentry`; use nullability annotations; watch for retain cycles in blocks (capture `weakSelf`). Route hybrid-SDK access through `RNSentryInternal` (see `packages/core/ios/AGENTS.md`), not deprecated `PrivateSentrySDKOnly`.
+- A native exception must **never crash the host app** — catch at the bridge boundary and reject/log instead.
+
+### Codegen (New Architecture)
+
+The bridge spec is codegen'd. `src/js/NativeRNSentry.ts` is the `TurboModule` spec; `RNSentryReplayMask*NativeComponent.ts` are Fabric component specs.
+
+- Codegen only supports a **restricted type vocabulary** — primitives, `Object` (untyped map), arrays, and nullable via `?`. No unions of literals, no generics, no `Record<K,V>` with non-string keys. If a method's shape can't be expressed, pass an `Object` and validate/parse on the native side.
+- Any change to a `Native*.ts` spec is a **bridge ABI change**: it must land in lockstep across the JS spec, `ios/RNSentry.mm`, and the Android `RNSentryModuleImpl`, and stay backward-compatible with older native binaries a user may have cached. Treat it like a public API change.
+
+### Usage tracking & SDK metadata
+
+The event's [SDK interface](https://develop.sentry.dev/sdk/data-model/event-payloads/sdk/) carries `sdk.integrations`, `sdk.packages`, and an optional `sdk.features` list; the spec says a feature should be reported through **either** an integration **or** the `features` list, not both. RN takes the *integrations* route: unlike sentry-dart (which populates `sdk.features` via an explicit `addFeature` / `SentryFeatures` API), RN's `@sentry/core` reports usage only through `event.sdk.integrations` and does **not** populate `sdk.features`. So usage is reported implicitly:
+
+- An **installed integration is auto-reported by its `name`** — `@sentry/core` collects the names of installed integrations into `event.sdk.integrations`. So the practical rule is: give the integration a stable, correct `INTEGRATION_NAME`, and register it (a default in `integrations/default.ts`, or `client.addIntegration(...)`) — that registration *is* the usage signal. A feature that runs without a registered, named integration is invisible to usage tracking.
+- **SDK identity/packages** come from `src/js/version.ts` (`SDK_NAME`, `SDK_PACKAGE_NAME`, `SDK_VERSION`) surfaced by `integrations/sdkinfo.ts`, which also appends the native SDK package — not the place to register feature usage.
+- Do **not** confuse this with `addFeatureFlag` on the native module (`wrapper.ts` / `NativeRNSentry.ts`) — that is the user-facing **feature-flags** product, unrelated to SDK usage tracking.
+
+When adding something you want measured, make sure it lands as a named, registered integration rather than a bare side effect.
+
+### Logging
+
+- **`debug`** (from `@sentry/core`) is the internal diagnostic logger — use it for all SDK diagnostics. It is tree-shaken / gated so it stays quiet in production.
+- **`logger`** (from `@sentry/core`) is the **Logs API** — it emits user-visible log *events*. Never use it for internal diagnostics, and never in a hot path (see bridge rules above).
+- Log at the right level: `debug` for lifecycle/config, `warn` for recoverable/degraded paths (native module missing, option ignored), `error` for failures that affect SDK behavior.
+
+### Privacy (PII)
+
+- **Never collect PII without gating on `options.sendDefaultPii`.** This covers IP inference, device identifiers, deep-link URLs, navigation params, request/response bodies, and user-supplied context.
+- Flag any change that could place user data into breadcrumbs, event payloads, span attributes, or logs for review.
+- Deliberate exceptions exist and must be documented where they live (e.g. TurboModule module/method names are app-defined identifiers sent regardless of `sendDefaultPii` — see `packages/core/AGENTS.md` "Privacy"). Don't add new always-on data collection without that justification.
+
+### Breaking changes
+
+- The public API is the `src/js/index.ts` barrel plus every exported option in `options.ts`. Its shape is captured in the API report (`packages/core/etc/sentry-react-native.api.md`); regenerate with `yarn api-report` and check with `yarn api-report:check`.
+- Removing or changing the signature/behavior of an exported symbol or option is a **semver-major breaking change**. Prefer **deprecation with a migration path** (`@deprecated` JSDoc + a working shim) over immediate removal.
+- Bridge/ABI changes (see Codegen) are breaking even when the JS surface looks unchanged — an app can ship new JS against an older cached native binary.
+
+## File Organization
+
+**Group by feature, not by type.** A processor or helper a feature owns lives with that feature (the TurboModule files sit together as `turbomodule/` + `integrations/turboModuleContext*.ts`). The `integrations/` directory is a **type-bucket** — it collects things that share the `Integration` type. Don't treat "it's an integration" as the whole home for a cohesive subsystem; keep the subsystem's own logic together and let the integration file be thin wiring.
+
+Native code lives under `packages/core/android/` and `packages/core/ios/` and is reached only through the `NATIVE` wrapper seam — features *call* the bridge, they don't embed native code.
+
+*Where* a given piece goes is a locality judgment — see **design-first**.
+
+## TypeScript & API style
+
+Shape the public surface deliberately (see **design-first** for module shape). In an SDK these matter more than in app code:
+
+- **Private by default.** Don't export a symbol from the barrel unless it's genuinely part of the SDK's API — every export is a breaking-change liability and shows up in the API report.
+- **Explicit types on public functions** — annotate parameters and return types; don't rely on inference across the API boundary.
+- **`unknown` over `any`.** Narrow with type guards; `any` disables the checker exactly where SDK robustness matters.
+- **Prefer `interface` for object shapes**; use `type` for unions/mapped types.
+- **Optional chaining / nullish coalescing** (`?.`, `??`) over hand-rolled truthiness — but remember `??` and `?.` treat `0`/`''`/`false` correctly where `||` doesn't.
+- **Re-throw, don't wrap-and-rethrow.** Preserve the original error and its stack; when adding context, attach a `cause` rather than replacing the error — stack-trace fidelity is the product.
+- **No cross-boundary deep imports.** Import from `@sentry/core` / `@sentry/browser` public entry points, not their internal paths; keep RN-internal imports within `src/js`.
+
+Style enforced by ESLint/oxlint/Prettier (single quotes, trailing commas, 120 cols, arrow-paren avoidance, import ordering) is **not** restated here — don't flag what `yarn lint` / `yarn fix` already handles. See `packages/core/AGENTS.md` for the list.
+
+## Documentation comments
+
+Prefer self-documenting code; comment for the two cases that earn it:
+
+- **Public APIs** — JSDoc for every exported symbol and option, written for users who can't see the implementation.
+- **Non-obvious *why*** — workarounds, ordering constraints, native-bridge quirks, RN-version differences. The reasoning, not the play-by-play.
+
+Don't narrate obvious behavior or restate the code. Use `@deprecated`, `@internal`, and `@hidden` deliberately — `@internal`/`@hidden` keep a symbol out of the generated API surface even when it must be exported for cross-file use.

--- a/.agents/skills/code-guidelines/references/native-bridge.md
+++ b/.agents/skills/code-guidelines/references/native-bridge.md
@@ -1,0 +1,58 @@
+# Native bridge & codegen gotchas
+
+Reference for the JS↔native seam. Loaded by **code-guidelines** and cited by **review**'s Correctness axis. The living, file-level detail is in [`packages/core/AGENTS.md`](../../../../packages/core/AGENTS.md) — this doc is the durable checklist.
+
+## The two architectures
+
+React Native ships two module systems and this SDK supports both:
+
+- **New Architecture** — JSI / TurboModules (JS spec in `src/js/NativeRNSentry.ts`) + Fabric components. Codegen generates the C++/Java/ObjC glue from the TS spec. Native side: `ios/RNSentry.mm`, `android/src/newarch/`.
+- **Old Architecture** — the async bridge, `NativeModules.RNSentry`. Native side: `android/src/oldarch/`. Legacy auto-instrumentation of third-party modules is opt-in (`enableLegacyNativeModules`) and best-effort.
+
+A change is only "done" when it works on **both** archs. `Platform`/arch branches (`isTurboModuleEnabled()`, `isFabricEnabled()`) are the usual seams — test both branches.
+
+## Codegen type vocabulary (New Arch)
+
+Codegen only understands a narrow set of types in a `TurboModule` / component spec:
+
+- Primitives: `boolean`, `number`, `string`
+- `Object` — an **untyped** map (opaque `NSDictionary`/`ReadableMap`); the shape is *not* checked
+- Arrays of the above
+- Nullability via `?` on the property/param
+- `Promise<T>` return
+
+Not supported: literal unions, enums, generics, `Record<K, V>`, tuples, discriminated unions, function-valued props (except event callbacks on components), `undefined` as a value. If a method needs a richer shape, declare the param as `Object` and validate/normalize on the native side — the type system will *not* catch a mismatch for you.
+
+## Serialization across the bridge
+
+Everything crossing the bridge is serialized to a JSON-ish value:
+
+- **No** functions, class instances, `Symbol`, `BigInt`, `undefined` holes, circular references, or `Map`/`Set`. These are dropped, throw, or arrive mangled.
+- `undefined` object properties do not survive; use `null` or omit the key.
+- Large payloads (envelopes, screenshots, replay frames) cross as base64/byte arrays — mind the copy cost and size limits.
+- Always confirm the value **round-trips**: what you send is what native receives and what comes back parses. Add a serialization test for any new payload shape.
+
+## ABI / versioning
+
+- Any edit to `src/js/NativeRNSentry.ts` (or a `*NativeComponent.ts` spec) is a **bridge ABI change**. It must land in lockstep in the JS spec, `ios/RNSentry.mm`, and `android/.../RNSentryModuleImpl`, and must be **backward compatible**: a user can ship new JS against an older cached native binary. New methods are safe; changing an existing method's signature/semantics is breaking.
+- Treat spec changes like public-API changes — they belong in the changelog and may be semver-major.
+
+## Memory & crash safety
+
+- **Android:** release JNI local refs; resolve *or* reject every `Promise` on every path (a leaked Promise hangs the JS caller). Never let a native exception propagate uncaught across the bridge.
+- **iOS:** avoid retain cycles in blocks (`__weak` self); honor nullability annotations; route hybrid-SDK access through `RNSentryInternal`.
+- A native crash caused by the SDK crashes the **host app** — the highest-severity failure this SDK can cause. Catch at the bridge boundary; degrade, don't crash.
+
+## Privacy at the bridge
+
+Data flowing from native (device context, breadcrumbs, module/method names, deep-link URLs) must respect `sendDefaultPii`. Any always-on collection needs an explicit, documented justification (see `packages/core/AGENTS.md` "Privacy" for the TurboModule exception and why it exists).
+
+## Quick checklist for a bridge change
+
+- [ ] Works on New **and** Old Architecture (both branches exercised)
+- [ ] Spec change (if any) landed in JS + iOS + Android in lockstep, backward-compatible
+- [ ] Payload is codegen-expressible or validated as `Object` on the native side
+- [ ] Payload round-trips (serialization test added)
+- [ ] Native failure is caught at the boundary — no host-app crash, no leaked Promise, no leaked native memory
+- [ ] PII gated on `sendDefaultPii` (or documented exception)
+- [ ] Graceful fallback when `enableNative` is false / module not linked

--- a/.agents/skills/design-first/SKILL.md
+++ b/.agents/skills/design-first/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: design-first
+description: Shape non-trivial work before writing it — decide the modules, the seams, and the public API surface up front. Use when starting a feature, adding an integration, changing the public barrel (`packages/core/src/js/index.ts`), crossing the JS↔native bridge, changing a codegen spec, or deciding where a seam should go. Produces a design sketch to approve before implementation, then hands off to code-guidelines and test-guidelines.
+---
+
+Design the shape before writing the code. The pass ends in a **design sketch** the user approves; implementation does not start until it does. Aim for **deep modules** placed at clean **seams** — so callers get leverage, maintainers get locality, and tests get a surface to push against.
+
+This is a design pass, not an implementation plan. Decide *what shape the code takes and why*; leave line-level rules to **code-guidelines** and test structure to **test-guidelines**.
+
+## When to run
+
+Run for work where the shape is a real decision:
+
+- A new feature or a new integration
+- A change to the public barrel (`packages/core/src/js/index.ts`) or a public option in `options.ts` — it cascades to every downstream user and the API report
+- A change to a **codegen spec** (`src/js/NativeRNSentry.ts`, `*NativeComponent.ts`) or anything crossing the JS↔native bridge — the ABI must move in lockstep across JS/iOS/Android
+- Any moment you are choosing where a seam goes, or how a module is shaped to be testable
+
+Skip it — and say you are skipping it — for one-line fixes, localized bug fixes with obvious placement, and refactors that change no interface.
+
+## Vocabulary
+
+Use these terms exactly in the sketch — consistent language is what makes the design legible across sessions. Don't substitute "component," "service," or "layer."
+
+- **Module** — anything with an interface and an implementation: a function, a factory, a class, a file.
+- **Interface** — everything a caller must know to use it correctly: the signature, plus invariants, ordering, error modes, required config.
+- **Deep module** — a lot of behavior behind a small interface. The goal. A **shallow** module has an interface nearly as complex as its implementation — avoid it.
+- **Seam** — the place where you can swap behavior without editing in that place. Where an interface lives, and where a test double crosses. In this SDK the biggest seam is the `NATIVE` wrapper (`src/js/wrapper.ts`) between JS and native.
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+
+Two checks settle most design questions:
+
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, it was a pass-through — don't build it. If complexity reappears across N callers, it earns its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you need to test *past* the interface, the module is the wrong shape.
+
+## The design pass
+
+### 1. Frame the change
+
+State the behavior the change introduces, in the domain's own words. Name the surface(s) it lands in — JS, Android, iOS, bridge — and read the relevant `AGENTS.md` (root, `packages/core/`, `packages/core/android/`, `packages/core/ios/`).
+
+**Find the nearest well-shaped precedent and align to it.** The codebase has almost certainly solved something adjacent — locate its *best* current example and match it, or improve on it deliberately and say why. The TurboModule subsystem (`turbomodule/` + thin `integrations/turboModuleContext*.ts` wiring) is a strong precedent for a cohesive feature that touches JS, native, and the bridge; the integration factory in `integrations/nativelinkederrors.ts` is the precedent for a plain JS integration.
+
+### 2. Shape the modules
+
+Decide the modules and where their seams go. Prefer fewer, deeper modules over many shallow ones. For each module, name its interface — not just the signature, but the invariants and error modes a caller must know. Run the deletion test on anything you suspect is a pass-through.
+
+Decide where the code lives as part of shaping it — a **locality** call: co-locate what changes together so one change stays directory-local.
+
+- A cohesive subsystem owns its model, lifecycle, and pipeline as one **concept** — group it in its own dir (like `turbomodule/`), and let the `integrations/` file be thin wiring. `integrations/` is a type-bucket, not a home for a subsystem's logic.
+- Native code belongs behind the bridge seam under `packages/core/android/` and `packages/core/ios/`; JS features *call* it via `NATIVE`, they don't embed native code.
+- **If you can't name the concern a piece serves, that's a smell** — it's doing two things, or belongs to a concept you haven't named.
+
+### 3. Design for testability
+
+A seam exists so a test can cross it (test-guidelines builds the fakes there). Three rules make that possible:
+
+- **Accept dependencies, don't create them.** A module that reaches for `NativeModules.RNSentry` itself can't be faked; one that receives the bridge (or goes through the `NATIVE` seam a test can mock) can.
+- **Keep the platform/arch branch at the edge.** Push `Platform.OS` / `isTurboModuleEnabled()` decisions to a thin boundary so the core logic is arch-agnostic and unit-testable without simulating a device.
+- **Make the observable output the contract.** Tests assert on the produced event/envelope/resolved value, not on private state — so the design must route results through the interface.
+
+### 4. Account for the bridge, up front
+
+If the change crosses the bridge, decide *now* (not during implementation):
+
+- What the payload shape is and whether it is **codegen-expressible** or must be an `Object` validated natively (see `code-guidelines/references/native-bridge.md`).
+- Whether it's an **ABI change** and how JS/iOS/Android land in lockstep while staying backward-compatible with older cached native binaries.
+- How it behaves when `enableNative` is false or the module isn't linked.
+- What crosses regarding **PII** and how it's gated.
+
+### 5. Write the sketch and get sign-off
+
+Produce, in the conversation: the modules and their interfaces; where each lives and why (locality); the seams and what fakes cross them; the bridge/ABI decisions; and what you deliberately chose *not* to build (deletion-test casualties). Get the user's approval before implementing, then hand off to **code-guidelines** + **test-guidelines**.

--- a/.agents/skills/diagnosing-bugs/SKILL.md
+++ b/.agents/skills/diagnosing-bugs/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: diagnosing-bugs
+description: A discipline for hard bugs, flaky tests, CI hangs, native crashes, and performance regressions in this SDK. Use when the user says "diagnose" or "debug this", reports something broken/throwing/failing/hanging/slow/crashing, or a test is flaky. Builds a tight, red-capable feedback loop before hypothesizing.
+---
+
+A discipline for hard bugs. Skip a phase only when you can say why.
+
+**The whole skill is Phase 1: get a loop that goes red on this bug.** Everything after is mechanical once you have it. If you catch yourself reading code to form a theory before that loop exists, stop — jumping to a hypothesis without a red-capable loop is the exact failure this prevents.
+
+For trivial bugs with an obvious fix and an obvious test, skip this and just write the failing test — this skill is for the bugs that resist.
+
+## Phase 1 — Build a feedback loop
+
+A **tight** loop is fast, deterministic, and goes **red** on *this* bug. Build one and the bug is 90% solved. Be aggressive and creative here — spend disproportionate effort.
+
+### Ways to construct one — try roughly in this order
+
+1. **Failing Jest test at the seam** — `yarn test path/to/file.test.ts -t 'name'`, at whatever seam reaches the bug. Tightest loop there is. Mock the bridge via `test/mockWrapper.ts`.
+2. **Fake-timer harness** — for flush timers, debounces, retries, and most flakes: `jest.useFakeTimers()` and advance the clock deterministically instead of waiting.
+3. **Arch/platform matrix** — reproduce under the failing combination: pin `Platform.OS`, `isTurboModuleEnabled()`, `isFabricEnabled()`. "Only on New Arch" or "only on Android" is a clue *and* the loop's config.
+4. **Replay a captured payload** — save a real envelope / event / native payload to disk and push it through the code path in isolation. Great for serialization / round-trip bugs.
+5. **Throwaway harness** — a minimal script exercising the bug path with mocked deps.
+6. **Sample app** — when the bug only shows end-to-end, reproduce in `samples/react-native` (or `samples/expo`); see their `AGENTS.md`. Slower loop; use only when a unit seam can't reach it.
+7. **Native repro** — for a native crash / leak, reproduce in the native test targets (iOS `RNSentryCocoaTester`, Android instrumentation) or with the sample app + native debugger. The bridge can't be faked here.
+8. **Stress / repetition loop** — for non-deterministic bugs: run the trigger 100×, narrow timing windows, inject delays. Goal is a higher reproduction rate, not a clean repro.
+9. **Differential loop** — same input through two versions/configs (e.g. before/after a dependency or RN bump) and diff the output. For regressions that "appeared after X".
+
+### Tighten the loop
+
+Once you have *a* loop, treat it as a product: **faster** (narrow scope, skip unrelated init), **sharper** (assert the exact symptom the user described, not "didn't crash"), **more deterministic** (fake timers, seed randomness, no real network/bridge). A 2-second deterministic loop beats a 30-second flaky one. For non-deterministic bugs the goal is a *high enough* reproduction rate to debug against — 50% is debuggable, 1% is not.
+
+### Completion criterion
+
+Phase 1 is done when you can name **one command** — a test invocation or script — that you have **already run at least once** (paste the invocation and its output), and that is:
+
+- [ ] **Red-capable** — drives the actual bug path and asserts the user's exact symptom
+- [ ] **Deterministic** — same verdict every run (flaky bugs: a pinned, high reproduction rate)
+- [ ] **Fast** — seconds, not minutes
+
+No red-capable command, no Phase 2.
+
+### When you genuinely cannot build a loop
+
+Say so explicitly, list what you tried, and ask the user for: an environment that reproduces it, a captured artifact (envelope dump, native crash log / symbolicated stack, CI run, screen recording with timestamps, `adb logcat` / Xcode console output), or permission for temporary instrumentation. Do **not** hypothesise without a loop.
+
+## Phase 2 — Reproduce and minimise
+
+Run the loop, watch it go red. Confirm it produces the failure mode the **user** described — not a nearby one (wrong bug = wrong fix). Then shrink the repro to the smallest scenario that still goes red: cut inputs, callers, config, and steps **one at a time**, re-running after each cut. Done when every remaining element is load-bearing. The minimal repro becomes the regression test.
+
+## Phase 3 — Hypothesise
+
+Generate **3–5 ranked, falsifiable hypotheses** before testing any — a single hypothesis anchors you on the first plausible idea. Each states its prediction: "If X is the cause, then changing Y makes the bug vanish." If you can't state the prediction, it's a vibe — sharpen or discard it. Show the ranked list to the user; they often re-rank it instantly ("we just changed #3"). Common suspects in this SDK: arch/platform branch, bridge serialization, timer/async ordering, scope-sync recursion, native memory/lifecycle, RN or native-SDK version skew.
+
+## Phase 4 — Instrument & fix
+
+Confirm the hypothesis with the cheapest observation that would falsify it (a log via `debug`, a native breakpoint, a diffed payload) before changing code. Then make the minimal fix, watch the loop go green, and keep the minimal repro as the regression test. Re-run the broader suite (`yarn test`) and, for native/bridge fixes, the affected native tests and both architectures.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: review
+description: Three-axis review of the branch diff — Standards (this repo's documented standards + public API/bridge surface), Spec (the originating Linear/GitHub issue or PR), and Correctness (runtime bugs + the RN SDK threat model — PII, native crashes/leaks, bridge serialization, arch parity, concurrency). Runs the axes as parallel sub-agents and reports them side by side. Use when reviewing a branch, a PR, or work-in-progress changes before opening or merging, or "review since X".
+---
+
+Review the diff between `HEAD` and a base, on three axes:
+
+- **Standards** — does the diff conform to this repo's documented standards?
+- **Spec** — does it faithfully implement the originating issue / PR?
+- **Correctness** — will it actually work, and is it safe?
+
+Run the axes as **parallel sub-agents** so none pollutes another's context, then aggregate. Report them side by side, and **never rerank across axes** — keeping them separate is the whole point (see *Why separate axes*).
+
+Run this on demand before opening or merging a PR (Warden's automated PR review uses the remote `code-review` + `find-bugs` skills; this local pass is the RN-tailored, deeper review you invoke yourself). It complements `security-review` (deeper security audit), `gha-security-review` (workflow/CI), and `span-convention-review` (tracing-span conventions) — invoke those for depth. It is *not* a debugger: when a bug is already known and reproducing, use `diagnosing-bugs`.
+
+## 1. Pin the base
+
+Use whatever base the user named — a commit, branch, tag, or `HEAD~N`. If they named none, default to the merge-base with the default branch (`git merge-base HEAD origin/main`). Capture once:
+
+- `git diff <base>...HEAD` (three-dot, so it compares against the merge-base)
+- `git log <base>..HEAD --oneline`
+
+Confirm the ref resolves (`git rev-parse <base>`) and the diff is non-empty. A bad ref or empty diff fails **here** — not inside parallel sub-agents.
+
+## 2. Identify the spec source
+
+Look for the originating spec, in order:
+
+1. Linear issue references (e.g. `RN-###`) in commit messages or the PR (fetch via the Linear tools).
+2. GitHub issue/PR references (`gh issue view` / `gh pr view --json title,body,comments`).
+3. A path the user passed.
+
+If none is found, ask. If there genuinely is no spec, the Spec sub-agent skips and reports "no spec available".
+
+## 3. Spawn the sub-agents in parallel
+
+Send one message with three `Agent` tool calls (a general-purpose subagent each). Give each the diff command and the commit list, plus its brief:
+
+**Standards sub-agent:**
+
+> Read `.agents/skills/code-guidelines/SKILL.md`, `.agents/skills/code-guidelines/references/native-bridge.md`, and `.agents/skills/test-guidelines/SKILL.md`, then review the diff against them.
+> **Top priority — public surface:** for any change to the barrel (`packages/core/src/js/index.ts`), an exported option in `options.ts`, or a codegen spec (`src/js/NativeRNSentry.ts`, `*NativeComponent.ts`), classify each exported/spec symbol as added / removed / signature-changed / behavior-changed. Flag every removal or incompatible change as a **breaking change** (semver-major) and check it carries a deprecation path; flag a bridge spec change that isn't backward-compatible or isn't mirrored across JS/iOS/Android. Note if the API report (`packages/core/etc/sentry-react-native.api.md`) needs regenerating.
+> Then report, per file/hunk, every place the diff violates a documented standard — cite the rule. For areas the docs don't cover, apply the smell baseline in `.agents/skills/review/references/smell-baseline.md` as judgement calls. Distinguish hard violations from judgement calls; a documented standard overrides the baseline. Skip anything ESLint/oxlint/Prettier/clang-format/ktlint/swiftlint enforce. Under 400 words.
+
+**Spec sub-agent** (skip and note if no spec):
+
+> Report: (a) requirements the spec asked for that are missing or partial; (b) behavior in the diff that wasn't asked for (scope creep); (c) requirements that look implemented but wrong. For this SDK check the spec's platform/architecture scope (iOS/Android, New/Old Arch) and opt-in vs default-on decision are actually honored. Quote the spec line for each finding. Under 400 words.
+
+**Correctness sub-agent:**
+
+> Find bugs and unsafe code the diff introduces — not style, which Standards owns. Check, per file/hunk:
+> - **Runtime bugs** — unhandled promise rejections / fire-and-forget async, uncleared timers or listeners, missing null/undefined guards, swallowed errors, races/TOCTOU, missing teardown in an integration.
+> - **RN SDK threat model** —
+>   - **PII**: data collected or placed into breadcrumbs/events/span attributes/logs without gating on `options.sendDefaultPii` (deep-link URLs, navigation params, device identifiers, request/response bodies). Undocumented always-on collection.
+>   - **Native safety**: a native exception that could crash the host app, a leaked JNI local ref, an iOS retain cycle, a `Promise` neither resolved nor rejected (hangs the JS caller).
+>   - **Bridge**: non-serializable payloads (functions, class instances, `undefined` holes, circular refs, `BigInt`), `toJSON`/normalization round-trip errors, codegen type-vocabulary violations, an ABI change not mirrored across JS/iOS/Android or not backward-compatible with an older cached native binary.
+>   - **Arch/platform parity**: logic that works on one of New/Old Arch or iOS/Android but not the other.
+>   - **Recursion/hot path**: wrapping `RNSentry` scope-sync methods, or using the Logs API `logger` (vs `debug`) in the TurboModule wrap path — see `packages/core/AGENTS.md`.
+>   - **Resource growth**: unbounded buffers/queues/caches; a periodic flush timer that re-arms forever.
+> For each finding give file:line, a one-line severity (critical/high/medium/low), why it's real (not already handled, no covering test), and a concrete fix. Skip anything the linters or existing tests already catch. Under 400 words.
+
+## 4. Aggregate
+
+Present the reports under `## Standards`, `## Spec`, and `## Correctness` headings, verbatim or lightly cleaned. Do **not** merge or rerank findings across axes.
+
+End with a one-line summary per axis: total findings, and the worst issue *within that axis*. Don't pick a single winner across axes — that's the reranking the separation exists to prevent.
+
+## Why separate axes
+
+Each axis asks a different question and would drown the others if merged: Standards is about conformance, Spec about intent, Correctness about safety. A critical native-crash bug and a barrel-file naming nit are not comparable, and forcing them onto one ranked list buries the one that matters under the one that's easy to find. Keeping them side by side lets the reader act on each in its own terms.

--- a/.agents/skills/review/references/smell-baseline.md
+++ b/.agents/skills/review/references/smell-baseline.md
@@ -1,0 +1,21 @@
+# Smell Baseline
+
+A fallback set of code smells (Fowler, _Refactoring_ ch.3) for the Standards axis to apply **only in areas the repo doesn't document**. Two rules bind it:
+
+- **The repo overrides.** A documented standard in `code-guidelines` / `test-guidelines` always wins; where it endorses something this baseline would flag, suppress the smell.
+- **Always a judgement call.** Each smell is a labelled heuristic ("possible Feature Envy"), never a hard violation — and skip anything ESLint/oxlint/Prettier/clang-format/ktlint/swiftlint already enforce.
+
+Each reads *what it is* → *how to fix*; match against the diff.
+
+- **Mysterious Name** — a name that doesn't reveal what it does or holds. → rename; if no honest name comes, the design is murky.
+- **Duplicated Code** — the same logic shape in more than one hunk or file in the change. → extract the shared shape, call it from both.
+- **Feature Envy** — a function that reaches into another object's data more than its own. → move it onto the data it envies.
+- **Data Clumps** — the same few fields/params keep travelling together (e.g. the same `{ name, method, arch }` trio). → bundle them into one type, pass that.
+- **Primitive Obsession** — a primitive or string standing in for a domain concept that deserves its own type (a raw string where an `IntegrationName` or a branded id belongs). → give the concept a small type.
+- **Repeated Switches** — the same `switch`/`if`-cascade on the same type recurs across the change (e.g. repeated `Platform.OS` / `isTurboModuleEnabled()` branching). → centralize behind one boundary or a lookup.
+- **Shotgun Surgery** — one logical change forces scattered edits across many files. → gather what changes together into one module. (A legitimate exception: a bridge ABI change *must* touch JS + iOS + Android — that's lockstep, not scatter.)
+- **Divergent Change** — one file edited for several unrelated reasons. → split so each module changes for one reason.
+- **Speculative Generality** — abstraction, params, options, or hooks added for needs the spec doesn't have. → delete it; inline until a real need shows. (Every new public option is also a breaking-change liability.)
+- **Message Chains** — long `a.b().c().d()` navigation the caller shouldn't depend on. → hide the walk behind one method.
+- **Middle Man** — a class or function that mostly just delegates onward. → cut it, call the real target directly. (An integration file that's *only* thin wiring over a subsystem is intended, not a Middle Man.)
+- **Shallow Module** — an interface nearly as complex as its implementation (per design-first). → deepen or merge; apply the deletion test.

--- a/.agents/skills/spec/SKILL.md
+++ b/.agents/skills/spec/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: spec
+description: Produce a verified spec — problem, desired outcome, and acceptance criteria — before building. Use when given a GitHub/Linear issue link, when starting from a fuzzy in-conversation idea, or asked to "figure out what to do" / "scope this" / "what should I build" — whenever the *what* isn't yet pinned down. Grills the ambiguities, checks the premise against the code, and produces acceptance criteria you sign off on — then hands to design-first.
+---
+
+Settle *what* to build and *why* — with verifiable acceptance criteria — before any design or code. This is the front of the pipeline: **spec** (what) → **design-first** (how) → **code-guidelines** + **test-guidelines** (build) → **review** (which verifies the result against this spec).
+
+Run it for a tracked issue or a fuzzy ask. Skip it — and say so — when the ask is already a precise, verifiable instruction.
+
+## 1. Establish the source
+
+Get the raw intent from wherever it lives:
+
+- **From a tracked issue** (a GitHub/Linear link) — fetch it, don't work from the link text or your memory of it:
+  - **GitHub:** `gh issue view <url-or-number> --json title,body,comments,labels,state`, plus any linked PRs.
+  - **Linear:** the Linear tools — the issue and its comments. Sentry SDK issues often carry a Linear backlink (e.g. `RN-###`) in a comment.
+  - Read the full body, **every comment**, labels, and linked issues/PRs. The real decision is often buried in a comment, not the title.
+- **From an in-conversation idea** — start from what the user said, in their words. If a tracked issue might exist, ask for the link; otherwise proceed — the spec itself is the source of truth.
+
+Either way you now hold the raw intent — usually vague. Sharpen it below.
+
+## 2. Reconstruct the real intent
+
+The raw ask usually names a symptom; the real need is underneath. State, in the domain's own words: the problem this solves, who it's for (SDK user? a downstream SDK like Flutter/.NET that depends on the native layer?), and what "done" looks like. Separate the *reported symptom* from the *underlying need* — they're often not the same fix.
+
+## 3. Check the premise against the code
+
+The ask may be stale, partial, or wrong. Investigate before believing it:
+
+- Does the described behavior actually exist / reproduce? For a bug, find the code path — and if it's non-trivial, build the repro loop now (see **diagnosing-bugs**).
+- Is part of it already implemented, or made moot by a later change (an RN/native-SDK bump, a new arch path)?
+- Does the codebase contradict the issue's assumptions? Check both JS and the relevant native side.
+- Does it touch the public API surface (barrel / options) or the bridge ABI? That raises the stakes and the review bar.
+
+Surface any contradiction to the user before going further — a spec built on a false premise wastes the whole pipeline.
+
+## 4. Grill the gaps
+
+Interview relentlessly until the intent is unambiguous. **One question at a time**, waiting for the answer before the next — batching is bewildering. Give your **recommended answer** with each question. If a question can be answered by reading the code, read it instead of asking. Drive out scope, edge cases, and the in-vs-out boundary — for this SDK that usually includes: which platforms/architectures are in scope, whether it's opt-in or default-on, PII implications, and whether downstream SDKs are affected.
+
+## 5. Write the spec and get sign-off
+
+Produce, in the conversation:
+
+- **Problem** — what's wrong or missing, and why it matters.
+- **Outcome** — the desired end state, in the domain's words.
+- **Acceptance criteria** — verifiable, observable conditions (e.g. "an event captured with X carries attribute Y on both New and Old Architecture"; "the native module missing → SDK returns a fallback, no throw"). This is the bar `review`'s Spec axis checks against.
+- **Non-goals** — what's explicitly out of scope (platforms, arch, options deferred).
+- **Open questions** — anything still unresolved.
+
+Done when the user **signs off on the acceptance criteria** — explicit agreement that meeting them means the work is complete. Not "looks reasonable"; agreement on the bar.
+
+## 6. Hand off
+
+The *what* is now settled. This spec becomes the PR description's problem / outcome / acceptance at ship time, and `review`'s Spec axis verifies against it. Hand off to **design-first** to shape the *how*.

--- a/.agents/skills/test-guidelines/SKILL.md
+++ b/.agents/skills/test-guidelines/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: test-guidelines
+description: Enforce Sentry React Native SDK test conventions for naming, structure, mocking, and fixtures with Jest. Use when writing tests, adding tests, modifying tests, reviewing test code, fixing failing tests, adding coverage, TDD, test-first / red-green, reproducing bugs with tests, regression tests, or test refactoring in `packages/core`.
+---
+
+Apply these conventions to all new and modified tests in `packages/core`. Existing tests may not follow them — do not refactor them unless asked. Tests run on **Jest** (`yarn test`, `yarn test:watch`, `yarn test:sdk`, `yarn test:tools`).
+
+Tests are easiest to write against code designed to accept its dependencies — when implementing the code under test, load **design-first** (where the seams go) and **code-guidelines** (the rules).
+
+## Test-first loop
+
+Work in **vertical slices**. One failing test → the minimal code that makes it pass → repeat. Each test proves one thin path end-to-end, and what it teaches shapes the next.
+
+Do **not** write all the tests first and then all the implementation. That horizontal slicing produces tests of *imagined* behavior — they assert the shape you guessed at and pass when the real behavior breaks. Write one test at a time, against behavior you can already reason about.
+
+Fixing a bug? Reproduce it with a failing test first — see **diagnosing-bugs**.
+
+## File structure
+
+- **One test file per source file.** Mirror the path: `src/js/client.ts` → `test/client.test.ts`; `src/js/integrations/release.ts` → `test/integrations/release.test.ts`.
+- React component tests use `.test.tsx` and `@testing-library/react-native`.
+- A single top-level `describe` naming the unit under test, with nested `describe`/`it` inside it.
+
+## Naming
+
+Follow the convention in `packages/core/AGENTS.md`: `describe`/`it` blocks (preferred), with the `it` describing the expected behavior for a given input.
+
+- The top-level `describe` names the unit under test — the exported name (`myFeatureIntegration`, `NATIVE`, the class).
+- Nested `describe` groups a method or a scenario; `it` states the behavior being verified.
+- Write `it` as a clear behavior description, e.g. `returns expected value when input is valid`.
+
+```typescript
+describe('nativeLinkedErrorsIntegration', () => {
+  describe('when the native module is unavailable', () => {
+    it('returns the event unchanged', () => { /* ... */ });
+  });
+
+  describe('processEvent', () => {
+    it('appends linked errors up to the configured limit', () => { /* ... */ });
+  });
+});
+```
+
+## Style — Arrange / Act / Assert
+
+Structure every test in three clear sections; a blank line between them is enough.
+
+```typescript
+it('returns expected value when input is valid', () => {
+  // Arrange
+  const input = 'test';
+
+  // Act
+  const result = functionName(input);
+
+  // Assert
+  expect(result).toBe('expected');
+});
+```
+
+Use **specific matchers** — they produce better failure messages:
+
+```typescript
+expect(array).toHaveLength(3);          // not expect(array.length).toBe(3)
+expect(obj).toMatchObject({ a: 1 });    // partial structural match
+expect(fn).toThrow(Error);
+await expect(promise).resolves.toBe('ok');
+await expect(promise).rejects.toThrow();
+```
+
+Assert the **exact** symptom, not "didn't crash". A test that only checks a call didn't throw catches almost nothing.
+
+## Mocking
+
+- **Reset between tests.** Use `afterEach(() => { jest.clearAllMocks(); })` (or `resetAllMocks` when you also stub implementations). A leaked mock is the most common flaky-test cause here.
+- **Mock the native module, not the whole SDK.** Prefer the shared helpers (`test/mockWrapper.ts`, `test/mocks/`) over re-mocking `react-native` ad hoc. When you must, mock the bridge surface only:
+
+```typescript
+jest.mock('react-native', () => ({
+  NativeModules: { RNSentry: { fetchNativeSdkInfo: jest.fn(() => Promise.resolve({})) } },
+  Platform: { OS: 'ios', select: (o: any) => o.ios ?? o.default },
+}));
+```
+
+- **Test both architectures / platforms** when the code branches on them. Drive `Platform.OS`, `isTurboModuleEnabled()`, `isFabricEnabled()` from the test rather than assuming one.
+- Prefer injecting a fake at a seam over `jest.mock` of a deep import — a test that mocks internals breaks on refactors even when behavior is unchanged (see **design-first**: the interface is the test surface).
+- Don't mock the thing under test. Don't assert on private internals; assert on observable output (the event, the envelope, the resolved value).
+
+## Async & timers
+
+- Always `await` async assertions; return or await the promise so Jest sees failures.
+- For timing-dependent code (flush timers, debounces, retries) use **fake timers** (`jest.useFakeTimers()` + `jest.advanceTimersByTime(...)`), not real `setTimeout` — real delays make tests slow *and* flaky. Restore with `jest.useRealTimers()` in `afterEach`.
+- No real network or filesystem. Stub the transport / bridge.
+
+## What to test
+
+- The **behavior at the seam** a caller depends on — inputs → observable outputs.
+- Edge cases the code guidelines call out: native module missing, `enableNative` false, PII gating on/off, serialization round-trips across the bridge, both architectures.
+- Every bug fix carries a regression test that goes red before the fix and green after.

--- a/agents.toml
+++ b/agents.toml
@@ -7,3 +7,102 @@ github_orgs = ["getsentry"]
 [[skills]]
 name = "warden"
 source = "getsentry/warden"
+
+# getsentry/skills — core development
+[[skills]]
+name = "commit"
+source = "getsentry/skills"
+
+[[skills]]
+name = "pr-writer"
+source = "getsentry/skills"
+
+[[skills]]
+name = "create-branch"
+source = "getsentry/skills"
+
+[[skills]]
+name = "iterate-pr"
+source = "getsentry/skills"
+
+[[skills]]
+name = "code-simplifier"
+source = "getsentry/skills"
+
+[[skills]]
+name = "agents-md"
+source = "getsentry/skills"
+
+[[skills]]
+name = "skill-writer"
+source = "getsentry/skills"
+
+[[skills]]
+name = "skill-scanner"
+source = "getsentry/skills"
+
+[[skills]]
+name = "claude-settings-audit"
+source = "getsentry/skills"
+
+[[skills]]
+name = "security-review"
+source = "getsentry/skills"
+
+[[skills]]
+name = "gha-security-review"
+source = "getsentry/skills"
+
+[[skills]]
+name = "gh-review-requests"
+source = "getsentry/skills"
+
+# getsentry/sdk-skills — SDK-specific
+[[skills]]
+name = "sdk-feature-implementation"
+source = "getsentry/sdk-skills"
+
+[[skills]]
+name = "span-convention-review"
+source = "getsentry/sdk-skills"
+
+[[skills]]
+name = "linear-initiative"
+source = "getsentry/sdk-skills"
+
+[[skills]]
+name = "linear-type-labeler"
+source = "getsentry/sdk-skills"
+
+[[skills]]
+name = "linear-sdk-telemetry-labeler"
+source = "getsentry/sdk-skills"
+
+[[skills]]
+name = "contributing-md"
+source = "getsentry/sdk-skills"
+
+# Local — Sentry React Native SDK guidelines (see .agents/skills/)
+[[skills]]
+name = "spec"
+source = "path:.agents/skills/spec"
+
+[[skills]]
+name = "design-first"
+source = "path:.agents/skills/design-first"
+
+[[skills]]
+name = "code-guidelines"
+source = "path:.agents/skills/code-guidelines"
+
+[[skills]]
+name = "test-guidelines"
+source = "path:.agents/skills/test-guidelines"
+
+[[skills]]
+name = "diagnosing-bugs"
+source = "path:.agents/skills/diagnosing-bugs"
+
+[[skills]]
+name = "review"
+source = "path:.agents/skills/review"


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Extends the agent setup, modeled on `sentry-dart`:

- **`agents.toml`** — registers the shared `getsentry/skills` and `getsentry/sdk-skills`, plus six local `path:` skills tailored to the RN SDK.
- **`.agents/skills/`** — six skills forming a pipeline: `spec` → `design-first` → `code-guidelines` + `test-guidelines` → `diagnosing-bugs` / `review`. They encode RN-specific knowledge the shared skills can't:
  - `code-guidelines` (+ `references/native-bridge.md`) — integrations, the JS↔native bridge, codegen type-vocabulary gotchas, ABI/lockstep rules, usage-tracking via `sdk.integrations`, and PII gating on `sendDefaultPii`.
  - `review` (+ `references/smell-baseline.md`) — three-axis review (Standards / Spec / Correctness) with the RN SDK threat model.
  - `test-guidelines` — Jest conventions (naming aligned to `packages/core/AGENTS.md`).
  - `spec`, `design-first`, `diagnosing-bugs` — the front and debugging halves of the pipeline.
- Removes the now-redundant `.agents/skills/.gitkeep` (the directory now has content).

Docs/config only — no SDK runtime code changes.


## :bulb: Motivation and Context
Closes #6637. Brings the RN SDK's agent guidelines and skills in line with `sentry-dart`, adapted for RN's TypeScript + native-bridge + Jest surfaces.


## :green_heart: How did you test it?
Not runtime-testable (Markdown + TOML). Verified:
- all cited repo paths and cross-skill Markdown links resolve;
- `agents.toml` parses and every registered remote skill name exists in `getsentry/skills` / `getsentry/sdk-skills`;
- claims cross-checked against the repo, the [SDK dev docs](https://develop.sentry.dev/sdk/), and [docs.sentry.io](https://docs.sentry.io/platforms/react-native/);
- no build/test/lint/CI gate reads `.agents/**` or `*.toml`.


## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
Supply-chain / dependency-provenance guidance is added in a stacked follow-up PR on top of this one.