### PR TITLE
feat(android): Add anrProfilingSampleRate option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add `anrProfilingSampleRate` option to profile ANRs on Android ([#6672](https://github.com/getsentry/sentry-react-native/pull/6672))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v9.26.1 to v9.27.0 ([#6670](https://github.com/getsentry/sentry-react-native/pull/6670))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Add `anrProfilingSampleRate` option to profile ANRs on Android ([#6672](https://github.com/getsentry/sentry-react-native/pull/6672))
+- Add `anrProfilingSampleRate` option to profile ANRs on Android ([#6673](https://github.com/getsentry/sentry-react-native/pull/6673))
 
 ### Dependencies
 

--- a/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryStartTest.kt
+++ b/packages/core/RNSentryAndroidTester/app/src/test/java/io/sentry/react/RNSentryStartTest.kt
@@ -401,6 +401,38 @@ class RNSentryStartTest {
     }
 
     @Test
+    fun `when anrProfilingSampleRate is set, the ANR profiling sample rate is applied`() {
+        val rnOptions = JavaOnlyMap.of("anrProfilingSampleRate", 0.5)
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertEquals(0.5, options.anrProfilingSampleRate!!, 0.0)
+        assertTrue("ANR profiling should be enabled", options.isAnrProfilingEnabled)
+    }
+
+    @Test
+    fun `when anrProfilingSampleRate is not set, it remains at default (disabled)`() {
+        val rnOptions = JavaOnlyMap()
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertNull("ANR profiling sample rate should be null by default", options.anrProfilingSampleRate)
+        assertFalse("ANR profiling should be disabled by default", options.isAnrProfilingEnabled)
+    }
+
+    @Test
+    fun `when anrProfilingSampleRate is not a number, it is ignored`() {
+        val rnOptions = JavaOnlyMap.of("anrProfilingSampleRate", "invalid")
+        val options = SentryAndroidOptions()
+
+        RNSentryStart.getSentryAndroidOptions(options, rnOptions, logger)
+
+        assertNull("ANR profiling sample rate should remain null", options.anrProfilingSampleRate)
+    }
+
+    @Test
     fun `network detail replay options are forwarded to the native replay options`() {
         val mobileReplayOptions =
             JavaOnlyMap.of(

--- a/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
+++ b/packages/core/android/src/main/java/io/sentry/react/RNSentryStart.java
@@ -202,6 +202,10 @@ final class RNSentryStart {
     if (rnOptions.hasKey("enableAnrFingerprinting")) {
       options.setEnableAnrFingerprinting(rnOptions.getBoolean("enableAnrFingerprinting"));
     }
+    if (rnOptions.hasKey("anrProfilingSampleRate")
+        && rnOptions.getType("anrProfilingSampleRate") == ReadableType.Number) {
+      options.setAnrProfilingSampleRate(rnOptions.getDouble("anrProfilingSampleRate"));
+    }
     if (rnOptions.hasKey("enableNdkAppHangTracking")) {
       options.setEnableNdkAppHangTracking(rnOptions.getBoolean("enableNdkAppHangTracking"));
     }

--- a/packages/core/src/js/options.ts
+++ b/packages/core/src/js/options.ts
@@ -104,6 +104,21 @@ export interface BaseReactNativeOptions {
   enableAnrFingerprinting?: boolean;
 
   /**
+   * Sample rate for profiling ANR (Application Not Responding) events.
+   *
+   * When set to a value greater than `0.0`, the SDK profiles the main thread while an ANR is
+   * happening and attaches the resulting profile to the ANR event. The value is the probability
+   * (`0.0`–`1.0`) that any given ANR is profiled.
+   *
+   * Requires ANR detection, which is enabled by default. This is independent of UI/transaction
+   * profiling configured via `profilesSampleRate` and `_experiments.profilingOptions`.
+   *
+   * @default undefined (ANR profiling disabled)
+   * @platform android
+   */
+  anrProfilingSampleRate?: number;
+
+  /**
    * When enabled, all the threads are automatically attached to all logged events on Android
    *
    * @platform android

--- a/packages/core/test/wrapper.test.ts
+++ b/packages/core/test/wrapper.test.ts
@@ -177,6 +177,23 @@ describe('Tests Native Wrapper', () => {
       expect(debug.warn).toHaveBeenLastCalledWith('Note: Native Sentry SDK is disabled.');
     });
 
+    test('forwards anrProfilingSampleRate to the Native SDK', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: VALID_DSN,
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        anrProfilingSampleRate: 0.5,
+        devServerUrl: undefined,
+        defaultSidecarUrl: undefined,
+        mobileReplayOptions: undefined,
+      });
+
+      expect(RNSentry.initNativeSdk).toHaveBeenCalled();
+      // @ts-expect-error mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter.anrProfilingSampleRate).toBe(0.5);
+    });
+
     test('filter beforeSend when initializing Native SDK', async () => {
       await NATIVE.initNativeSdk({
         dsn: VALID_DSN,


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] New feature
- [x] Enhancement

## :scroll: Description
Adds a new `anrProfilingSampleRate` SDK option that exposes Android ANR profiling to React Native users.

When set to a value greater than `0.0`, the native Android SDK profiles the main thread while an ANR (Application Not Responding) is happening and attaches the resulting profile to the ANR event. The value is the probability (`0.0`–`1.0`) that any given ANR is profiled.

Wiring:
- New `anrProfilingSampleRate?: number` option on `BaseReactNativeOptions` (`options.ts`), Android-only, JSDoc'd.
- Consumed in `RNSentryStart.getSentryAndroidOptions(...)` with a `ReadableType.Number` guard, applied via `SentryAndroidOptions.setAnrProfilingSampleRate(...)`.
- Flows to native through the existing `initNativeSdk` options passthrough — no bridge/codegen spec change needed.

It is independent of UI/transaction profiling (`profilesSampleRate`, `_experiments.profilingOptions`).

## :bulb: Motivation and Context
ANR profiling graduated out of experimental in sentry-java 8.55.0 ([getsentry/sentry-java#6042](https://github.com/getsentry/sentry-java/pull/6042)), which RN now bundles. RN previously had no way to configure it from JS-only init — this closes that gap.

Closes #6661. Follow-up from the 8.55.0 bump (#6658).

## :green_heart: How did you test it?
- Added Kotlin tests in `RNSentryStartTest.kt`: sample rate applied & profiling enabled, default (null/disabled), non-number ignored.
- Added a JS test in `wrapper.test.ts` verifying the value is forwarded to the native SDK.
- Verified `setAnrProfilingSampleRate(Double)` / `isAnrProfilingEnabled()` against the bundled sentry-android 8.55.0 API.
- `yarn build:sdk`, JS lint (oxlint), and `google-java-format` pass on the changed source.

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed https://github.com/getsentry/sentry-docs/pull/19274
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
