### PR TITLE
[DO NOT MERGE] chore(e2e): Bump E2E tests to React Native 0.88.0-rc.0

### DIFF
--- a/.github/workflows/e2e-v2.yml
+++ b/.github/workflows/e2e-v2.yml
@@ -232,7 +232,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ["0.71.19", "0.87.1"]
+        rn-version: ["0.71.19", "0.88.0-rc.0"]
         rn-architecture: ["legacy", "new"]
         platform: ["android", "ios"]
         build-type: ["production"]
@@ -245,7 +245,7 @@ jobs:
             runs-on: macos-15-xlarge
           # Use Xcode 26 (macos-26) for newer RN versions
           - platform: ios
-            rn-version: "0.87.1"
+            rn-version: "0.88.0-rc.0"
             runs-on: macos-26-xlarge
           - platform: android
             runs-on: ubuntu-24.04
@@ -385,7 +385,7 @@ jobs:
     strategy:
       fail-fast: false # keeps matrix running if one fails
       matrix:
-        rn-version: ["0.87.1"]
+        rn-version: ["0.88.0-rc.0"]
         rn-architecture: ["legacy", "new"]
         platform: ["android", "ios"]
         build-type: ["production"]


### PR DESCRIPTION
## 📢 Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring

## 📜 Description

Bumps the E2E build/test matrix in `e2e-v2.yml` from React Native `0.87.1` to `0.88.0-rc.0` (the current 0.88 release candidate). The `0.71.19` baseline is kept unchanged.

## 💡 Motivation and Context

Validate the SDK against the React Native 0.88 release candidate before it goes stable. Closes #6689.

## 💚 How did you test it?

Built the plain RN E2E app on `0.88.0-rc.0` **locally** with the SDK linked via yalc, both on the New Architecture:

- **iOS** (new arch, Release, Xcode 26) — `Build Succeeded`; `RNSentry` and codegen (`RNSentrySpec`) compiled cleanly, Xcode project patch applied for `0.88.0-rc.0`.
- **Android** (new arch, Release, Java 17) — `BUILD SUCCESSFUL`; `sentry_react-native` codegen, JNI (`buildCMakeRelWithDebInfo`), and JS bundle all built, APK produced.

The remaining matrix cells (legacy architecture, iOS `use_frameworks` static/dynamic, and the Maestro E2E test job on Sauce Labs) run on CI via the `ready-to-merge` label.

## 📝 Checklist
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the develop docs spec.
- [x] No breaking changes.

## 🔮 Next steps

Bump the `react-native`/`metro` devDependencies and the sample/perf-test apps once React Native `0.88.0` stable is released (typically handled by the dependency updater).