### PR TITLE
docs: Revamp root and nested AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,21 @@
 # AGENTS.md
 
-Sentry React Native SDK — monorepo using yarn workspaces with a single package at `packages/core`.
+Sentry React Native SDK — a **hybrid SDK**: a TypeScript/JS layer on top that wraps the native **sentry-cocoa** (iOS) and **sentry-android/java** SDKs through a JS↔native bridge. Monorepo using yarn workspaces; the SDK itself is the `packages/core` package.
+
+## Stack
+
+- **Published packages:** `@sentry/react-native` (`packages/core`, the SDK) + companion `@sentry/expo-upload-sourcemaps`; yarn 4 workspaces.
+- **Wraps native SDKs:** sentry-cocoa (iOS) + sentry-android/java (Android) through the JS↔native bridge.
+- **Hosts:** React Native on **both** the New (TurboModule/Fabric) and Old (bridge) Architecture, plus Expo and React.
+- **Exact versions** (don't copy them here — they rot): JS deps and host peer ranges in [`packages/core/package.json`](packages/core/package.json); the bundled native SDK versions per release in [`SDK-VERSIONS.md`](SDK-VERSIONS.md) (regenerated each release by `craft-pre-release.sh`).
+
+Changes to the wrapped native SDKs can ripple to them and to downstream hybrid SDKs (Flutter, .NET/MAUI, Unity) — see *Cross-Platform Dependencies*.
 
 ## Agent Responsibilities
 
-- **Continuous Learning**: Document new patterns in the appropriate nested `AGENTS.md` file.
-- **Context Management**: After compaction, re-read `AGENTS.md` files relevant to your current task.
+- **Reach for a skill first.** For anything beyond a trivial edit, load the matching skill (see *Skills*) — it carries the deep, current guidance this file only indexes.
+- **Continuous Learning:** when you discover a durable pattern, record it in the nearest nested `AGENTS.md` (or the relevant skill), not inline in a PR.
+- **Context Management:** after compaction, re-read the `AGENTS.md` for the surface you're touching before continuing.
 
 ## Setup
 
@@ -31,6 +41,26 @@ yarn build
 | Kotlin lint | `yarn lint:kotlin` |
 | ObjC/C++ lint | `yarn lint:clang` |
 | Swift lint | `yarn lint:swift` |
+
+## Boundaries
+
+**✅ Always**
+- Run `yarn lint`, `yarn test`, and `yarn circularDepCheck` before calling a change done; regenerate the API report (`yarn api-report`) when the public surface moved.
+- Make a change work on **both** architectures (New + Old) and **both** platforms (iOS + Android) — a fix that only covers one is not done.
+- Gate any user data placed in events/breadcrumbs/spans/logs on `options.sendDefaultPii`.
+- Catch native errors at the bridge boundary and degrade — reject/log, never let them propagate.
+
+**⚠️ Ask first**
+- Adding or changing any dependency, `.vscode` extension, GitHub Action, or native dependency — verify provenance first (load `code-guidelines` → *Adding dependencies*).
+- Changing the public API (`packages/core/src/js/index.ts` barrel, exported options) or a codegen/bridge spec (`NativeRNSentry.ts`, `*NativeComponent.ts`) — these are breaking and need a deprecation path.
+- Changing CI workflows, release config, or anything under `scripts/`.
+
+**🚫 Never**
+- Crash the host app — a native exception that reaches the app is the highest-severity failure this SDK can cause.
+- Break the public API or bridge ABI without a `@deprecated` migration path (an app can ship new JS against an older cached native binary).
+- Hand-edit generated files: `packages/core/etc/sentry-react-native.api.md` (regenerate it) or New-Architecture codegen output — regenerate, never edit by hand.
+- Add `CHANGELOG.md` noise for routine internal/CI/test/chore changes — the user-facing sections (`### Features`, `### Fixes`) are for user-visible changes. A genuinely notable internal change goes under the `### Internal` section instead, not among the user-facing entries.
+- Commit secrets, tokens, or DSNs.
 
 ## Commit Conventions
 
@@ -98,6 +128,21 @@ Changes may impact downstream SDKs. Coordinate with other teams when modifying n
 - **JSDoc comments** for public APIs
 - **Inline comments** for complex logic only
 - Update `CHANGELOG.md` for user-visible changes
+
+## Skills — load on demand
+
+The deep, task-specific guidance lives in `.agents/skills/` (registered in `agents.toml`) and is loaded when you need it — this file is the always-on operating manual, the skills are the specialists. Reach for one **before** doing the matching work:
+
+| Skill | Load it when |
+|-------|--------------|
+| `spec` | The *what* isn't pinned down yet — a fuzzy issue or idea to scope into acceptance criteria. Hands off to `design-first`. |
+| `design-first` | Starting a feature/integration, changing the public barrel, crossing the bridge, or changing a codegen spec — shape modules and seams before coding. |
+| `code-guidelines` | Implementing, refactoring, designing APIs, writing integrations, handling breaking changes, or adding dependencies. |
+| `test-guidelines` | Writing, modifying, or reviewing Jest tests, fixtures, and mocks. |
+| `review` | A three-axis (Standards / Spec / Correctness) pass on a branch or PR before opening or merging. |
+| `diagnosing-bugs` | A hard bug, flaky test, CI hang, native crash, or perf regression — builds a red-capable loop before hypothesizing. |
+
+Warden's automated PR review and `agents.toml` also pull **remote** specialists (`security-review`, `gha-security-review`, `span-convention-review`, and more) — invoke those for depth beyond the local pass.
 
 ## Nested AGENTS.md Files
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,5 +1,7 @@
 # packages/core — TypeScript/JavaScript SDK
 
+> **Depth lives in the skills.** The `code-guidelines` and `test-guidelines` skills (`.agents/skills/`) hold the authoritative, current guidance on code style, API/integration design, the bridge, and tests — load them before non-trivial work. This file covers the package's build/test commands, quick-reference conventions, and the **TurboModule subsystem**, which is documented nowhere else. Where a convention here overlaps a skill, the skill wins.
+
 ## Build & Test
 
 ```bash
@@ -95,14 +97,18 @@ describe('MyComponent', () => {
 
 ## Common Patterns
 
+> Diagnostics use **`debug`** from `@sentry/core`, not `logger` — `logger` is the Logs API and emits log *events* (and recurses in the bridge hot path). See *TurboModule Instrumentation* below.
+
 ### Error Handling
 
 ```typescript
+import { debug } from '@sentry/core';
+
 try {
   const result = await riskyOperation();
   return result;
 } catch (error) {
-  logger.error('Operation failed', error);
+  debug.error('Operation failed', error);
   // Don't throw - log and return fallback
   return fallbackValue;
 }
@@ -117,14 +123,14 @@ const { RNSentry } = NativeModules;
 
 export async function nativeOperation(param: string): Promise<boolean> {
   if (!RNSentry) {
-    logger.warn('Native module not available');
+    debug.warn('Native module not available');
     return false;
   }
 
   try {
     return await RNSentry.nativeOperation(param);
   } catch (error) {
-    logger.error('Native operation failed', error);
+    debug.error('Native operation failed', error);
     return false;
   }
 }

--- a/packages/core/android/AGENTS.md
+++ b/packages/core/android/AGENTS.md
@@ -35,7 +35,7 @@ Android native code supports both React Native architectures — a bridge-method
 
 ## Native Bridge Pattern (Java)
 
-Catch everything at the boundary and reject — never let a native exception reach the app. The reject error code is the shared `"SentryReactNative"`, not a per-method code:
+Catch `Throwable` at the boundary — not just `Exception`, so an `Error` can't crash the app either (the module code catches `Throwable` throughout) — and reject with the shared `"SentryReactNative"` code, not a per-method one:
 
 ```java
 @ReactMethod
@@ -43,7 +43,7 @@ public void nativeOperation(String param, Promise promise) {
   try {
     boolean result = performOperation(param);
     promise.resolve(result);
-  } catch (Exception e) {
+  } catch (Throwable e) {
     promise.reject("SentryReactNative", e.getMessage(), e);
   }
 }
@@ -53,7 +53,7 @@ public void nativeOperation(String param, Promise promise) {
 
 **✅ Always**
 - Land a bridge-method change in **both** `src/oldarch/` and `src/newarch/` — one arch is not done.
-- Catch exceptions at every `@ReactMethod` and `promise.reject(...)` — an uncaught native exception crashes the host app.
+- Catch `Throwable` at every `@ReactMethod` and `promise.reject(...)` — an uncaught throwable crashes the host app.
 - Gate any user data added to events/breadcrumbs/spans on `sendDefaultPii`.
 
 **🚫 Never**

--- a/packages/core/android/AGENTS.md
+++ b/packages/core/android/AGENTS.md
@@ -1,5 +1,7 @@
 # packages/core/android — Java & Kotlin
 
+> **Depth lives in the skills.** `code-guidelines` (`.agents/skills/`, esp. `references/native-bridge.md`) is authoritative for bridge and native conventions — load it before non-trivial work. This file is the quick reference for the Android surface; where a convention here overlaps a skill, the skill wins.
+
 ## Formatting & Linting
 
 | Task | Command |
@@ -25,12 +27,15 @@
 
 ## Architecture Variants
 
-Android native code supports both old and new React Native architectures:
+Android native code supports both React Native architectures — a bridge-method change usually has to land in **both**:
+
 - `src/oldarch/` — Legacy bridge implementation
 - `src/newarch/` — TurboModule / Fabric implementation
-- `src/main/` — Shared code
+- `src/main/` — Shared code (`io.sentry.react`)
 
 ## Native Bridge Pattern (Java)
+
+Catch everything at the boundary and reject — never let a native exception reach the app. The reject error code is the shared `"SentryReactNative"`, not a per-method code:
 
 ```java
 @ReactMethod
@@ -39,10 +44,21 @@ public void nativeOperation(String param, Promise promise) {
     boolean result = performOperation(param);
     promise.resolve(result);
   } catch (Exception e) {
-    promise.reject("OPERATION_FAILED", "Operation failed: " + e.getMessage(), e);
+    promise.reject("SentryReactNative", e.getMessage(), e);
   }
 }
 ```
+
+## Boundaries
+
+**✅ Always**
+- Land a bridge-method change in **both** `src/oldarch/` and `src/newarch/` — one arch is not done.
+- Catch exceptions at every `@ReactMethod` and `promise.reject(...)` — an uncaught native exception crashes the host app.
+- Gate any user data added to events/breadcrumbs/spans on `sendDefaultPii`.
+
+**🚫 Never**
+- Change the codegen bridge ABI without mirroring it in JS + iOS and keeping it backward-compatible with an older cached native binary.
+- Bump the bundled `io.sentry:sentry-android` version by hand — go through `scripts/update-android.sh`.
 
 ## Working with Local sentry-java
 

--- a/packages/core/ios/AGENTS.md
+++ b/packages/core/ios/AGENTS.md
@@ -1,5 +1,7 @@
 # packages/core/ios — Objective-C & Swift
 
+> **Depth lives in the skills.** `code-guidelines` (`.agents/skills/`, esp. `references/native-bridge.md`) is authoritative for bridge and native conventions — load it before non-trivial work. This file is the quick reference for the iOS surface; where a convention here overlaps a skill, the skill wins.
+
 ## Formatting & Linting
 
 | Task | Command |
@@ -22,19 +24,9 @@
 - Use **swiftlint** (enforced by CI)
 - Follow Swift API design guidelines
 
-## Error Handling Pattern
-
-```objc
-NSError *error = nil;
-BOOL success = [self performOperation:&error];
-if (!success) {
-  [SentryLog logWithMessage:[NSString stringWithFormat:@"Operation failed: %@", error]
-                   andLevel:kSentryLevelError];
-  return fallback;
-}
-```
-
 ## Native Bridge Pattern (Objective-C)
+
+Catch everything at the boundary and reject — never let an exception reach the app. The reject error code is the shared `@"SentryReactNative"`, not a per-method code:
 
 ```objc
 RCT_EXPORT_METHOD(nativeOperation:(NSString *)param
@@ -45,10 +37,21 @@ RCT_EXPORT_METHOD(nativeOperation:(NSString *)param
     BOOL result = [self performOperation:param];
     resolve(@(result));
   } @catch (NSException *exception) {
-    reject(@"OPERATION_FAILED", exception.reason, nil);
+    reject(@"SentryReactNative", exception.reason, nil);
   }
 }
 ```
+
+## Boundaries
+
+**✅ Always**
+- Resolve or reject every exported method — a `Promise` left neither resolved nor rejected hangs the JS caller.
+- Catch native exceptions at the bridge — an exception that reaches the app crashes it.
+- Gate any user data added to events/breadcrumbs/spans on `sendDefaultPii`.
+
+**🚫 Never**
+- Reach for `PrivateSentrySDKOnly` from new code — route hybrid-SDK access through `RNSentryInternal` (see below).
+- Bump the bundled sentry-cocoa version by hand — go through `scripts/update-cocoa.sh`.
 
 ## Working with Local sentry-cocoa
 

--- a/samples/expo/AGENTS.md
+++ b/samples/expo/AGENTS.md
@@ -1,9 +1,13 @@
 # samples/expo — Expo Sample App
 
+The test bed for the SDK under Expo (config plugin, Metro integration, EAS). Use it to verify a change behaves in an Expo-managed app, not just a bare RN one.
+
 ## Running
 
 ```bash
