### PR TITLE
chore(ci): Only build production builds for visionOS and tvOS

### DIFF
--- a/.github/workflows/sample-application.yml
+++ b/.github/workflows/sample-application.yml
@@ -335,7 +335,7 @@ jobs:
       fail-fast: false
       matrix:
         # @callstack/react-native-visionos is New Architecture only.
-        build-type: ["dev", "production"]
+        build-type: ["production"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -421,7 +421,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: ["dev", "production"]
+        build-type: ["production"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring


## :scroll: Description
<!--- Describe your changes in detail and optionally add screenshots -->
Following up on https://github.com/getsentry/sentry-react-native/pull/6687 only build production builds for visionOS and tvOS that were introduced with https://github.com/getsentry/sentry-react-native/pull/6677 and https://github.com/getsentry/sentry-react-native/pull/6676

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Same motivation as https://github.com/getsentry/sentry-react-native/pull/6687

## :green_heart: How did you test it?
<!---
Include a link to Sentry when applicable:
* Link to Sentry: <LINK>
-->
CI

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [ ] I added tests to verify changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] All tests passing.
- [x] Public API changes reviewed by another Mobile SDK team member or implemented according to the [develop docs](https://develop.sentry.dev/) spec.
- [x] No breaking changes.

## :crystal_ball: Next steps
