### PR TITLE
test(e2e): Restore iOS replay assertion in captureReplay test

### DIFF
--- a/dev-packages/e2e-tests/maestro/captureReplay.yml
+++ b/dev-packages/e2e-tests/maestro/captureReplay.yml
@@ -5,5 +5,16 @@ jsEngine: graaljs
     file: utils/launchTestAppClear.yml
     env:
       replaysOnErrorSampleRate: 1.0
+# Prime the native replay buffer before capturing the exception so a replay_id
+# is attached to the event (iOS only; Android does not reliably capture replays
+# in CI — see https://github.com/getsentry/sentry-react-native/pull/4277).
+- runFlow:
+    file: utils/primeReplayBuffer.yml
+    when:
+      platform: iOS
 - tapOn: "Capture Exception"
 - runFlow: utils/assertEventIdVisible.yml
+- runFlow:
+    file: utils/assertReplay.yml
+    when:
+      platform: iOS

--- a/dev-packages/e2e-tests/maestro/utils/assertReplay.yml
+++ b/dev-packages/e2e-tests/maestro/utils/assertReplay.yml
@@ -1,0 +1,23 @@
+appId: ${APP_ID}
+jsEngine: graaljs
+---
+- extendedWaitUntil:
+    visible:
+      id: "eventId"
+    timeout: 60_000 # 60 seconds
+
+- copyTextFrom:
+    id: "eventId"
+- assertTrue: ${maestro.copiedText}
+
+- runScript:
+    file: sentryApi.js
+    env:
+      fetch: replay
+      eventId: ${maestro.copiedText}
+      sentryAuthToken: ${SENTRY_AUTH_TOKEN}
+
+- assertTrue: ${output.replayId}
+- assertTrue: ${output.replayDuration}
+- assertTrue: ${output.replaySegments}
+- assertTrue: ${output.replayCodec == "ftypmp42"}

--- a/dev-packages/e2e-tests/maestro/utils/primeReplayBuffer.yml
+++ b/dev-packages/e2e-tests/maestro/utils/primeReplayBuffer.yml
@@ -1,0 +1,16 @@
+appId: ${APP_ID}
+jsEngine: graaljs
+---
+# Buffer-mode replay (replaysOnErrorSampleRate) only attaches a replay_id to the
+# error event if the native replay buffer captured at least one frame before the
+# error fired. Immediately after launch the buffer can still be empty on slow CI
+# simulators, so the event is sent without a replay_id and no server-side retry
+# can recover it. Tap the "Replay Ping" counter repeatedly to mutate the view
+# hierarchy (and spend a few seconds of wall-clock while Maestro re-reads the UI
+# between taps) so the native capture records frames before the exception is
+# captured. If this proves insufficient on CI, increase the repeat count.
+- repeat:
+    times: 8
+    commands:
+      - tapOn:
+          id: 'replayPing'

--- a/dev-packages/e2e-tests/src/EndToEndTests.tsx
+++ b/dev-packages/e2e-tests/src/EndToEndTests.tsx
@@ -8,6 +8,12 @@ const EndToEndTestsScreen = (): React.JSX.Element => {
   const [isReady, setIsReady] = React.useState(false);
   const [eventId, setEventId] = React.useState<string | null>(null);
   const [error, setError] = React.useState<string>('No error');
+  // Buffer-mode replay (replaysOnErrorSampleRate) only attaches a replay_id to
+  // an error event if the native replay buffer captured at least one frame
+  // before the error fired. This counter is tapped by the captureReplay e2e
+  // flow to mutate the view hierarchy (side-effect free, no events sent) so the
+  // buffer records frames before the exception is captured.
+  const [replayPingCount, setReplayPingCount] = React.useState(0);
 
   React.useEffect(() => {
     const client: Sentry.ReactNativeClient | undefined = Sentry.getClient();
@@ -77,6 +83,9 @@ const EndToEndTestsScreen = (): React.JSX.Element => {
       {eventId ? <Text testID='eventId'>{eventId}</Text> : <Text>No event ID</Text>}
       <Text onPress={() => setEventId(null)}>
         Clear Event Id
+      </Text>
+      <Text testID='replayPing' onPress={() => setReplayPingCount((count) => count + 1)}>
+        Replay Ping {replayPingCount}
       </Text>
       {testCases.map((testCase) => (
         <Text key={testCase.id} onPress={testCase.action}>


### PR DESCRIPTION
## :loudspeaker: Type of change
- [x] Bugfix

## :scroll: Description

Re-adds the `assertReplay.yml` iOS check to the `captureReplay` e2e test, removed in #6072, and makes it deterministic instead of flaky.

The assertion was flaky for a structural reason, not CI noise: buffer-mode replay (`replaysOnErrorSampleRate`) only attaches a `replay_id` to the error event if the native replay buffer captured at least one frame **before** the error fired. On slow CI the exception was captured while the buffer was still empty, so the event was sent **permanently** without a `replay_id` — and no server-side retry could recover it (`sentryApi.js` already retries non-200s for ~10 min, so replay processing lag was never the real problem).

Changes:
- **`src/EndToEndTests.tsx`** — add a side-effect-free `Replay Ping` counter (`testID='replayPing'`) that mutates the view hierarchy without sending any events.
- **`maestro/utils/primeReplayBuffer.yml`** (new) — tap `replayPing` 8× to churn the view (and spend a few seconds while Maestro re-reads the UI between taps) so the native capture records frames before the exception.
- **`maestro/utils/assertReplay.yml`** — restored verbatim from before #6072 (asserts `replay_id`, duration, segments, `ftypmp42` codec via the Sentry API).
- **`maestro/captureReplay.yml`** — run the prime step, then re-wire `assertReplay.yml`, both gated `platform: iOS`.

`dist/` is gitignored and rebuilt by `cli.mjs` on create, so the harness change flows into CI automatically.

## :bulb: Motivation and Context

Closes #6082.

## :green_heart: How did you test it?

[CI](https://github.com/getsentry/sentry-react-native/actions/runs/34131281750/job/101776247314?pr=6683)

## :pencil: Checklist
- [x] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps

https://github.com/getsentry/sentry-react-native/pull/6684