-yarn start
+yarn start          # Start the dev server (expo start)
+yarn ios            # Build & run the iOS dev client (expo run:ios)
+yarn android        # Build & run the Android dev client (expo run:android)
 ```
 
-Follow the Expo CLI prompts to open on iOS simulator, Android emulator, or a physical device.
+`yarn start` then follows the Expo CLI prompts to open on an iOS simulator, Android emulator, or a physical device. Because the SDK ships native code, plain Expo Go isn't enough — the `run:*` scripts build a dev client that includes it.

--- a/samples/react-native/AGENTS.md
+++ b/samples/react-native/AGENTS.md
@@ -1,5 +1,7 @@
 # samples/react-native — React Native Sample App
 
+The end-to-end test bed for the SDK on a bare RN app. Use it to reproduce and verify a change on real devices/simulators, on **both** architectures.
+
 ## Running
 
 ```bash
@@ -7,6 +9,15 @@ yarn start    # Start Metro bundler
 yarn ios      # Run iOS app (separate terminal)
 yarn android  # Run Android app (separate terminal)
 ```
+
+## New vs Old Architecture
+
+The sample runs on either architecture — toggle, then reinstall pods / rebuild:
+
+- **iOS:** `RCT_NEW_ARCH_ENABLED=1 npx pod-install` (unset for Old Arch).
+- **Android:** `newArchEnabled` in `android/gradle.properties`.
+
+A native change is only verified once it runs on both.
 
 ## Troubleshooting
 

--- a/samples/react-native/AGENTS.md
+++ b/samples/react-native/AGENTS.md
@@ -10,14 +10,23 @@ yarn ios      # Run iOS app (separate terminal)
 yarn android  # Run Android app (separate terminal)
 ```
 
