### PR TITLE
feat(ios): Expose enableMemoryIntrospection option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## Unreleased
 
+### Features
+
+- Expose the iOS `enableMemoryIntrospection` option to omit memory contents from native crash reports ([#6547](https://github.com/getsentry/sentry-react-native/issues/6547))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v9.26.1 to v9.27.0 ([#6670](https://github.com/getsentry/sentry-react-native/pull/6670))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Features
 
-- Expose the iOS `enableMemoryIntrospection` option to omit memory contents from native crash reports ([#6547](https://github.com/getsentry/sentry-react-native/issues/6547))
+- Expose the iOS `enableMemoryIntrospection` option to omit memory contents from native crash reports ([#6547](https://github.com/getsentry/sentry-react-native/pull/6674))
 
 ### Dependencies
 

--- a/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartTests.swift
+++ b/packages/core/RNSentryCocoaTester/RNSentryCocoaTesterTests/RNSentryStartTests.swift
@@ -226,6 +226,25 @@ final class RNSentryStartTests: XCTestCase {
         XCTAssertTrue(actualOptions.screenshot.maskAllImages)
     }
 
+    func testMemoryIntrospectionOption() throws {
+        try startFromRN(options: [
+            "dsn": "https://abcd@efgh.ingest.sentry.io/123456",
+            "enableMemoryIntrospection": true
+        ])
+
+        let actualOptions = SentrySDK.internal.options
+        XCTAssertTrue(actualOptions.enableMemoryIntrospection)
+    }
+
+    func testMemoryIntrospectionOptionDefault() throws {
+        try startFromRN(options: [
+            "dsn": "https://abcd@efgh.ingest.sentry.io/123456"
+        ])
+
+        let actualOptions = SentrySDK.internal.options
+        XCTAssertFalse(actualOptions.enableMemoryIntrospection)
+    }
+
     func startFromRN(options: [String: Any]) throws {
         var error: NSError?
         RNSentryStart.start(options: options, error: &error)

--- a/packages/core/src/js/options.ts
+++ b/packages/core/src/js/options.ts
@@ -238,6 +238,21 @@ export interface BaseReactNativeOptions {
   enableMetricKit?: boolean;
 
   /**
+   * When enabled, `SentryCrash` reads memory near the crash site while capturing a native crash
+   * (e.g. `EXC_BAD_ACCESS`) and embeds string-based stack contents in the event. This can help
+   * with debugging, but may also expose sensitive information (such as user IDs or personal data),
+   * which can even surface in the issue title.
+   *
+   * Disable this option to keep native crash reporting while omitting memory contents.
+   *
+   * iOS only
+   *
+   * @default false
+   * @platform ios
+   */
+  enableMemoryIntrospection?: boolean;
+
+  /**
    * The max queue size for capping the number of envelopes waiting to be sent by Transport.
    */
   maxQueueSize?: number;

--- a/packages/core/test/wrapper.test.ts
+++ b/packages/core/test/wrapper.test.ts
@@ -336,6 +336,41 @@ describe('Tests Native Wrapper', () => {
       expect(NATIVE.enableNative).toBe(true);
     });
 
+    test('passes enableMemoryIntrospection to the Native SDK when set', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: VALID_DSN,
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        enableMemoryIntrospection: true,
+        devServerUrl: undefined,
+        defaultSidecarUrl: undefined,
+        mobileReplayOptions: undefined,
+      });
+
+      expect(RNSentry.initNativeSdk).toHaveBeenCalled();
+      // @ts-expect-error mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).toEqual(expect.objectContaining({ enableMemoryIntrospection: true }));
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
+    test('does not pass enableMemoryIntrospection to the Native SDK when not set', async () => {
+      await NATIVE.initNativeSdk({
+        dsn: VALID_DSN,
+        enableNative: true,
+        autoInitializeNativeSdk: true,
+        devServerUrl: undefined,
+        defaultSidecarUrl: undefined,
+        mobileReplayOptions: undefined,
+      });
+
+      expect(RNSentry.initNativeSdk).toHaveBeenCalled();
+      // @ts-expect-error mock value
+      const initParameter = RNSentry.initNativeSdk.mock.calls[0][0];
+      expect(initParameter).not.toHaveProperty('enableMemoryIntrospection');
+      expect(NATIVE.enableNative).toBe(true);
+    });
+
     test('does not initialize with autoInitializeNativeSdk: false', async () => {
       NATIVE.enableNative = false;
       debug.warn = jest.fn();


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] New feature
- [ ] Bugfix
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Exposes the public sentry-cocoa `enableMemoryIntrospection` option (added in cocoa `9.24.0`, PR getsentry/sentry-cocoa#8571) as a typed, documented iOS option on `ReactNativeOptions`.

When the SDK captures a native crash (e.g. `EXC_BAD_ACCESS`), `SentryCrash` reads memory near the crash site and embeds string-based stack contents in the event, which can expose sensitive information (user IDs, personal data) — sometimes even in the issue title. This option lets privacy-sensitive apps keep native crash reporting while omitting memory contents.

- iOS-only (`@platform ios`), `@default false` (matches Cocoa's default since `9.24.0`).
- No ObjC bridging needed — iOS options pass straight through to Cocoa via `optionsFromDictionary`, so the plain `SentryOptions.enableMemoryIntrospection` boolean is set automatically.
- The prior blocker (bundled Cocoa `< 9.24.0`) is resolved — the SDK now bundles Cocoa `9.27.0`.


## :bulb: Motivation and Context
Fixes #6547. Gives privacy-sensitive apps a supported toggle to omit crash-site memory contents from native iOS crash reports.


## :green_heart: How did you test it?
Added Swift native tests in `RNSentryStartTests.swift`:
- `testMemoryIntrospectionOption` — passing `enableMemoryIntrospection: true` from the RN options dictionary reaches `SentrySDK.internal.options.enableMemoryIntrospection`.
- `testMemoryIntrospectionOptionDefault` — the option defaults to `false` when omitted.

Also verified locally: `yarn build:sdk`, `yarn api-report:check` (up to date), `yarn lint:lerna`.


## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
Docs update: getsentry/sentry-docs#19276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
