### PR TITLE
chore(deps): Bump fast-uri to ^3.1.6 to resolve security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
     "shell-quote": "^1.10.0",
     "downlevel-dts@npm:0.11.0/typescript": "5.9.3",
     "deepmerge-ts": "^8.0.0",
-    "browserslist": "^4.28.7"
+    "browserslist": "^4.28.7",
+    "fast-uri": "^3.1.6"
   },
   "version": "0.0.0",
   "name": "sentry-react-native",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17271,10 +17271,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+"fast-uri@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "fast-uri@npm:3.1.6"
+  checksum: 10c0/77fa4f966f7d2cf83c34af2d3eb88882872fe90634f27a6bd309551db65377d3ca55616467c7cb4dcc57e33523d149e2fec1952d51cc2f00bfce68a66c3711ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Adds a `fast-uri` resolution (`^3.1.6`) to the root `package.json`, deduping the transitive copy (pulled via `ajv`) to a patched version (3.1.6).

## :bulb: Motivation and Context
Resolves four high-severity Dependabot alerts affecting `fast-uri >= 3.0.0, < 3.1.6`:
- [Dependabot alert 639](https://github.com/getsentry/sentry-react-native/security/dependabot/639) — host confusion via percent-encoded scheme normalization
- [Dependabot alert 634](https://github.com/getsentry/sentry-react-native/security/dependabot/634) — host confusion via skipped IDN canonicalization on scheme-relative references
- [Dependabot alert 640](https://github.com/getsentry/sentry-react-native/security/dependabot/640) — SSRF via malformed IPv6 normalization
- [Dependabot alert 635](https://github.com/getsentry/sentry-react-native/security/dependabot/635) — SSRF via repeated hostname percent-decoding

`fast-uri` is a **dev/build/test-only transitive dependency** — it is not a dependency of `packages/core` and is not shipped in the published `@sentry/react-native` package, so there is no exposure for SDK consumers.

## :green_heart: How did you test it?
- `yarn install` — resolves cleanly; `fast-uri` dedupes to 3.1.6.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed. (n/a — dev tooling only)
- [x] I updated the wizard if needed. (n/a)
- [ ] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec. (n/a — no API change)
- [x] No breaking changes.

## :crystal_ball: Next steps
- Separate PRs follow for the `qs` and `@xmldom/xmldom` Dependabot alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)