-## New vs Old Architecture
+## iOS: pod install build matrix
 
-The sample runs on either architecture — toggle, then reinstall pods / rebuild:
+The iOS build varies on three axes, and there's a `yarn` script per combination. Install pods through one of these rather than a bare `pod install` — each exports the env the Podfile and `pod update` read (`USE_FRAMEWORKS`, `ENABLE_PROD`, `ENABLE_NEW_ARCH`):
 
-- **iOS:** `RCT_NEW_ARCH_ENABLED=1 npx pod-install` (unset for Old Arch).
-- **Android:** `newArchEnabled` in `android/gradle.properties`.
+```
+yarn pod-install-<debug|release>-<static|dynamic>[-legacy]
+```
 
-A native change is only verified once it runs on both.
+- **debug / release** → `ENABLE_PROD` (0/1)
+- **static / dynamic** → `USE_FRAMEWORKS` framework linkage
+- **New Arch (default) / `-legacy`** → `ENABLE_NEW_ARCH` (1/0)
+
+e.g. `yarn pod-install-debug-static` (New Arch, static frameworks) or `yarn pod-install-release-dynamic-legacy` (Old Arch, dynamic frameworks). A native change is only verified once it runs across the arch and linkage combinations it can affect.
+
+## Android: architecture toggle
+
+Set `newArchEnabled` (`true`/`false`) in `android/gradle.properties`, then rebuild.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [x] Refactoring


