### PR TITLE
chore(replay): Mark mobileReplayIntegration as stable

### DIFF
--- a/packages/core/src/js/replay/mobilereplay.ts
+++ b/packages/core/src/js/replay/mobilereplay.ts
@@ -309,8 +309,6 @@ export function serializeNetworkDetailUrlsForNative(urls: (string | RegExp)[] | 
  *  })],
  * });
  * ```
- *
- * @experimental
  */
 export const mobileReplayIntegration = (initOptions: MobileReplayOptions = defaultOptions): MobileReplayIntegration => {
   if (isExpoGo()) {


### PR DESCRIPTION
## :loudspeaker: Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## :scroll: Description
Removes the `@experimental` JSDoc tag from `mobileReplayIntegration`. This is a comment-only change — no behavior, type, or API-signature impact (the API report already reports the symbol as `@public`).

## :bulb: Motivation and Context
Mobile Session Replay has been [generally available](https://sentry.io/changelog/mobile-replay-is-now-in-open-beta) since early 2026, and the [React Native Session Replay docs](https://docs.sentry.io/platforms/react-native/session-replay/) no longer mark the integration as beta/experimental (only two Android-specific capture strategies remain flagged). The stale `@experimental` tag on the integration entry point sent the wrong signal.

Part of a broader audit of `@experimental` markers in the repo. Other markers were reviewed and left in place because docs still classify them as beta/experimental (e.g. profiling, standalone app-start tracing).

## :green_heart: How did you test it?
Comment-only change; no runtime behavior affected. No test changes required.

## :pencil: Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed. (Docs already reflect GA status.)
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec. (No API-signature change; API report unchanged, already `@public`.)
- [x] No breaking changes.

## :crystal_ball: Next steps
