### PR TITLE
ci: Unpin Android E2E emulator build

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -462,11 +462,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # pin@v2.38.0
         with:
           api-level: ${{ env.ANDROID_API_LEVEL }}
-          # Pin the emulator binary: canary 37.1.6.0 (build 15726199) broke emulator
-          # networking (no egress to 10.0.2.2 mock server or external internet), which
-          # makes the whole E2E suite time out. 37.1.5.0 (build 15679343) is the last
-          # known-good build. Remove once a fixed canary emulator ships.
-          emulator-build: 15679343
           force-avd-creation: false
           disable-animations: true
           disable-spellchecker: true


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Removes the `emulator-build: 15679343` pin (and its explanatory comment) from the `Test android production REV2` job in `.github/workflows/sample-application.yml`, letting the emulator use the latest canary build again.

`channel: canary` / `target: aosp_atd` are intentionally kept as-is — ATD images are only available on the canary channel, so switching to `stable` is a separate, conditional follow-up (see #6379).

## :bulb: Motivation and Context
The pin was a workaround for a canary emulator networking regression: `37.1.6.0` (build `15726199`) lost egress to both the `10.0.2.2` host-loopback mock Sentry server and the external internet, timing out the entire Android E2E suite (20/20 failures). `37.1.5.0` (build `15679343`) was the last known-good build.

This PR is the acceptance test for that issue: with the pin removed, a green Android E2E run confirms the current canary emulator has fixed the regression and the pin is no longer needed.

Closes #6379

## :green_heart: How did you test it?
Relying on CI — the `ready-to-merge` label is applied so the sample-application Android E2E suite runs against the unpinned (latest canary) emulator. Green = regression fixed and safe to merge.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