## :scroll: Description
Revamps the agent operating manual (`AGENTS.md`, symlinked as `CLAUDE.md`) and **all** nested `AGENTS.md` files against the "how to write a great AGENTS.md" checklist.

Root `AGENTS.md`:

- **`## Boundaries`** — a three-tier ✅ Always / ⚠️ Ask first / 🚫 Never section encoding the decisions an agent can't derive from the code (arch + platform parity, PII gating, bridge/ABI deprecation path, generated-file edits, CHANGELOG placement).
- **`## Skills — load on demand`** — an index mapping each local skill (`spec`, `design-first`, `code-guidelines`, `test-guidelines`, `review`, `diagnosing-bugs`) to when to reach for it, plus a note on the remote specialists pulled via `agents.toml`.
- **`## Stack`** — reframes the intro as a hybrid SDK (TS/JS wrapping sentry-cocoa + sentry-android/java via the bridge) and, rather than copying rot-prone version strings, points at the live sources: `packages/core/package.json` for JS/peer versions and the release-generated `SDK-VERSIONS.md` for bundled native versions.
- Corrected the generated-files boundary (dropped a stale `.yalc` reference) and refined the CHANGELOG rule so notable internal changes land under `### Internal` rather than being excluded outright.

`packages/core/AGENTS.md`:

