### PR TITLE
fix(e2e): Pin json gem < 3.0 for RN < 0.72 iOS builds

### DIFF
--- a/dev-packages/e2e-tests/cli.mjs
+++ b/dev-packages/e2e-tests/cli.mjs
@@ -105,6 +105,24 @@ function patchBoostIfNeeded(rnVersion, patchScriptsDir) {
   });
 }
 
+// RN < 0.72 runs its iOS codegen while CocoaPods evaluates the Podfile
+// (`use_react_native!`), and that codegen passes `quirks_mode: true` to the
+// json gem. json 3.0.0 removed the `quirks_mode` option, so a fresh
+// `bundle install` (the rn-diff-purge Gemfile pins cocoapods but not json)
+// resolves json 3.0.0 and pod install fails with
+// "Invalid `Podfile` file: unknown keyword: quirks_mode.". Pin json below 3.0
+// for these older RN versions. Newer RN codegen dropped the option and is
+// unaffected.
+function pinJsonGemIfNeeded(rnVersion, appDir) {
+  const versionNumber = parseFloat(rnVersion.replace(/[^\d.]/g, ''));
+  const gemfilePath = `${appDir}/Gemfile`;
+  if (platform !== 'ios' || versionNumber >= 0.72 || !fs.existsSync(gemfilePath)) {
+    return;
+  }
+  console.log(`Pinning json gem < 3.0 for React Native ${rnVersion}`);
+  fs.appendFileSync(gemfilePath, `\ngem 'json', '< 3.0'\n`, { encoding: 'utf-8' });
+}
+
 // Build and publish the SDK - we only need to do this once in CI.
 // Locally, we may want to get updates from the latest build so do it on every app build.
 if (actions.includes('create') || (env.CI === undefined && actions.includes('build'))) {
@@ -244,6 +262,8 @@ if (actions.includes('create')) {
     if (fs.existsSync(`${appDir}/ios/Podfile.lock`)) {
       fs.rmSync(`${appDir}/ios/Podfile.lock`);
     }
+
+    pinJsonGemIfNeeded(RNVersion, appDir);
 
     if (fs.existsSync(`${appDir}/Gemfile`)) {
       execSync(`bundle install`, { stdio: 'inherit', cwd: appDir, env: env });


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description
The RN 0.71.19 iOS E2E build (`Setup Plain RN 0.71.19 App`) started failing at `bundle exec pod install`:

```
[Codegen] Generating ./build/generated/ios/React-Codegen.podspec.json
[!] Invalid `Podfile` file: unknown keyword: quirks_mode.
 #  from .../0.71.19/RnDiffApp/ios/Podfile:30
 >    use_react_native!(
```

RN < 0.72 runs its iOS codegen while CocoaPods evaluates the Podfile (`use_react_native!`), and that codegen still passes `quirks_mode: true` to the `json` gem. The cloned rn-diff-purge Gemfile pins `cocoapods` and `activesupport` but **not** `json`, so a fresh `bundle install` floats to the latest json.

This change appends `gem 'json', '< 3.0'` to the app's Gemfile before `bundle install`, guarded to iOS + RN < 0.72. Newer RN (0.87.1) codegen dropped the `quirks_mode` usage and is unaffected — which is why only the 0.71.19 iOS job was red.

## :bulb: Motivation and Context
- [CI failure](https://github.com/getsentry/sentry-react-native/actions/runs/34092857699/job/101655483041)

## :green_heart: How did you test it?
- [CI job passing](https://github.com/getsentry/sentry-react-native/actions/runs/34098906863/job/101668690955?pr=6678)

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