- Added a skill-precedence pointer ("depth lives in the skills; where a convention here overlaps a skill, the skill wins").
- Fixed drifted diagnostics examples that used `logger` (the Logs API — recurses in the bridge hot path) to `debug`, matching the SDK's own source (52 files import `{ debug }` from `@sentry/core`) and the file's own TurboModule warning.

Nested surface + sample files:

- **`packages/core/android/AGENTS.md`** & **`packages/core/ios/AGENTS.md`** — added the skill-precedence pointer and a scoped Boundaries block (each tailored to its surface), and fixed drifted bridge examples: the real reject error code is the shared `SentryReactNative`, not a per-method `OPERATION_FAILED`; dropped the iOS `[SentryLog logWithMessage:]` snippet that appears nowhere in the ObjC layer.
  - _Android boundaries:_ land a bridge change in **both** `src/oldarch/` + `src/newarch/`, catch-and-`reject` at every `@ReactMethod`, gate PII, keep the codegen ABI mirrored/backward-compatible, and don’t hand-bump `io.sentry:sentry-android` (use `scripts/update-android.sh`).
  - _iOS boundaries:_ always resolve-or-reject (an unfinished `Promise` hangs the JS caller), catch native exceptions, gate PII, route hybrid-SDK access through `RNSentryInternal` instead of `PrivateSentrySDKOnly`, and don’t hand-bump sentry-cocoa (use `scripts/update-cocoa.sh`).
- **`samples/react-native/AGENTS.md`** — documented the iOS `yarn pod-install-<debug|release>-<static|dynamic>[-legacy]` build matrix (each script sets `ENABLE_PROD` / `USE_FRAMEWORKS` / `ENABLE_NEW_ARCH`) and the Android `newArchEnabled` toggle, so a native change gets verified across the combinations it affects.
- **`samples/expo/AGENTS.md`** — added the real `run:ios` / `run:android` scripts and the dev-client caveat (native code means plain Expo Go isn't enough).


## :bulb: Motivation and Context
Closes #6638. The always-loaded manual was missing the highest-value guidance (boundaries, when to load which skill) and had drifted from the code in places. Version numbers are deliberately not copied into prose — they point at existing sources so they can't rot into confident falsehoods in a file agents treat as ground truth.


## :green_heart: How did you test it?
Docs-only change. Every factual claim was verified against the codebase: package/peer/native versions against `package.json`/`RNSentry.podspec`/`build.gradle`; all referenced skills against `agents.toml`; every command against `package.json` scripts; the `SentryReactNative` reject code and `NSLog`/`logger.log` idioms against the actual ObjC/Java source; the android arch dirs, `RNSentryInternal.swift`, `scripts/update-{cocoa,android}.sh`, and the sample arch toggles against the tree.


## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
None — the revamp now covers the root manual plus every nested `AGENTS.md` (`packages/core`, `android`, `ios`, `samples/react-native`, `samples/expo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


